### PR TITLE
Add GPS Hardware Driver

### DIFF
--- a/CRSFconfig.h
+++ b/CRSFconfig.h
@@ -16,6 +16,7 @@
 #define CRSF_DEBUG_RC 0        // Set to 1 to enable debug output for RC data.
 #define CRSF_DEBUG_TELEMETRY 0 // Set to 1 to enable debug output for telemetry.
 #define CRSF_DEBUG_GPS 0       // Set to 1 to enable debug output for GPS data.
+#define CRSF_DEBUG_GPS_NMEA 0  // Set to 1 to enable debug output for GPS NMEA data.
 
 #define CRSF_USE_RC 1                          // Set to 1 to enable RC support.
 #define CRSF_USE_TELEMETRY 1                   // Set to 1 to enable telemetry support.

--- a/examples/gps_telemetry/gps.cpp
+++ b/examples/gps_telemetry/gps.cpp
@@ -199,7 +199,7 @@ bool GPS::_initDMA()
  */
 void GPS::_parseNMEA(uint8_t *buffer, size_t length)
 {
-#if (CRSF_DEBUG_GPS > 0)
+#if (CRSF_DEBUG_GPS > 0) && (CRSF_DEBUG_GPS_NMEA > 0)
     Serial.print("GPS: ");
     for (size_t i = 0; i < length; i++)
     {
@@ -294,7 +294,7 @@ bool GPS::_gpsWaitForResponse(uint32_t timeout)
         {
             _dmaGpsRxComplete = false;
 
-#if (CRSF_DEBUG_GPS > 0)
+#if (CRSF_DEBUG_GPS > 0) && (CRSF_DEBUG_GPS_NMEA > 0)
             Serial.print("GPS module initialization response: ");
             Serial.print(_dmaGpsNmeaBuffer);
 #endif

--- a/examples/gps_telemetry/gps.cpp
+++ b/examples/gps_telemetry/gps.cpp
@@ -18,6 +18,12 @@ char _dmaGpsRxChar = 0;
 uint8_t _dmaGpsRxBuffer[GPS_RX_BUFFER_SIZE];
 size_t _dmaGpsRxIndex = 0;
 
+Adafruit_ZeroDMA _dmaGpsTx;
+volatile bool _dmaGpsTxComplete = false;
+char _dmaGpsTxChar = 0;
+uint8_t _dmaGpsTxBuffer[GPS_TX_BUFFER_SIZE];
+size_t _dmaGpsTxIndex = 0;
+
 volatile size_t _dmaGpsNmeaBufferLength = 0;
 char _dmaGpsNmeaBuffer[GPS_RX_BUFFER_SIZE];
 
@@ -55,6 +61,17 @@ bool GPS::begin()
 
     // Initialize DMA.
     _initDMA();
+
+    // Send the initialization command.
+    char initCommand[14] = "$PMTK000*32\r\n";
+    _gpsWrite(initCommand, sizeof(initCommand));
+    if (_gpsWaitForResponse(GPS_RX_TIMEOUT) != true)
+    {
+#if (CRSF_DEBUG_GPS > 0)
+        Serial.println("GPS initialization failed.");
+#endif
+        return false;
+    }
 
     return true;
 }
@@ -114,6 +131,18 @@ bool GPS::_initDMA()
         return false;
     }
 
+    _dmaGpsTx.setTrigger(SERCOM5_DMAC_ID_TX);
+    _dmaGpsTx.setAction(DMA_TRIGGER_ACTON_BEAT);
+    _dmaGpsTxStatus = _dmaGpsTx.allocate();
+    if (_dmaGpsTxStatus != DMA_STATUS_OK)
+    {
+#if (CRSF_DEBUG_GPS > 0)
+        Serial.print("DMA allocation error: ");
+        Serial.println(_dmaGpsTxStatus);
+#endif
+        return false;
+    }
+
     /* Configure the DMA descriptor. */
     _dmaGpsRxDescriptor = _dmaGpsRx.addDescriptor(
         (void *)&SERCOM5->USART.DATA.reg, /* source address */
@@ -126,8 +155,18 @@ bool GPS::_initDMA()
     _dmaGpsRxDescriptor->BTCTRL.bit.BLOCKACT = DMA_BLOCK_ACTION_INT;
     _dmaGpsRx.loop(true);
 
+    _dmaGpsTxDescriptor = _dmaGpsTx.addDescriptor(
+        _dmaGpsTxBuffer,                  /* source address */
+        (void *)&SERCOM5->USART.DATA.reg, /* destination address */
+        GPS_TX_BUFFER_SIZE,               /* beat transfer count */
+        DMA_BEAT_SIZE_BYTE,               /* beat size */
+        true,                             /* increment source address */
+        false                             /* increment desination address */
+    );
+
     /* Configure the DMA callback. */
     _dmaGpsRx.setCallback(_dmaGpsRxCallback);
+    _dmaGpsTx.setCallback(_dmaGpsTxCallback);
 
     /* Start the DMA job. */
     _dmaGpsRxStatus = _dmaGpsRx.startJob();
@@ -191,6 +230,117 @@ void GPS::_parseNMEA(uint8_t *buffer, size_t length)
     }
 }
 
+void GPS::_gpsWrite(uint8_t *buffer, size_t length)
+{
+    /* Copy the data to the DMA buffer. */
+    memset(_dmaGpsTxBuffer, 0, GPS_TX_BUFFER_SIZE);
+    memcpy(_dmaGpsTxBuffer, buffer, length);
+
+    /* Reset the DMA job complete flag. */
+    _dmaGpsTxComplete = false;
+
+    /* Update the DMA descriptor. */
+    _dmaGpsTx.changeDescriptor(
+        _dmaGpsTxDescriptor,
+        _dmaGpsTxBuffer,                  /* source address */
+        (void *)&SERCOM5->USART.DATA.reg, /* destination address */
+        length                            /* beat transfer count */
+    );
+
+    /* Start the DMA job. */
+    _dmaGpsTxStatus = _dmaGpsTx.startJob();
+    if (_dmaGpsTxStatus != DMA_STATUS_OK)
+    {
+#if (CRSF_DEBUG_GPS > 0)
+        Serial.print("DMA start job error: ");
+        Serial.println(_dmaGpsTxStatus);
+#endif
+    }
+
+    /* Wait for the DMA job to complete. */
+    uint32_t _timestamp = millis();
+    while (_dmaGpsTxComplete != true)
+    {
+        if (millis() - _timestamp >= GPS_TX_TIMEOUT)
+        {
+#if (CRSF_DEBUG_GPS > 0)
+            Serial.println("DMA timeout");
+#endif
+            break;
+        }
+    }
+}
+
+void GPS::_gpsWrite(const char *buffer, size_t length)
+{
+    _gpsWrite((uint8_t *)buffer, length);
+}
+
+bool GPS::_gpsWaitForResponse(uint32_t timeout)
+{
+    uint32_t _timestamp = millis();
+    while (millis() - _timestamp < timeout)
+    {
+        if (_dmaGpsRxComplete == true)
+        {
+            _dmaGpsRxComplete = false;
+
+#if (CRSF_DEBUG_GPS > 0)
+            Serial.print("GPS module initialization response: ");
+            Serial.print(_dmaGpsNmeaBuffer);
+#endif
+
+            // Calculate the checksum of the response.
+            uint8_t checksum = 0;
+            for (size_t i = 1; i < _dmaGpsNmeaBufferLength - 5; i++)
+            {
+                checksum ^= _dmaGpsNmeaBuffer[i];
+            }
+
+            // Convert the checksum to a hex string.
+            char checksumString[2];
+            sprintf(checksumString, "%02X", checksum);
+
+            // Compare the checksums.
+            if (strncmp(checksumString, &_dmaGpsNmeaBuffer[_dmaGpsNmeaBufferLength - 4], 2) == 0)
+            {
+                // Wait for acknowledgement.
+                if (strstr(_dmaGpsNmeaBuffer, "$PMTK001") != NULL)
+                {
+                    // Get the acknowledgement code and convert it to an integer.
+                    char ackCode[1];
+                    strncpy(ackCode, &_dmaGpsNmeaBuffer[13], 1);
+                    uint8_t ack = atoi(ackCode);
+
+                    // Check the acknowledgement code.
+                    if (ack == 3)
+                    {
+                        return true;
+                    }
+
+                    // Any other acknowledgement code is an error.
+                    else
+                    {
+#if (CRSF_DEBUG_GPS > 0)
+                        Serial.print("GPS module initialization error: ");
+                        Serial.println(ack);
+#endif
+                        return false;
+                    }
+                }
+            }
+
+            // Checksum failed.
+            else
+            {
+                return false;
+            }
+        }
+    }
+
+    return false;
+}
+
 void _dmaGpsRxCallback(Adafruit_ZeroDMA *dma)
 {
 
@@ -234,5 +384,13 @@ void _dmaGpsRxCallback(Adafruit_ZeroDMA *dma)
             Serial.println("Error: GPS NMEA buffer overflowed.");
 #endif
         }
+    }
+}
+
+void _dmaGpsTxCallback(Adafruit_ZeroDMA *dma)
+{
+    if (dma == &_dmaGpsTx)
+    {
+        _dmaGpsTxComplete = true;
     }
 }

--- a/examples/gps_telemetry/gps.cpp
+++ b/examples/gps_telemetry/gps.cpp
@@ -15,7 +15,7 @@
 Adafruit_ZeroDMA _dmaGpsRx;
 volatile bool _dmaGpsRxComplete = false;
 char _dmaGpsRxChar = 0;
-uint8_t _dmaGpsRxBuffer[GPS_RX_BUFFER_SIZE];
+char _dmaGpsRxBuffer[GPS_RX_BUFFER_SIZE];
 size_t _dmaGpsRxIndex = 0;
 
 Adafruit_ZeroDMA _dmaGpsTx;
@@ -197,7 +197,7 @@ bool GPS::_initDMA()
  * @param buffer
  * @param length
  */
-void GPS::_parseNMEA(uint8_t *buffer, size_t length)
+void GPS::_parseNMEA(const char *buffer, size_t length)
 {
 #if (CRSF_DEBUG_GPS > 0) && (CRSF_DEBUG_GPS_NMEA > 0)
     Serial.print("GPS: ");

--- a/examples/gps_telemetry/gps.cpp
+++ b/examples/gps_telemetry/gps.cpp
@@ -63,7 +63,7 @@ bool GPS::begin()
     _initDMA();
 
     // Set GPS Baud Rate.
-    if (_gpsNegotiateBaudRate(9600) != true)
+    if (_gpsNegotiateBaudRate(115200) != true)
     {
 #if (CRSF_DEBUG_GPS > 0)
         Serial.println("GPS initialization failed.");

--- a/examples/gps_telemetry/gps.cpp
+++ b/examples/gps_telemetry/gps.cpp
@@ -55,6 +55,11 @@ GPS::~GPS()
  */
 bool GPS::begin()
 {
+#if (CRSF_DEBUG_GPS > 0)
+    Serial.println("Initializing GPS module...");
+#endif
+
+    // Initialize the serial port.
     _serial->begin(9600);
     pinPeripheral(_rxPin, PIO_SERCOM);
     pinPeripheral(_txPin, PIO_SERCOM);
@@ -72,6 +77,10 @@ bool GPS::begin()
 #endif
         return false;
     }
+
+#if (CRSF_DEBUG_GPS > 0)
+    Serial.println("GPS initialization complete.");
+#endif
 
     return true;
 }

--- a/examples/gps_telemetry/gps.cpp
+++ b/examples/gps_telemetry/gps.cpp
@@ -53,6 +53,54 @@ bool GPS::begin()
     pinPeripheral(_rxPin, PIO_SERCOM);
     pinPeripheral(_txPin, PIO_SERCOM);
 
+    // Initialize DMA.
+    _initDMA();
+
+    return true;
+}
+
+/**
+ * @brief Parse NMEA data.
+ *
+ * @return true
+ * @return false
+ */
+bool GPS::update()
+{
+    if (_dmaGpsRxComplete == true)
+    {
+        _dmaGpsRxComplete = false;
+
+        // Copy the NMEA data.
+        memset(_dmaGpsRxBuffer, 0, GPS_RX_BUFFER_SIZE);
+        memcpy(_dmaGpsRxBuffer, _dmaGpsNmeaBuffer, _dmaGpsNmeaBufferLength);
+
+        // Parse the NMEA data.
+        _parseNMEA(_dmaGpsRxBuffer, _dmaGpsNmeaBufferLength);
+
+        // Update the GPS data.
+        data.latitude = _latitude;
+        data.longitude = _longitude;
+        data.altitude = _altitude;
+        data.speed = _speed;
+        data.heading = _heading;
+        data.satellites = _satellites;
+
+        return true;
+    }
+
+    else
+    {
+        return false;
+    }
+}
+
+/**
+ * @brief Initializes DMA.
+ *
+ */
+bool GPS::_initDMA()
+{
     /* Configure DMA. */
     _dmaGpsRx.setTrigger(SERCOM4_DMAC_ID_RX);
     _dmaGpsRx.setAction(DMA_TRIGGER_ACTON_BEAT);
@@ -93,42 +141,6 @@ bool GPS::begin()
     }
 
     return true;
-}
-
-/**
- * @brief Parse NMEA data.
- *
- * @return true
- * @return false
- */
-bool GPS::update()
-{
-    if (_dmaGpsRxComplete == true)
-    {
-        _dmaGpsRxComplete = false;
-
-        // Copy the NMEA data.
-        memset(_dmaGpsRxBuffer, 0, GPS_RX_BUFFER_SIZE);
-        memcpy(_dmaGpsRxBuffer, _dmaGpsNmeaBuffer, _dmaGpsNmeaBufferLength);
-
-        // Parse the NMEA data.
-        _parseNMEA(_dmaGpsRxBuffer, _dmaGpsNmeaBufferLength);
-
-        // Update the GPS data.
-        data.latitude = _latitude;
-        data.longitude = _longitude;
-        data.altitude = _altitude;
-        data.speed = _speed;
-        data.heading = _heading;
-        data.satellites = _satellites;
-
-        return true;
-    }
-
-    else
-    {
-        return false;
-    }
 }
 
 /**

--- a/examples/gps_telemetry/gps.cpp
+++ b/examples/gps_telemetry/gps.cpp
@@ -102,7 +102,7 @@ bool GPS::update()
 bool GPS::_initDMA()
 {
     /* Configure DMA. */
-    _dmaGpsRx.setTrigger(SERCOM4_DMAC_ID_RX);
+    _dmaGpsRx.setTrigger(SERCOM5_DMAC_ID_RX);
     _dmaGpsRx.setAction(DMA_TRIGGER_ACTON_BEAT);
     _dmaGpsRxStatus = _dmaGpsRx.allocate();
     if (_dmaGpsRxStatus != DMA_STATUS_OK)
@@ -116,7 +116,7 @@ bool GPS::_initDMA()
 
     /* Configure the DMA descriptor. */
     _dmaGpsRxDescriptor = _dmaGpsRx.addDescriptor(
-        (void *)&SERCOM4->USART.DATA.reg, /* source address */
+        (void *)&SERCOM5->USART.DATA.reg, /* source address */
         &_dmaGpsRxChar,                   /* destination address */
         1,                                /* beat transfer count */
         DMA_BEAT_SIZE_BYTE,               /* beat size */

--- a/examples/gps_telemetry/gps.cpp
+++ b/examples/gps_telemetry/gps.cpp
@@ -387,6 +387,7 @@ void _dmaGpsRxCallback(Adafruit_ZeroDMA *dma)
         {
             _dmaGpsRxIndex = 0;
             _dmaGpsNmeaBufferLength = 0;
+            _dmaGpsRxComplete = false;
             memset(_dmaGpsNmeaBuffer, 0, GPS_RX_BUFFER_SIZE);
 
 #if (CRSF_DEBUG_GPS > 0)

--- a/examples/gps_telemetry/gps.h
+++ b/examples/gps_telemetry/gps.h
@@ -52,6 +52,19 @@ protected:
 
     TinyGPSPlus _gps;
 
+    bool _gpsBaudRateLocked;
+    uint8_t _gpsBaudRateIndex;
+    uint32_t _gpsBaudRate;
+    const uint32_t _gpsBaudRates[7] = {
+        4800,
+        9600,
+        14400,
+        19200,
+        38400,
+        57600,
+        115200
+    };
+
     uint32_t _rxPin;
     uint32_t _txPin;
 
@@ -67,6 +80,7 @@ protected:
     bool _initDMA();
     void _parseNMEA(const char *buffer, size_t length);
 
+    bool _gpsNegotiateBaudRate(uint32_t targetBaudRate);
     void _gpsWrite(uint8_t *buffer, size_t length);
     void _gpsWrite(const char *buffer, size_t length);
     bool _gpsWaitForResponse(uint32_t timeout);

--- a/examples/gps_telemetry/gps.h
+++ b/examples/gps_telemetry/gps.h
@@ -65,7 +65,7 @@ protected:
     bool _updated;
 
     bool _initDMA();
-    void _parseNMEA(uint8_t *buffer, size_t length);
+    void _parseNMEA(const char *buffer, size_t length);
 
     void _gpsWrite(uint8_t *buffer, size_t length);
     void _gpsWrite(const char *buffer, size_t length);

--- a/examples/gps_telemetry/gps.h
+++ b/examples/gps_telemetry/gps.h
@@ -21,6 +21,30 @@
 #define GPS_RX_TIMEOUT 1000
 #define GPS_TX_TIMEOUT 1000
 
+#define GPS_BAUD_RATE 115200
+
+typedef enum __gps_baud_rate_e
+{
+    GPS_BAUD_RATE_4800 = 0,
+    GPS_BAUD_RATE_9600,
+    GPS_BAUD_RATE_14400,
+    GPS_BAUD_RATE_19200,
+    GPS_BAUD_RATE_38400,
+    GPS_BAUD_RATE_57600,
+    GPS_BAUD_RATE_115200,
+    GPS_BAUD_RATE_COUNT
+} gps_baud_rate_t;
+
+typedef enum __gps_update_rate_e
+{
+    GPS_UPDATE_RATE_INVALID = 0,
+    GPS_UPDATE_RATE_1HZ,
+    GPS_UPDATE_RATE_2HZ,
+    GPS_UPDATE_RATE_5HZ,
+    GPS_UPDATE_RATE_10HZ,
+    GPS_UPDATE_RATE_COUNT
+} gps_update_rate_t;
+
 class GPS
 {
 public:
@@ -40,6 +64,7 @@ public:
     ~GPS();
 
     bool begin();
+    bool setUpdateRate(gps_update_rate_t updateRate);
     bool update();
 
 protected:
@@ -63,6 +88,15 @@ protected:
         38400,
         57600,
         115200
+    };
+
+    uint16_t _gpsUpdateRate;
+    const uint16_t _gpsUpdateRates[GPS_UPDATE_RATE_COUNT] = {
+        0,    // 0 is not a valid update rate
+        1000, // 1 Hz
+        500,  // 2 Hz
+        200,  // 5 Hz
+        100   // 10 Hz
     };
 
     uint32_t _rxPin;

--- a/examples/gps_telemetry/gps.h
+++ b/examples/gps_telemetry/gps.h
@@ -17,6 +17,9 @@
 #include "TinyGPS++.h"
 
 #define GPS_RX_BUFFER_SIZE 255
+#define GPS_TX_BUFFER_SIZE 255
+#define GPS_RX_TIMEOUT 1000
+#define GPS_TX_TIMEOUT 1000
 
 class GPS
 {
@@ -43,7 +46,9 @@ protected:
     HardwareSerial *_serial;
 
     DmacDescriptor *_dmaGpsRxDescriptor;
+    DmacDescriptor *_dmaGpsTxDescriptor;
     ZeroDMAstatus _dmaGpsRxStatus;
+    ZeroDMAstatus _dmaGpsTxStatus;
 
     TinyGPSPlus _gps;
 
@@ -61,6 +66,11 @@ protected:
 
     bool _initDMA();
     void _parseNMEA(uint8_t *buffer, size_t length);
+
+    void _gpsWrite(uint8_t *buffer, size_t length);
+    void _gpsWrite(const char *buffer, size_t length);
+    bool _gpsWaitForResponse(uint32_t timeout);
 };
 
 void _dmaGpsRxCallback(Adafruit_ZeroDMA *dma);
+void _dmaGpsTxCallback(Adafruit_ZeroDMA *dma);

--- a/examples/gps_telemetry/gps.h
+++ b/examples/gps_telemetry/gps.h
@@ -59,6 +59,7 @@ protected:
 
     bool _updated;
 
+    bool _initDMA();
     void _parseNMEA(uint8_t *buffer, size_t length);
 };
 

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -92,9 +92,14 @@ void loop()
     }
 
     // Update the GPS sensor.
-    if (gps.update())
-    {
+    gps.update();
+
 #if (PRINT_GPS_DATA > 0)
+    // Schedule printing the GPS data to the serial port.
+    static uint32_t lastPrint = millis();
+    if (millis() - lastPrint >= 200)
+    {
+        lastPrint = millis();
         Serial.print("GPS <Lat: ");
         Serial.print(gps.data.latitude, 6);
         Serial.print(", Lon: ");
@@ -108,8 +113,8 @@ void loop()
         Serial.print(", Satellites: ");
         Serial.print(gps.data.satellites);
         Serial.println(">");
-#endif
     }
+#endif
 
     // Schedule writing the GPS telemetry data to the CRSF receiver.
     static uint32_t lastWrite = millis();

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -22,9 +22,9 @@
 #endif
 
 // Create a GPS object.
-const uint32_t GPSRxPin = 4;
-const uint32_t GPSTxPin = 5;
-Uart Serial2(&sercom4, GPSRxPin, GPSTxPin, SERCOM_RX_PAD_1, UART_TX_PAD_2);
+const uint32_t GPSRxPin = 2;
+const uint32_t GPSTxPin = 3;
+Uart Serial2(&sercom5, GPSRxPin, GPSTxPin, SERCOM_RX_PAD_1, UART_TX_PAD_0);
 GPS gps = GPS(&Serial2, GPSRxPin, GPSTxPin);
 
 // Create a CRSFforArduino object.
@@ -112,22 +112,22 @@ void loop()
     }
 }
 
-void SERCOM4_0_Handler()
+void SERCOM5_0_Handler()
 {
     Serial2.IrqHandler();
 }
 
-void SERCOM4_1_Handler()
+void SERCOM5_1_Handler()
 {
     Serial2.IrqHandler();
 }
 
-void SERCOM4_2_Handler()
+void SERCOM5_2_Handler()
 {
     Serial2.IrqHandler();
 }
 
-void SERCOM4_3_Handler()
+void SERCOM5_3_Handler()
 {
     Serial2.IrqHandler();
 }

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -32,7 +32,7 @@ CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 void setup()
 {
-#if (PRINT_RAW_RC_CHANNELS > 0) || (PRINT_GPS_DATA > 0)
+#if (PRINT_RAW_RC_CHANNELS > 0) || (PRINT_GPS_DATA > 0) || (CRSF_DEBUG_GPS > 0)
     // Initialize the serial port & wait for the port to open.
     Serial.begin(115200);
 

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -45,6 +45,10 @@ void setup()
     {
         ;
     }
+
+    // Show the user that the sketch is starting.
+    Serial.println("GPS Telemetry Example");
+    delay(1000);
 #endif
 
     // Initialize the CRSFforArduino library.
@@ -55,7 +59,6 @@ void setup()
 
 #if (PRINT_RAW_RC_CHANNELS > 0) || (PRINT_GPS_DATA > 0)
     // Show the user that the sketch is ready.
-    Serial.println("GPS Telemetry Example");
     delay(1000);
     Serial.println("Ready");
     delay(1000);

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -55,7 +55,34 @@ void setup()
     crsf.begin();
 
     // Initialize the GPS sensor.
-    gps.begin();
+    if (gps.begin() != true)
+    {
+#if (CRSF_DEBUG_GPS > 0) || (PRINT_GPS_DATA > 0) || (PRINT_RAW_RC_CHANNELS > 0)
+        Serial.println("GPS failed to initialize");
+#endif
+
+        // Stop the sketch from continuing.
+        while (true)
+        {
+            ;
+        }
+    }
+    else
+    {
+        // Set the GPS update rate to 10Hz.
+        if (gps.setUpdateRate(GPS_UPDATE_RATE_10HZ) != true)
+        {
+#if (CRSF_DEBUG_GPS > 0) || (PRINT_GPS_DATA > 0) || (PRINT_RAW_RC_CHANNELS > 0)
+            Serial.println("GPS failed to set update rate");
+#endif
+
+            // Stop the sketch from continuing.
+            while (true)
+            {
+                ;
+            }
+        }
+    }
 
 #if (PRINT_RAW_RC_CHANNELS > 0) || (PRINT_GPS_DATA > 0)
     // Show the user that the sketch is ready.

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -94,9 +94,6 @@ void loop()
     // Update the GPS sensor.
     if (gps.update())
     {
-        // Send the GPS telemetry data to the CRSF receiver.
-        crsf.writeGPStelemetry(gps.data.latitude, gps.data.longitude, gps.data.altitude, gps.data.speed, gps.data.heading, gps.data.satellites);
-
 #if (PRINT_GPS_DATA > 0)
         Serial.print("GPS <Lat: ");
         Serial.print(gps.data.latitude, 6);
@@ -112,6 +109,14 @@ void loop()
         Serial.print(gps.data.satellites);
         Serial.println(">");
 #endif
+    }
+
+    // Schedule writing the GPS telemetry data to the CRSF receiver.
+    static uint32_t lastWrite = millis();
+    if (millis() - lastWrite >= 20)
+    {
+        lastWrite = millis();
+        crsf.writeGPStelemetry(gps.data.latitude, gps.data.longitude, gps.data.altitude, gps.data.speed, gps.data.heading, gps.data.satellites);
     }
 }
 


### PR DESCRIPTION
## What's new

This pull request adds the following:
- 10Hz update frequency.
- Automatic baud rate negotiation.
- CRSF telemetry is now scheduled at an interval of 20ms.
- Move GPS Uart to SERCOM5.
  - Move Rx & Tx pins to pins 2 & 3, respectively.
  - On the Metro M4 Express, this puts the GPS pins right next to the UART pins for a connected ExpressLRS receiver.
- Sketch now holds if any one of the three compile options are enabled:
  - ```PRINT_RAW_RC_CHANNELS```
  - ```PRINT_GPS_DATA```
  - ```CRSF_DEBUG_GPS```
- Use DMA for both transmitting & receiving data to & from the GPS, respectively.

## Supported GPS hardware

This PR adds support for the following GPS modules:
- Modules that are based on the MediaTek MTK3339 chipset & outputs NMEA 0183 sentences.