### PR TITLE
Add hardware IMU driver

### DIFF
--- a/examples/ahrs_telemetry/busio_i2c_target.cpp
+++ b/examples/ahrs_telemetry/busio_i2c_target.cpp
@@ -1,0 +1,286 @@
+/**
+ * @file busio_i2c_target.cpp
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief A BusIO library for I2C Target Mode, based on Adafruit's BusIO library.
+ * @version 0.2.0
+ * @date 2023-02-08
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+#include "busio_i2c_target.h"
+
+ //#define DEBUG_SERIAL Serial
+
+ /*!
+  *    @brief  Create an I2C device at a given address
+  *    @param  addr The 7-bit I2C address for the device
+  *    @param  theWire The I2C bus to use, defaults to &Wire
+  */
+BusIO_I2C_Target::BusIO_I2C_Target(uint8_t addr, I2C* theWire) {
+  _addr = addr;
+  _wire = theWire;
+  _begun = false;
+  _maxBufferSize = 250; // as defined in Wire.h's RingBuffer
+}
+
+/*!
+ *    @brief  Initializes and does basic address detection
+ *    @param  addr_detect Whether we should attempt to detect the I2C address
+ * with a scan. 99% of sensors/devices don't mind but once in a while, they spaz
+ * on a scan!
+ *    @return True if I2C initialized and a device with the addr found
+ */
+bool BusIO_I2C_Target::begin(bool addr_detect) {
+  Serial.println("BusIO_I2C_Target::begin()");
+  _wire->begin();
+  _begun = true;
+
+  if (addr_detect) {
+    bool _detected = detected();
+    Serial.println("BusIO_I2C_Target::begin() - detected() - returned " + String(_detected));
+    return _detected;
+  }
+
+  Serial.println("BusIO_I2C_Target::begin() - done");
+  return true;
+}
+
+/*!
+ *    @brief  De-initialize device, turn off the Wire interface
+ */
+void BusIO_I2C_Target::end(void) {
+  // Not all port implement Wire::end(), such as
+  // - ESP8266
+  // - AVR core without WIRE_HAS_END
+  // - ESP32: end() is implemented since 2.0.1 which is latest at the moment.
+  // Temporarily disable for now to give time for user to update.
+#if !(defined(ESP8266) ||                                                      \
+      (defined(ARDUINO_ARCH_AVR) && !defined(WIRE_HAS_END)) ||                 \
+      defined(ARDUINO_ARCH_ESP32))
+  _wire->end();
+  _begun = false;
+#endif
+}
+
+/*!
+ *    @brief  Scans I2C for the address - note will give a false-positive
+ *    if there's no pullups on I2C
+ *    @return True if I2C initialized and a device with the addr found
+ */
+bool BusIO_I2C_Target::detected(void) {
+  Serial.println("BusIO_I2C_Target::detected()");
+
+  // Init I2C if not done yet
+  if (!_begun && !begin()) {
+    Serial.println("BusIO_I2C_Target::detected() - begin() failed");
+    return false;
+  }
+
+  // A basic scanner, see if it ACK's
+  Serial.println("BusIO_I2C_Target::detected() - scanning");
+  _wire->beginTransmission(_addr);
+  if (_wire->endTransmission() == 0) {
+    Serial.println("BusIO_I2C_Target::detected() - detected");
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.println(F("Detected"));
+#endif
+    Serial.println("BusIO_I2C_Target::detected() - done");
+    return true;
+  }
+  Serial.println("BusIO_I2C_Target::detected() - not detected");
+#ifdef DEBUG_SERIAL
+  DEBUG_SERIAL.println(F("Not detected"));
+#endif
+  Serial.println("BusIO_I2C_Target::detected() - done");
+  return false;
+}
+
+/*!
+ *    @brief  Write a buffer or two to the I2C device. Cannot be more than
+ * maxBufferSize() bytes.
+ *    @param  buffer Pointer to buffer of data to write. This is const to
+ *            ensure the content of this buffer doesn't change.
+ *    @param  len Number of bytes from buffer to write
+ *    @param  prefix_buffer Pointer to optional array of data to write before
+ * buffer. Cannot be more than maxBufferSize() bytes. This is const to
+ *            ensure the content of this buffer doesn't change.
+ *    @param  prefix_len Number of bytes from prefix buffer to write
+ *    @param  stop Whether to send an I2C STOP signal on write
+ *    @return True if write was successful, otherwise false.
+ */
+bool BusIO_I2C_Target::write(const uint8_t* buffer, size_t len, bool stop,
+  const uint8_t* prefix_buffer,
+  size_t prefix_len) {
+  if ((len + prefix_len) > maxBufferSize()) {
+    // currently not guaranteed to work if more than 32 bytes!
+    // we will need to find out if some platforms have larger
+    // I2C buffer sizes :/
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.println(F("\tI2CDevice could not write such a large buffer"));
+#endif
+    return false;
+  }
+
+  _wire->beginTransmission(_addr);
+
+  // Write the prefix data (usually an address)
+  if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
+    if (_wire->write(prefix_buffer, prefix_len) != prefix_len) {
+#ifdef DEBUG_SERIAL
+      DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
+#endif
+      return false;
+    }
+  }
+
+  // Write the data itself
+  if (_wire->write(buffer, len) != len) {
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
+#endif
+    return false;
+  }
+
+#ifdef DEBUG_SERIAL
+
+  DEBUG_SERIAL.print(F("\tI2CWRITE @ 0x"));
+  DEBUG_SERIAL.print(_addr, HEX);
+  DEBUG_SERIAL.print(F(" :: "));
+  if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
+    for (uint16_t i = 0; i < prefix_len; i++) {
+      DEBUG_SERIAL.print(F("0x"));
+      DEBUG_SERIAL.print(prefix_buffer[i], HEX);
+      DEBUG_SERIAL.print(F(", "));
+    }
+  }
+  for (uint16_t i = 0; i < len; i++) {
+    DEBUG_SERIAL.print(F("0x"));
+    DEBUG_SERIAL.print(buffer[i], HEX);
+    DEBUG_SERIAL.print(F(", "));
+    if (i % 32 == 31) {
+      DEBUG_SERIAL.println();
+    }
+  }
+
+  if (stop) {
+    DEBUG_SERIAL.print("\tSTOP");
+  }
+#endif
+
+  if (_wire->endTransmission(stop) == 0) {
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.println();
+    // DEBUG_SERIAL.println("Sent!");
+#endif
+    return true;
+  }
+  else {
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.println("\tFailed to send!");
+#endif
+    return false;
+  }
+}
+
+/*!
+ *    @brief  Read from I2C into a buffer from the I2C device.
+ *    Cannot be more than maxBufferSize() bytes.
+ *    @param  buffer Pointer to buffer of data to read into
+ *    @param  len Number of bytes from buffer to read.
+ *    @param  stop Whether to send an I2C STOP signal on read
+ *    @return True if read was successful, otherwise false.
+ */
+bool BusIO_I2C_Target::read(uint8_t* buffer, size_t len, bool stop) {
+  size_t pos = 0;
+  while (pos < len) {
+    size_t read_len =
+      ((len - pos) > maxBufferSize()) ? maxBufferSize() : (len - pos);
+    bool read_stop = (pos < (len - read_len)) ? false : stop;
+    if (!_read(buffer + pos, read_len, read_stop))
+      return false;
+    pos += read_len;
+  }
+  return true;
+}
+
+bool BusIO_I2C_Target::_read(uint8_t* buffer, size_t len, bool stop) {
+#if defined(TinyWireM_h)
+  size_t recv = _wire->requestFrom((uint8_t)_addr, (uint8_t)len);
+#elif defined(ARDUINO_ARCH_MEGAAVR)
+  size_t recv = _wire->requestFrom(_addr, len, stop);
+#else
+  size_t recv = _wire->requestFrom((uint8_t)_addr, (uint8_t)len, (uint8_t)stop);
+#endif
+
+  if (recv != len) {
+    // Not enough data available to fulfill our obligation!
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.print(F("\tI2CDevice did not receive enough data: "));
+    DEBUG_SERIAL.println(recv);
+#endif
+    return false;
+  }
+
+  for (uint16_t i = 0; i < len; i++) {
+    buffer[i] = _wire->read();
+  }
+
+#ifdef DEBUG_SERIAL
+  DEBUG_SERIAL.print(F("\tI2CREAD  @ 0x"));
+  DEBUG_SERIAL.print(_addr, HEX);
+  DEBUG_SERIAL.print(F(" :: "));
+  for (uint16_t i = 0; i < len; i++) {
+    DEBUG_SERIAL.print(F("0x"));
+    DEBUG_SERIAL.print(buffer[i], HEX);
+    DEBUG_SERIAL.print(F(", "));
+    if (len % 32 == 31) {
+      DEBUG_SERIAL.println();
+    }
+  }
+  DEBUG_SERIAL.println();
+#endif
+
+  return true;
+}
+
+/*!
+ *    @brief  Write some data, then read some data from I2C into another buffer.
+ *    Cannot be more than maxBufferSize() bytes. The buffers can point to
+ *    same/overlapping locations.
+ *    @param  write_buffer Pointer to buffer of data to write from
+ *    @param  write_len Number of bytes from buffer to write.
+ *    @param  read_buffer Pointer to buffer of data to read into.
+ *    @param  read_len Number of bytes from buffer to read.
+ *    @param  stop Whether to send an I2C STOP signal between the write and read
+ *    @return True if write & read was successful, otherwise false.
+ */
+bool BusIO_I2C_Target::write_then_read(const uint8_t* write_buffer,
+  size_t write_len, uint8_t* read_buffer,
+  size_t read_len, bool stop) {
+  if (!write(write_buffer, write_len, stop)) {
+    return false;
+  }
+
+  return read(read_buffer, read_len);
+}
+
+/*!
+ *    @brief  Returns the 7-bit address of this device
+ *    @return The 7-bit address of this device
+ */
+uint8_t BusIO_I2C_Target::address(void) { return _addr; }
+
+/*!
+ *    @brief  Change the I2C clock speed to desired (relies on
+ *    underlying Wire support!
+ *    @param desiredclk The desired I2C SCL frequency
+ *    @return True if this platform supports changing I2C speed.
+ *    Not necessarily that the speed was achieved!
+ */
+bool BusIO_I2C_Target::setSpeed(uint32_t desiredclk) {
+  _wire->setClock(desiredclk);
+  return true;
+}
+

--- a/examples/ahrs_telemetry/busio_i2c_target.cpp
+++ b/examples/ahrs_telemetry/busio_i2c_target.cpp
@@ -19,10 +19,10 @@
   *    @param  theWire The I2C bus to use, defaults to &Wire
   */
 BusIO_I2C_Target::BusIO_I2C_Target(uint8_t addr, I2C* theWire) {
-  _addr = addr;
-  _wire = theWire;
-  _begun = false;
-  _maxBufferSize = 250; // as defined in Wire.h's RingBuffer
+    _addr = addr;
+    _wire = theWire;
+    _begun = false;
+    _maxBufferSize = 250; // as defined in Wire.h's RingBuffer
 }
 
 /*!
@@ -33,34 +33,31 @@ BusIO_I2C_Target::BusIO_I2C_Target(uint8_t addr, I2C* theWire) {
  *    @return True if I2C initialized and a device with the addr found
  */
 bool BusIO_I2C_Target::begin(bool addr_detect) {
-  Serial.println("BusIO_I2C_Target::begin()");
-  _wire->begin();
-  _begun = true;
+    _wire->begin();
+    _begun = true;
 
-  if (addr_detect) {
-    bool _detected = detected();
-    Serial.println("BusIO_I2C_Target::begin() - detected() - returned " + String(_detected));
-    return _detected;
-  }
+    if (addr_detect) {
+        bool _detected = detected();
+        return _detected;
+    }
 
-  Serial.println("BusIO_I2C_Target::begin() - done");
-  return true;
+    return true;
 }
 
 /*!
  *    @brief  De-initialize device, turn off the Wire interface
  */
 void BusIO_I2C_Target::end(void) {
-  // Not all port implement Wire::end(), such as
-  // - ESP8266
-  // - AVR core without WIRE_HAS_END
-  // - ESP32: end() is implemented since 2.0.1 which is latest at the moment.
-  // Temporarily disable for now to give time for user to update.
+    // Not all port implement Wire::end(), such as
+    // - ESP8266
+    // - AVR core without WIRE_HAS_END
+    // - ESP32: end() is implemented since 2.0.1 which is latest at the moment.
+    // Temporarily disable for now to give time for user to update.
 #if !(defined(ESP8266) ||                                                      \
       (defined(ARDUINO_ARCH_AVR) && !defined(WIRE_HAS_END)) ||                 \
       defined(ARDUINO_ARCH_ESP32))
-  _wire->end();
-  _begun = false;
+    _wire->end();
+    _begun = false;
 #endif
 }
 
@@ -70,31 +67,24 @@ void BusIO_I2C_Target::end(void) {
  *    @return True if I2C initialized and a device with the addr found
  */
 bool BusIO_I2C_Target::detected(void) {
-  Serial.println("BusIO_I2C_Target::detected()");
 
-  // Init I2C if not done yet
-  if (!_begun && !begin()) {
-    Serial.println("BusIO_I2C_Target::detected() - begin() failed");
+    // Init I2C if not done yet
+    if (!_begun && !begin()) {
+        return false;
+    }
+
+    // A basic scanner, see if it ACK's
+    _wire->beginTransmission(_addr);
+    if (_wire->endTransmission() == 0) {
+#ifdef DEBUG_SERIAL
+        DEBUG_SERIAL.println(F("Detected"));
+#endif
+        return true;
+    }
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.println(F("Not detected"));
+#endif
     return false;
-  }
-
-  // A basic scanner, see if it ACK's
-  Serial.println("BusIO_I2C_Target::detected() - scanning");
-  _wire->beginTransmission(_addr);
-  if (_wire->endTransmission() == 0) {
-    Serial.println("BusIO_I2C_Target::detected() - detected");
-#ifdef DEBUG_SERIAL
-    DEBUG_SERIAL.println(F("Detected"));
-#endif
-    Serial.println("BusIO_I2C_Target::detected() - done");
-    return true;
-  }
-  Serial.println("BusIO_I2C_Target::detected() - not detected");
-#ifdef DEBUG_SERIAL
-  DEBUG_SERIAL.println(F("Not detected"));
-#endif
-  Serial.println("BusIO_I2C_Target::detected() - done");
-  return false;
 }
 
 /*!
@@ -111,77 +101,77 @@ bool BusIO_I2C_Target::detected(void) {
  *    @return True if write was successful, otherwise false.
  */
 bool BusIO_I2C_Target::write(const uint8_t* buffer, size_t len, bool stop,
-  const uint8_t* prefix_buffer,
-  size_t prefix_len) {
-  if ((len + prefix_len) > maxBufferSize()) {
-    // currently not guaranteed to work if more than 32 bytes!
-    // we will need to find out if some platforms have larger
-    // I2C buffer sizes :/
+    const uint8_t* prefix_buffer,
+    size_t prefix_len) {
+    if ((len + prefix_len) > maxBufferSize()) {
+        // currently not guaranteed to work if more than 32 bytes!
+        // we will need to find out if some platforms have larger
+        // I2C buffer sizes :/
 #ifdef DEBUG_SERIAL
-    DEBUG_SERIAL.println(F("\tI2CDevice could not write such a large buffer"));
+        DEBUG_SERIAL.println(F("\tI2CDevice could not write such a large buffer"));
 #endif
-    return false;
-  }
-
-  _wire->beginTransmission(_addr);
-
-  // Write the prefix data (usually an address)
-  if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
-    if (_wire->write(prefix_buffer, prefix_len) != prefix_len) {
-#ifdef DEBUG_SERIAL
-      DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
-#endif
-      return false;
+        return false;
     }
-  }
 
-  // Write the data itself
-  if (_wire->write(buffer, len) != len) {
+    _wire->beginTransmission(_addr);
+
+    // Write the prefix data (usually an address)
+    if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
+        if (_wire->write(prefix_buffer, prefix_len) != prefix_len) {
 #ifdef DEBUG_SERIAL
-    DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
+            DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
 #endif
-    return false;
-  }
-
-#ifdef DEBUG_SERIAL
-
-  DEBUG_SERIAL.print(F("\tI2CWRITE @ 0x"));
-  DEBUG_SERIAL.print(_addr, HEX);
-  DEBUG_SERIAL.print(F(" :: "));
-  if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
-    for (uint16_t i = 0; i < prefix_len; i++) {
-      DEBUG_SERIAL.print(F("0x"));
-      DEBUG_SERIAL.print(prefix_buffer[i], HEX);
-      DEBUG_SERIAL.print(F(", "));
+            return false;
+        }
     }
-  }
-  for (uint16_t i = 0; i < len; i++) {
-    DEBUG_SERIAL.print(F("0x"));
-    DEBUG_SERIAL.print(buffer[i], HEX);
-    DEBUG_SERIAL.print(F(", "));
-    if (i % 32 == 31) {
-      DEBUG_SERIAL.println();
+
+    // Write the data itself
+    if (_wire->write(buffer, len) != len) {
+#ifdef DEBUG_SERIAL
+        DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
+#endif
+        return false;
     }
-  }
 
-  if (stop) {
-    DEBUG_SERIAL.print("\tSTOP");
-  }
+#ifdef DEBUG_SERIAL
+
+    DEBUG_SERIAL.print(F("\tI2CWRITE @ 0x"));
+    DEBUG_SERIAL.print(_addr, HEX);
+    DEBUG_SERIAL.print(F(" :: "));
+    if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
+        for (uint16_t i = 0; i < prefix_len; i++) {
+            DEBUG_SERIAL.print(F("0x"));
+            DEBUG_SERIAL.print(prefix_buffer[i], HEX);
+            DEBUG_SERIAL.print(F(", "));
+        }
+    }
+    for (uint16_t i = 0; i < len; i++) {
+        DEBUG_SERIAL.print(F("0x"));
+        DEBUG_SERIAL.print(buffer[i], HEX);
+        DEBUG_SERIAL.print(F(", "));
+        if (i % 32 == 31) {
+            DEBUG_SERIAL.println();
+        }
+    }
+
+    if (stop) {
+        DEBUG_SERIAL.print("\tSTOP");
+    }
 #endif
 
-  if (_wire->endTransmission(stop) == 0) {
+    if (_wire->endTransmission(stop) == 0) {
 #ifdef DEBUG_SERIAL
-    DEBUG_SERIAL.println();
-    // DEBUG_SERIAL.println("Sent!");
+        DEBUG_SERIAL.println();
+        // DEBUG_SERIAL.println("Sent!");
 #endif
-    return true;
-  }
-  else {
+        return true;
+    }
+    else {
 #ifdef DEBUG_SERIAL
-    DEBUG_SERIAL.println("\tFailed to send!");
+        DEBUG_SERIAL.println("\tFailed to send!");
 #endif
-    return false;
-  }
+        return false;
+    }
 }
 
 /*!
@@ -193,56 +183,56 @@ bool BusIO_I2C_Target::write(const uint8_t* buffer, size_t len, bool stop,
  *    @return True if read was successful, otherwise false.
  */
 bool BusIO_I2C_Target::read(uint8_t* buffer, size_t len, bool stop) {
-  size_t pos = 0;
-  while (pos < len) {
-    size_t read_len =
-      ((len - pos) > maxBufferSize()) ? maxBufferSize() : (len - pos);
-    bool read_stop = (pos < (len - read_len)) ? false : stop;
-    if (!_read(buffer + pos, read_len, read_stop))
-      return false;
-    pos += read_len;
-  }
-  return true;
+    size_t pos = 0;
+    while (pos < len) {
+        size_t read_len =
+            ((len - pos) > maxBufferSize()) ? maxBufferSize() : (len - pos);
+        bool read_stop = (pos < (len - read_len)) ? false : stop;
+        if (!_read(buffer + pos, read_len, read_stop))
+            return false;
+        pos += read_len;
+    }
+    return true;
 }
 
 bool BusIO_I2C_Target::_read(uint8_t* buffer, size_t len, bool stop) {
 #if defined(TinyWireM_h)
-  size_t recv = _wire->requestFrom((uint8_t)_addr, (uint8_t)len);
+    size_t recv = _wire->requestFrom((uint8_t)_addr, (uint8_t)len);
 #elif defined(ARDUINO_ARCH_MEGAAVR)
-  size_t recv = _wire->requestFrom(_addr, len, stop);
+    size_t recv = _wire->requestFrom(_addr, len, stop);
 #else
-  size_t recv = _wire->requestFrom((uint8_t)_addr, (uint8_t)len, (uint8_t)stop);
+    size_t recv = _wire->requestFrom((uint8_t)_addr, (uint8_t)len, (uint8_t)stop);
 #endif
 
-  if (recv != len) {
-    // Not enough data available to fulfill our obligation!
+    if (recv != len) {
+        // Not enough data available to fulfill our obligation!
 #ifdef DEBUG_SERIAL
-    DEBUG_SERIAL.print(F("\tI2CDevice did not receive enough data: "));
-    DEBUG_SERIAL.println(recv);
+        DEBUG_SERIAL.print(F("\tI2CDevice did not receive enough data: "));
+        DEBUG_SERIAL.println(recv);
 #endif
-    return false;
-  }
-
-  for (uint16_t i = 0; i < len; i++) {
-    buffer[i] = _wire->read();
-  }
-
-#ifdef DEBUG_SERIAL
-  DEBUG_SERIAL.print(F("\tI2CREAD  @ 0x"));
-  DEBUG_SERIAL.print(_addr, HEX);
-  DEBUG_SERIAL.print(F(" :: "));
-  for (uint16_t i = 0; i < len; i++) {
-    DEBUG_SERIAL.print(F("0x"));
-    DEBUG_SERIAL.print(buffer[i], HEX);
-    DEBUG_SERIAL.print(F(", "));
-    if (len % 32 == 31) {
-      DEBUG_SERIAL.println();
+        return false;
     }
-  }
-  DEBUG_SERIAL.println();
+
+    for (uint16_t i = 0; i < len; i++) {
+        buffer[i] = _wire->read();
+    }
+
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.print(F("\tI2CREAD  @ 0x"));
+    DEBUG_SERIAL.print(_addr, HEX);
+    DEBUG_SERIAL.print(F(" :: "));
+    for (uint16_t i = 0; i < len; i++) {
+        DEBUG_SERIAL.print(F("0x"));
+        DEBUG_SERIAL.print(buffer[i], HEX);
+        DEBUG_SERIAL.print(F(", "));
+        if (len % 32 == 31) {
+            DEBUG_SERIAL.println();
+        }
+    }
+    DEBUG_SERIAL.println();
 #endif
 
-  return true;
+    return true;
 }
 
 /*!
@@ -257,13 +247,13 @@ bool BusIO_I2C_Target::_read(uint8_t* buffer, size_t len, bool stop) {
  *    @return True if write & read was successful, otherwise false.
  */
 bool BusIO_I2C_Target::write_then_read(const uint8_t* write_buffer,
-  size_t write_len, uint8_t* read_buffer,
-  size_t read_len, bool stop) {
-  if (!write(write_buffer, write_len, stop)) {
-    return false;
-  }
+    size_t write_len, uint8_t* read_buffer,
+    size_t read_len, bool stop) {
+    if (!write(write_buffer, write_len, stop)) {
+        return false;
+    }
 
-  return read(read_buffer, read_len);
+    return read(read_buffer, read_len);
 }
 
 /*!
@@ -280,7 +270,7 @@ uint8_t BusIO_I2C_Target::address(void) { return _addr; }
  *    Not necessarily that the speed was achieved!
  */
 bool BusIO_I2C_Target::setSpeed(uint32_t desiredclk) {
-  _wire->setClock(desiredclk);
-  return true;
+    _wire->setClock(desiredclk);
+    return true;
 }
 

--- a/examples/ahrs_telemetry/busio_i2c_target.h
+++ b/examples/ahrs_telemetry/busio_i2c_target.h
@@ -1,0 +1,45 @@
+/**
+ * @file busio_i2c_target.h
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief A BusIO library for I2C Target Mode, based on Adafruit's BusIO library.
+ * @version 0.2.0
+ * @date 2023-02-08
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+#pragma once
+
+#include "Arduino.h"
+#include "i2c.h"
+
+ ///< The class which defines how we will talk to this device over I2C
+class BusIO_I2C_Target {
+public:
+    BusIO_I2C_Target(uint8_t addr, I2C* theWire = &Wire);
+    uint8_t address(void);
+    bool begin(bool addr_detect = true);
+    void end(void);
+    bool detected(void);
+
+    bool read(uint8_t* buffer, size_t len, bool stop = true);
+    bool write(const uint8_t* buffer, size_t len, bool stop = true,
+        const uint8_t* prefix_buffer = nullptr, size_t prefix_len = 0);
+    bool write_then_read(const uint8_t* write_buffer, size_t write_len,
+        uint8_t* read_buffer, size_t read_len,
+        bool stop = false);
+    bool setSpeed(uint32_t desiredclk);
+
+    /*!   @brief  How many bytes we can read in a transaction
+     *    @return The size of the Wire receive/transmit buffer */
+    size_t maxBufferSize() { return _maxBufferSize; }
+
+private:
+    uint8_t _addr;
+    I2C* _wire;
+    bool _begun;
+    size_t _maxBufferSize;
+    bool _read(uint8_t* buffer, size_t len, bool stop);
+};
+

--- a/examples/ahrs_telemetry/i2c.cpp
+++ b/examples/ahrs_telemetry/i2c.cpp
@@ -51,19 +51,13 @@ I2C::I2C(SERCOM* s, uint8_t pinSDA, uint8_t pinSCL)
  * @param baudrate The baudrate to use for I2C. Defaults to 100000.
  */
 void I2C::begin(uint32_t baudrate) {
-    Serial.println("I2C: I2C::begin()");
-
     // Controller Mode
-    Serial.println("I2C: I2C::begin() - sercom->initMasterWIRE()");
     sercom->initMasterWIRE(baudrate);
     sercom->enableWIRE();
-    Serial.println("I2C: I2C::begin() - sercom->enableWIRE()");
 
     // Force PIO_SERCOM_ALT for now.
     pinPeripheral(_uc_pinSDA, PIO_SERCOM_ALT);
     pinPeripheral(_uc_pinSCL, PIO_SERCOM_ALT);
-
-    Serial.println("I2C: I2C::begin() - done");
 }
 
 /**
@@ -161,15 +155,11 @@ uint8_t I2C::requestFrom(uint8_t address, size_t quantity)
 }
 
 void I2C::beginTransmission(uint8_t address) {
-    Serial.println("I2C: I2C::beginTransmission()");
-
     // save address of target and clear buffer
-    Serial.println("I2C: I2C::beginTransmission() - save address of target and clear buffer");
     txAddress = address;
     txBuffer.clear();
 
     transmissionBegun = true;
-    Serial.println("I2C: I2C::beginTransmission() - done");
 }
 
 // Errors:
@@ -180,43 +170,31 @@ void I2C::beginTransmission(uint8_t address) {
 //  4 : Other error
 uint8_t I2C::endTransmission(bool stopBit)
 {
-    Serial.println("I2C: I2C::endTransmission()");
     transmissionBegun = false;
 
     // Start I2C transmission
-    Serial.println("I2C: I2C::endTransmission() - Start I2C transmission");
     if (!sercom->startTransmissionWIRE(txAddress, WIRE_WRITE_FLAG))
     {
-        Serial.println("I2C: I2C::endTransmission() - Start I2C transmission - Send stop bit");
         sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
-        Serial.println("I2C: I2C::endTransmission() - Start I2C transmission - Address error");
         return 2;  // Address error
     }
-    Serial.println("I2C: I2C::endTransmission() - Start I2C transmission - done");
 
     // Send all buffer
-    Serial.println("I2C: I2C::endTransmission() - Send all buffer");
     while (txBuffer.available())
     {
         // Trying to send data
         if (!sercom->sendDataMasterWIRE(txBuffer.read_char()))
         {
-            Serial.println("I2C: I2C::endTransmission() - Send all buffer - Send stop bit");
             sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
-            Serial.println("I2C: I2C::endTransmission() - Send all buffer - Data error");
             return 3;  // Nack or error
         }
     }
-    Serial.println("I2C: I2C::endTransmission() - Send all buffer - done");
 
     if (stopBit)
     {
-        Serial.println("I2C: I2C::endTransmission() - Stop bit - Send stop bit");
         sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
-        Serial.println("I2C: I2C::endTransmission() - Stop bit - done");
     }
 
-    Serial.println("I2C: I2C::endTransmission() - done");
     return 0;
 }
 

--- a/examples/ahrs_telemetry/i2c.cpp
+++ b/examples/ahrs_telemetry/i2c.cpp
@@ -1,0 +1,357 @@
+/**
+ * @file i2c.h
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief A hardware I2C driver for SAMD51, based on the TWI/I2C library for Arduino Zero.
+ * @version 0.2.0
+ * @date 2023-02-08
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+extern "C" {
+#include <string.h>
+}
+
+#include <Arduino.h>
+#include <wiring_private.h>
+
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB
+#include <Adafruit_TinyUSB.h>
+#endif
+
+#include "i2c.h"
+
+/* I am not a fan of the sercom library using references to "Master" & "Slave" modes.
+ * In 2021, there was a shift away from the "Master" & "Slave" terminology to "Controller" & "Target" as it is more inclusive.
+ * Later on, I will create my own sercom library that uses the "Controller" & "Target" terminology.
+ * For now, I am using the sercom library as-is - but I will be changing the terminology in the comments.
+ * --Cassie Robinson, 2023-02-08
+ */
+
+ /**
+  * @brief Construct a new I2C object
+  *
+  * @param s A pointer to the SERCOM object to use for I2C.
+  * @param pinSDA The pin to use for I2C SDA.
+  * @param pinSCL The pin to use for I2C SCL.
+  */
+I2C::I2C(SERCOM* s, uint8_t pinSDA, uint8_t pinSCL)
+{
+    this->sercom = s;
+    this->_uc_pinSDA = pinSDA;
+    this->_uc_pinSCL = pinSCL;
+    transmissionBegun = false;
+}
+
+/**
+ * @brief Start I2C as a controller.
+ *
+ * @param baudrate The baudrate to use for I2C. Defaults to 100000.
+ */
+void I2C::begin(uint32_t baudrate) {
+    Serial.println("I2C: I2C::begin()");
+
+    // Controller Mode
+    Serial.println("I2C: I2C::begin() - sercom->initMasterWIRE()");
+    sercom->initMasterWIRE(baudrate);
+    sercom->enableWIRE();
+    Serial.println("I2C: I2C::begin() - sercom->enableWIRE()");
+
+    // Force PIO_SERCOM_ALT for now.
+    pinPeripheral(_uc_pinSDA, PIO_SERCOM_ALT);
+    pinPeripheral(_uc_pinSCL, PIO_SERCOM_ALT);
+
+    Serial.println("I2C: I2C::begin() - done");
+}
+
+/**
+ * @brief Start I2C as a target.
+ *
+ * @param address The address to use for I2C.
+ * @param enableGeneralCall Whether or not to enable general call.
+ */
+void I2C::begin(uint8_t address, bool enableGeneralCall) {
+    // Target mode
+    sercom->initSlaveWIRE(address, enableGeneralCall);
+    sercom->enableWIRE();
+
+    // Force PIO_SERCOM_ALT for now.
+    pinPeripheral(_uc_pinSDA, PIO_SERCOM_ALT);
+    pinPeripheral(_uc_pinSCL, PIO_SERCOM_ALT);
+}
+
+/**
+ * @brief Set the baud rate (clock speed) for I2C.
+ *
+ * @param baudrate The baudrate to use for I2C.
+ */
+void I2C::setClock(uint32_t baudrate) {
+
+    // Exit if the baudrate is out of range
+    if (baudrate < I2C_BAUDRATE_STANDARD || baudrate > I2C_BAUDRATE_FASTPLUS)
+    {
+        return;
+    }
+
+    sercom->disableWIRE();
+    sercom->initMasterWIRE(baudrate);
+    sercom->enableWIRE();
+}
+
+/**
+ * @brief Stop I2C.
+ *
+ */
+void I2C::end() {
+    sercom->disableWIRE();
+    sercom->resetWIRE();
+
+    pinPeripheral(_uc_pinSDA, PIO_DIGITAL);
+    pinPeripheral(_uc_pinSCL, PIO_DIGITAL);
+}
+
+/**
+ * @brief Request a number of bytes from a target.
+ *
+ * @param address The address of the target to request bytes from.
+ * @param quantity The number of bytes to request.
+ * @param stopBit Whether or not to send a stop bit after the request.
+ * @return uint8_t The number of bytes read.
+ */
+uint8_t I2C::requestFrom(uint8_t address, size_t quantity, bool stopBit)
+{
+    if (quantity == 0)
+    {
+        return 0;
+    }
+
+    size_t byteRead = 0;
+
+    rxBuffer.clear();
+
+    if (sercom->startTransmissionWIRE(address, WIRE_READ_FLAG))
+    {
+        // Read first data
+        rxBuffer.store_char(sercom->readDataWIRE());
+
+        // Connected to target
+        for (byteRead = 1; byteRead < quantity; ++byteRead)
+        {
+            sercom->prepareAckBitWIRE();                          // Prepare Acknowledge
+            sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_READ); // Prepare the ACK command for the target
+            rxBuffer.store_char(sercom->readDataWIRE());          // Read data and send the ACK
+        }
+        sercom->prepareNackBitWIRE();                           // Prepare NACK to stop target transmission
+        //sercom->readDataWIRE();                               // Clear data register to send NACK
+
+        if (stopBit)
+        {
+            sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);   // Send Stop
+        }
+    }
+
+    return byteRead;
+}
+
+uint8_t I2C::requestFrom(uint8_t address, size_t quantity)
+{
+    return requestFrom(address, quantity, true);
+}
+
+void I2C::beginTransmission(uint8_t address) {
+    Serial.println("I2C: I2C::beginTransmission()");
+
+    // save address of target and clear buffer
+    Serial.println("I2C: I2C::beginTransmission() - save address of target and clear buffer");
+    txAddress = address;
+    txBuffer.clear();
+
+    transmissionBegun = true;
+    Serial.println("I2C: I2C::beginTransmission() - done");
+}
+
+// Errors:
+//  0 : Success
+//  1 : Data too long
+//  2 : NACK on transmit of address
+//  3 : NACK on transmit of data
+//  4 : Other error
+uint8_t I2C::endTransmission(bool stopBit)
+{
+    Serial.println("I2C: I2C::endTransmission()");
+    transmissionBegun = false;
+
+    // Start I2C transmission
+    Serial.println("I2C: I2C::endTransmission() - Start I2C transmission");
+    if (!sercom->startTransmissionWIRE(txAddress, WIRE_WRITE_FLAG))
+    {
+        Serial.println("I2C: I2C::endTransmission() - Start I2C transmission - Send stop bit");
+        sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+        Serial.println("I2C: I2C::endTransmission() - Start I2C transmission - Address error");
+        return 2;  // Address error
+    }
+    Serial.println("I2C: I2C::endTransmission() - Start I2C transmission - done");
+
+    // Send all buffer
+    Serial.println("I2C: I2C::endTransmission() - Send all buffer");
+    while (txBuffer.available())
+    {
+        // Trying to send data
+        if (!sercom->sendDataMasterWIRE(txBuffer.read_char()))
+        {
+            Serial.println("I2C: I2C::endTransmission() - Send all buffer - Send stop bit");
+            sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+            Serial.println("I2C: I2C::endTransmission() - Send all buffer - Data error");
+            return 3;  // Nack or error
+        }
+    }
+    Serial.println("I2C: I2C::endTransmission() - Send all buffer - done");
+
+    if (stopBit)
+    {
+        Serial.println("I2C: I2C::endTransmission() - Stop bit - Send stop bit");
+        sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+        Serial.println("I2C: I2C::endTransmission() - Stop bit - done");
+    }
+
+    Serial.println("I2C: I2C::endTransmission() - done");
+    return 0;
+}
+
+uint8_t I2C::endTransmission()
+{
+    return endTransmission(true);
+}
+
+size_t I2C::write(uint8_t ucData)
+{
+    // No writing, without begun transmission or a full buffer
+    if (!transmissionBegun || txBuffer.isFull())
+    {
+        return 0;
+    }
+
+    txBuffer.store_char(ucData);
+
+    return 1;
+}
+
+size_t I2C::write(const uint8_t* data, size_t quantity)
+{
+    // Try to store all data
+    for (size_t i = 0; i < quantity; ++i)
+    {
+        // Return the number of data stored, when the buffer is full (if write return 0)
+        if (!write(data[i]))
+            return i;
+    }
+
+    // All data stored
+    return quantity;
+}
+
+int I2C::available(void)
+{
+    return rxBuffer.available();
+}
+
+int I2C::read(void)
+{
+    return rxBuffer.read_char();
+}
+
+int I2C::peek(void)
+{
+    return rxBuffer.peek();
+}
+
+void I2C::flush(void)
+{
+    // Do nothing, use endTransmission(..) to force
+    // data transfer.
+}
+
+void I2C::onReceive(void(*function)(int))
+{
+    onReceiveCallback = function;
+}
+
+void I2C::onRequest(void(*function)(void))
+{
+    onRequestCallback = function;
+}
+
+void I2C::onService(void)
+{
+    if (sercom->isSlaveWIRE())
+    {
+        if (sercom->isStopDetectedWIRE() ||
+            (sercom->isAddressMatch() && sercom->isRestartDetectedWIRE() && !sercom->isMasterReadOperationWIRE())) //Stop or Restart detected
+        {
+            sercom->prepareAckBitWIRE();
+            sercom->prepareCommandBitsWire(0x03);
+
+            //Calling onReceiveCallback, if exists
+            if (onReceiveCallback)
+            {
+                onReceiveCallback(available());
+            }
+
+            rxBuffer.clear();
+        }
+        else if (sercom->isAddressMatch())  //Address Match
+        {
+            sercom->prepareAckBitWIRE();
+            sercom->prepareCommandBitsWire(0x03);
+
+            if (sercom->isMasterReadOperationWIRE()) //Is a request ?
+            {
+                txBuffer.clear();
+
+                transmissionBegun = true;
+
+                //Calling onRequestCallback, if exists
+                if (onRequestCallback)
+                {
+                    onRequestCallback();
+                }
+            }
+        }
+        else if (sercom->isDataReadyWIRE())
+        {
+            if (sercom->isMasterReadOperationWIRE())
+            {
+                uint8_t c = 0xff;
+
+                if (txBuffer.available()) {
+                    c = txBuffer.read_char();
+                }
+
+                transmissionBegun = sercom->sendDataSlaveWIRE(c);
+            }
+            else { //Received data
+                if (rxBuffer.isFull()) {
+                    sercom->prepareNackBitWIRE();
+                }
+                else {
+                    //Store data
+                    rxBuffer.store_char(sercom->readDataWIRE());
+
+                    sercom->prepareAckBitWIRE();
+                }
+
+                sercom->prepareCommandBitsWire(0x03);
+            }
+        }
+    }
+}
+
+// SERCOM4 is on pins A4 and A5. SDA: A4, SCL: A5.
+I2C Wire(&sercom4, A4, A5);
+
+void SERCOM4_0_Handler(void) { Wire.onService(); }
+void SERCOM4_1_Handler(void) { Wire.onService(); }
+void SERCOM4_2_Handler(void) { Wire.onService(); }
+void SERCOM4_3_Handler(void) { Wire.onService(); }

--- a/examples/ahrs_telemetry/i2c.cpp
+++ b/examples/ahrs_telemetry/i2c.cpp
@@ -326,10 +326,9 @@ void I2C::onService(void)
     }
 }
 
-// SERCOM4 is on pins A4 and A5. SDA: A4, SCL: A5.
-I2C Wire(&sercom4, A4, A5);
+I2C Wire(&I2C_SERCOM, I2C_PIN_SDA, I2C_PIN_SCL);
 
-void SERCOM4_0_Handler(void) { Wire.onService(); }
-void SERCOM4_1_Handler(void) { Wire.onService(); }
-void SERCOM4_2_Handler(void) { Wire.onService(); }
-void SERCOM4_3_Handler(void) { Wire.onService(); }
+void I2C_IRQ_HANDLER_0(void) { Wire.onService(); }
+void I2C_IRQ_HANDLER_1(void) { Wire.onService(); }
+void I2C_IRQ_HANDLER_2(void) { Wire.onService(); }
+void I2C_IRQ_HANDLER_3(void) { Wire.onService(); }

--- a/examples/ahrs_telemetry/i2c.h
+++ b/examples/ahrs_telemetry/i2c.h
@@ -1,0 +1,78 @@
+/**
+ * @file i2c.h
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief A hardware I2C driver for SAMD51, based on the TWI/I2C library for Arduino Zero.
+ * @version 0.2.0
+ * @date 2023-02-08
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+#pragma once
+
+#include "Stream.h"
+#include "variant.h"
+
+#include "SERCOM.h"
+#include "RingBuffer.h"
+
+#define I2C_BAUDRATE_STANDARD 100000
+#define I2C_BAUDRATE_FAST 400000
+#define I2C_BAUDRATE_FASTPLUS 1000000
+#define I2C_BAUDRATE_HIGH 3400000
+
+class I2C: public Stream
+{
+public:
+    I2C(SERCOM* s, uint8_t pinSDA, uint8_t pinSCL);
+    void begin(uint32_t baudrate = I2C_BAUDRATE_STANDARD);
+    void begin(uint8_t, bool enableGeneralCall = false);
+    void end();
+    void setClock(uint32_t);
+
+    void beginTransmission(uint8_t);
+    uint8_t endTransmission(bool stopBit);
+    uint8_t endTransmission(void);
+
+    uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit);
+    uint8_t requestFrom(uint8_t address, size_t quantity);
+
+    size_t write(uint8_t data);
+    size_t write(const uint8_t* data, size_t quantity);
+
+    virtual int available(void);
+    virtual int read(void);
+    virtual int peek(void);
+    virtual void flush(void);
+    void onReceive(void(*)(int));
+    void onRequest(void(*)(void));
+
+    inline size_t write(unsigned long n) { return write((uint8_t)n); }
+    inline size_t write(long n) { return write((uint8_t)n); }
+    inline size_t write(unsigned int n) { return write((uint8_t)n); }
+    inline size_t write(int n) { return write((uint8_t)n); }
+    using Print::write;
+
+    void onService(void);
+
+private:
+    SERCOM* sercom;
+    uint8_t _uc_pinSDA;
+    uint8_t _uc_pinSCL;
+
+    bool transmissionBegun;
+
+    // RX Buffer
+    RingBufferN<256> rxBuffer;
+
+    //TX buffer
+    RingBufferN<256> txBuffer;
+    uint8_t txAddress;
+
+    // Callback user functions
+    void (*onRequestCallback)(void);
+    void (*onReceiveCallback)(int);
+};
+
+extern I2C Wire;

--- a/examples/ahrs_telemetry/i2c.h
+++ b/examples/ahrs_telemetry/i2c.h
@@ -21,6 +21,14 @@
 #define I2C_BAUDRATE_FASTPLUS 1000000
 #define I2C_BAUDRATE_HIGH 3400000
 
+#define I2C_SERCOM sercom4
+#define I2C_PIN_SDA A4
+#define I2C_PIN_SCL A5
+#define I2C_IRQ_HANDLER_0 SERCOM4_0_Handler
+#define I2C_IRQ_HANDLER_1 SERCOM4_1_Handler
+#define I2C_IRQ_HANDLER_2 SERCOM4_2_Handler
+#define I2C_IRQ_HANDLER_3 SERCOM4_3_Handler
+
 class I2C: public Stream
 {
 public:

--- a/examples/ahrs_telemetry/i2c.h
+++ b/examples/ahrs_telemetry/i2c.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "Stream.h"
-#include "variant.h"
 
 #include "SERCOM.h"
 #include "RingBuffer.h"

--- a/examples/ahrs_telemetry/imu.cpp
+++ b/examples/ahrs_telemetry/imu.cpp
@@ -79,8 +79,8 @@ bool IMU::begin()
     // Set the IMU to use external crystal.
     _imu->setExtCrystalUse(true);
 
-    // Set the IMU to use NDOF mode.
-    // _imu->setMode(OPERATION_MODE_NDOF);
+    // Set the IMU to only use the gyroscope.
+    _imu->setMode(OPERATION_MODE_GYRONLY);
 
     return true;
 }

--- a/examples/ahrs_telemetry/imu.cpp
+++ b/examples/ahrs_telemetry/imu.cpp
@@ -1,0 +1,119 @@
+/**
+ * @file imu.h
+ * @author Cassandra "ZZ Cat" Robinson
+ * @brief A generic IMU sensor class.
+ * @version 0.2.0
+ * @date 2023-02-09
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+#include "Arduino.h"
+#include "imu.h"
+#include "unified_sensor.h"
+#include "imu_imumaths.h"
+
+IMU::IMU(I2C* i2cBus)
+{
+    _imu = nullptr;
+    _i2c = i2cBus;
+}
+
+IMU::~IMU()
+{
+    if (_imu != nullptr)
+    {
+        delete _imu;
+    }
+    _i2c = nullptr;
+}
+
+bool IMU::begin()
+{
+    uint8_t address = 0x00;
+    uint8_t id = 0x00;
+
+    // Scan the I2C bus for the IMU.
+    _i2c->begin();
+    for (uint8_t i = 0; i < 128; i++)
+    {
+        _i2c->beginTransmission(i);
+        if (_i2c->endTransmission() == 0)
+        {
+            // Got a response, check if it's the right one.
+            if (i == 0x28 || i == 0x29)
+            {
+                // Check the ID register.
+                _i2c->beginTransmission(i);
+                _i2c->write(0x00);
+                _i2c->endTransmission();
+                _i2c->requestFrom(i, 1);
+                id = _i2c->read();
+
+                // IMU found, it's a BNO055.
+                if (id == 0xA0)
+                {
+                    address = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    // If I didn't find the IMU, return false.
+    if (address == 0x00)
+    {
+        return false;
+    }
+
+    // Create the BNO055 object.
+    _imu = new IMU_BNO055(id, address, _i2c);
+
+    // Initialize the IMU.
+    if (_imu->begin() != true)
+    {
+        return false;
+    }
+
+    // Set the IMU to use external crystal.
+    _imu->setExtCrystalUse(true);
+
+    // Set the IMU to use NDOF mode.
+    // _imu->setMode(OPERATION_MODE_NDOF);
+
+    return true;
+}
+
+bool IMU::update()
+{
+
+    static uint32_t sampleTimestamp = millis();
+
+    // Check if it's time to sample the IMU.
+    if (millis() - sampleTimestamp >= 10)
+    {
+        // Get the IMU data.
+        _imu->getEvent(&_event, IMU_BNO055::VECTOR_GYROSCOPE);
+
+        // Update the sample timestamp.
+        sampleTimestamp = _event.timestamp;
+
+        // Convert the IMU data to floats.
+        _data.gyro.x = _event.gyro.x;
+        _data.gyro.y = _event.gyro.y;
+        _data.gyro.z = _event.gyro.z;
+
+        return true;
+    }
+
+    return false;
+}
+
+bool IMU::getData(IMU_Data_t* data)
+{
+    // Copy the data to the output.
+    *data = _data;
+
+    return true;
+}

--- a/examples/ahrs_telemetry/imu.h
+++ b/examples/ahrs_telemetry/imu.h
@@ -1,0 +1,72 @@
+/**
+ * @file imu.h
+ * @author Cassandra "ZZ Cat" Robinson
+ * @brief A generic IMU sensor class.
+ * @version 0.2.0
+ * @date 2023-02-09
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+#pragma once
+
+#include "i2c.h"
+#include "imu_bno055.h"
+
+typedef struct fvec_s
+{
+    float x;
+    float y;
+    float z;
+} fvec_t;
+
+typedef struct fquat_s
+{
+    float w;
+    float x;
+    float y;
+    float z;
+} fquat_t;
+
+typedef struct feuler_s
+{
+    float x;
+    float y;
+    float z;
+} feuler_t;
+
+typedef struct IMU_Data_s
+{
+    fvec_t accel;
+    fvec_t gyro;
+    fvec_t mag;
+    fquat_t quat;
+    feuler_t euler;
+} IMU_Data_t;
+
+typedef struct IMU_Calibration_s
+{
+    uint8_t accel;
+    uint8_t gyro;
+    uint8_t mag;
+    uint8_t sys;
+} IMU_Calibration_t;
+
+class IMU
+{
+public:
+    IMU(I2C*);
+    ~IMU();
+
+    bool begin();
+    bool update();
+
+    bool getData(IMU_Data_t*);
+
+protected:
+    I2C* _i2c;
+    IMU_BNO055* _imu;
+    IMU_Data_t _data;
+    sensors_event_t _event;
+};

--- a/examples/ahrs_telemetry/imu_bno055.cpp
+++ b/examples/ahrs_telemetry/imu_bno055.cpp
@@ -26,14 +26,14 @@
   *          Wire object
   */
 IMU_BNO055::IMU_BNO055(int32_t sensorID, uint8_t address,
-  I2C* theWire) {
-  // BNO055 clock stretches for 500us or more!
+    I2C* theWire) {
+    // BNO055 clock stretches for 500us or more!
 #ifdef ESP8266
-  theWire->setClockStretchLimit(1000); // Allow for 1000us of clock stretching
+    theWire->setClockStretchLimit(1000); // Allow for 1000us of clock stretching
 #endif
 
-  _sensorID = sensorID;
-  i2c_dev = new BusIO_I2C_Target(address, theWire);
+    _sensorID = sensorID;
+    i2c_dev = new BusIO_I2C_Target(address, theWire);
 }
 
 /*!
@@ -56,102 +56,82 @@ IMU_BNO055::IMU_BNO055(int32_t sensorID, uint8_t address,
  *  @return true if process is successful
  */
 bool IMU_BNO055::begin(adafruit_bno055_opmode_t mode) {
-  Serial.println("BNO055: begin()");
-
-  // Start without a detection
-  i2c_dev->begin(false);
+    // Start without a detection
+    i2c_dev->begin(false);
 
 #if defined(TARGET_RP2040)
-  // philhower core seems to work with this speed?
-  i2c_dev->setSpeed(50000);
+    // philhower core seems to work with this speed?
+    i2c_dev->setSpeed(50000);
 #endif
 
-  Serial.println("BNO055: begin() - i2c_dev->begin()");
-  // can take 850 ms to boot!
-  int timeout = 850; // in ms
-  while (timeout > 0) {
-    if (i2c_dev->begin()) {
-      Serial.println("BNO055: begin() - i2c_dev->begin() - success");
-      break;
+    // can take 850 ms to boot!
+    int timeout = 850; // in ms
+    while (timeout > 0) {
+        if (i2c_dev->begin()) {
+            break;
+        }
+        // wasnt detected... we'll retry!
+        delay(10);
+        timeout -= 10;
     }
-    // wasnt detected... we'll retry!
-    delay(10);
-    timeout -= 10;
-  }
-  if (timeout <= 0)
-  {
-    Serial.println("BNO055: begin() - i2c_dev->begin() - timeout");
-    return false;
-  }
+    if (timeout <= 0)
+    {
+        return false;
+    }
 
-  /* Make sure we have the right device */
-  Serial.println("BNO055: begin() - check chip ID");
-  uint8_t id = read8(BNO055_CHIP_ID_ADDR);
-  if (id != BNO055_ID) {
-    Serial.println("BNO055: begin() - check chip ID - start boot");
-    delay(1000); // hold on for boot
-    id = read8(BNO055_CHIP_ID_ADDR);
-    Serial.println("BNO055: begin() - check chip ID - end boot");
+    /* Make sure we have the right device */
+    uint8_t id = read8(BNO055_CHIP_ID_ADDR);
     if (id != BNO055_ID) {
-      Serial.println("BNO055: begin() - check chip ID - failed");
-      return false; // still not? ok bail
+        delay(1000); // hold on for boot
+        id = read8(BNO055_CHIP_ID_ADDR);
+        if (id != BNO055_ID) {
+            return false; // still not? ok bail
+        }
     }
-    Serial.println("BNO055: begin() - check chip ID - success");
-  }
 
-  /* Switch to config mode (just in case since this is the default) */
-  Serial.println("BNO055: begin() - set mode - config");
-  setMode(OPERATION_MODE_CONFIG);
-  Serial.println("BNO055: begin() - set mode - success");
+    /* Switch to config mode (just in case since this is the default) */
+    setMode(OPERATION_MODE_CONFIG);
 
-  /* Reset */
-  Serial.println("BNO055: begin() - reset");
-  write8(BNO055_SYS_TRIGGER_ADDR, 0x20);
-  /* Delay incrased to 30ms due to power issues https://tinyurl.com/y375z699 */
-  delay(30);
-  Serial.println("BNO055: begin() - reset - waiting for boot");
-  while (read8(BNO055_CHIP_ID_ADDR) != BNO055_ID) {
+    /* Reset */
+    write8(BNO055_SYS_TRIGGER_ADDR, 0x20);
+    /* Delay incrased to 30ms due to power issues https://tinyurl.com/y375z699 */
+    delay(30);
+    while (read8(BNO055_CHIP_ID_ADDR) != BNO055_ID) {
+        delay(10);
+    }
+    delay(50);
+
+    /* Set to normal power mode */
+    write8(BNO055_PWR_MODE_ADDR, POWER_MODE_NORMAL);
     delay(10);
-  }
-  delay(50);
-  Serial.println("BNO055: begin() - reset - success");
 
-  /* Set to normal power mode */
-  Serial.println("BNO055: begin() - set power mode");
-  write8(BNO055_PWR_MODE_ADDR, POWER_MODE_NORMAL);
-  delay(10);
-  Serial.println("BNO055: begin() - set power mode - success");
+    write8(BNO055_PAGE_ID_ADDR, 0);
 
-  write8(BNO055_PAGE_ID_ADDR, 0);
+    /* Set the output units */
+    /*
+    uint8_t unitsel = (0 << 7) | // Orientation = Android
+                      (0 << 4) | // Temperature = Celsius
+                      (0 << 2) | // Euler = Degrees
+                      (1 << 1) | // Gyro = Rads
+                      (0 << 0);  // Accelerometer = m/s^2
+    write8(BNO055_UNIT_SEL_ADDR, unitsel);
+    */
 
-  /* Set the output units */
-  /*
-  uint8_t unitsel = (0 << 7) | // Orientation = Android
-                    (0 << 4) | // Temperature = Celsius
-                    (0 << 2) | // Euler = Degrees
-                    (1 << 1) | // Gyro = Rads
-                    (0 << 0);  // Accelerometer = m/s^2
-  write8(BNO055_UNIT_SEL_ADDR, unitsel);
-  */
+    /* Configure axis mapping (see section 3.4) */
+    /*
+    write8(BNO055_AXIS_MAP_CONFIG_ADDR, REMAP_CONFIG_P2); // P0-P7, Default is P1
+    delay(10);
+    write8(BNO055_AXIS_MAP_SIGN_ADDR, REMAP_SIGN_P2); // P0-P7, Default is P1
+    delay(10);
+    */
 
-  /* Configure axis mapping (see section 3.4) */
-  /*
-  write8(BNO055_AXIS_MAP_CONFIG_ADDR, REMAP_CONFIG_P2); // P0-P7, Default is P1
-  delay(10);
-  write8(BNO055_AXIS_MAP_SIGN_ADDR, REMAP_SIGN_P2); // P0-P7, Default is P1
-  delay(10);
-  */
+    write8(BNO055_SYS_TRIGGER_ADDR, 0x0);
+    delay(10);
+    /* Set the requested operating mode (see section 3.3) */
+    setMode(mode);
+    delay(20);
 
-  write8(BNO055_SYS_TRIGGER_ADDR, 0x0);
-  delay(10);
-  /* Set the requested operating mode (see section 3.3) */
-  Serial.println("BNO055: begin() - set mode - requested");
-  setMode(mode);
-  delay(20);
-
-  Serial.println("BNO055: begin() - success");
-
-  return true;
+    return true;
 }
 
 /*!
@@ -173,9 +153,9 @@ bool IMU_BNO055::begin(adafruit_bno055_opmode_t mode) {
  *            OPERATION_MODE_NDOF]
  */
 void IMU_BNO055::setMode(adafruit_bno055_opmode_t mode) {
-  _mode = mode;
-  write8(BNO055_OPR_MODE_ADDR, _mode);
-  delay(30);
+    _mode = mode;
+    write8(BNO055_OPR_MODE_ADDR, _mode);
+    delay(30);
 }
 
 /*!
@@ -184,7 +164,7 @@ void IMU_BNO055::setMode(adafruit_bno055_opmode_t mode) {
  *           for example: a return of 12 (0X0C) => NDOF
  */
 adafruit_bno055_opmode_t IMU_BNO055::getMode() {
-  return (adafruit_bno055_opmode_t)read8(BNO055_OPR_MODE_ADDR);
+    return (adafruit_bno055_opmode_t)read8(BNO055_OPR_MODE_ADDR);
 }
 
 /*!
@@ -201,16 +181,16 @@ adafruit_bno055_opmode_t IMU_BNO055::getMode() {
  *           REMAP_CONFIG_P7]
  */
 void IMU_BNO055::setAxisRemap(
-  adafruit_bno055_axis_remap_config_t remapcode) {
-  adafruit_bno055_opmode_t modeback = _mode;
+    adafruit_bno055_axis_remap_config_t remapcode) {
+    adafruit_bno055_opmode_t modeback = _mode;
 
-  setMode(OPERATION_MODE_CONFIG);
-  delay(25);
-  write8(BNO055_AXIS_MAP_CONFIG_ADDR, remapcode);
-  delay(10);
-  /* Set the requested operating mode (see section 3.3) */
-  setMode(modeback);
-  delay(20);
+    setMode(OPERATION_MODE_CONFIG);
+    delay(25);
+    write8(BNO055_AXIS_MAP_CONFIG_ADDR, remapcode);
+    delay(10);
+    /* Set the requested operating mode (see section 3.3) */
+    setMode(modeback);
+    delay(20);
 }
 
 /*!
@@ -227,15 +207,15 @@ void IMU_BNO055::setAxisRemap(
  *           REMAP_SIGN_P7]
  */
 void IMU_BNO055::setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign) {
-  adafruit_bno055_opmode_t modeback = _mode;
+    adafruit_bno055_opmode_t modeback = _mode;
 
-  setMode(OPERATION_MODE_CONFIG);
-  delay(25);
-  write8(BNO055_AXIS_MAP_SIGN_ADDR, remapsign);
-  delay(10);
-  /* Set the requested operating mode (see section 3.3) */
-  setMode(modeback);
-  delay(20);
+    setMode(OPERATION_MODE_CONFIG);
+    delay(25);
+    write8(BNO055_AXIS_MAP_SIGN_ADDR, remapsign);
+    delay(10);
+    /* Set the requested operating mode (see section 3.3) */
+    setMode(modeback);
+    delay(20);
 }
 
 /*!
@@ -244,22 +224,22 @@ void IMU_BNO055::setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign) {
  *          use external crystal boolean
  */
 void IMU_BNO055::setExtCrystalUse(boolean usextal) {
-  adafruit_bno055_opmode_t modeback = _mode;
+    adafruit_bno055_opmode_t modeback = _mode;
 
-  /* Switch to config mode (just in case since this is the default) */
-  setMode(OPERATION_MODE_CONFIG);
-  delay(25);
-  write8(BNO055_PAGE_ID_ADDR, 0);
-  if (usextal) {
-    write8(BNO055_SYS_TRIGGER_ADDR, 0x80);
-  }
-  else {
-    write8(BNO055_SYS_TRIGGER_ADDR, 0x00);
-  }
-  delay(10);
-  /* Set the requested operating mode (see section 3.3) */
-  setMode(modeback);
-  delay(20);
+    /* Switch to config mode (just in case since this is the default) */
+    setMode(OPERATION_MODE_CONFIG);
+    delay(25);
+    write8(BNO055_PAGE_ID_ADDR, 0);
+    if (usextal) {
+        write8(BNO055_SYS_TRIGGER_ADDR, 0x80);
+    }
+    else {
+        write8(BNO055_SYS_TRIGGER_ADDR, 0x00);
+    }
+    delay(10);
+    /* Set the requested operating mode (see section 3.3) */
+    setMode(modeback);
+    delay(20);
 }
 
 /*!
@@ -272,55 +252,55 @@ void IMU_BNO055::setExtCrystalUse(boolean usextal) {
  *           system error info
  */
 void IMU_BNO055::getSystemStatus(uint8_t* system_status,
-  uint8_t* self_test_result,
-  uint8_t* system_error) {
-  write8(BNO055_PAGE_ID_ADDR, 0);
+    uint8_t* self_test_result,
+    uint8_t* system_error) {
+    write8(BNO055_PAGE_ID_ADDR, 0);
 
-  /* System Status (see section 4.3.58)
-     0 = Idle
-     1 = System Error
-     2 = Initializing Peripherals
-     3 = System Iniitalization
-     4 = Executing Self-Test
-     5 = Sensor fusio algorithm running
-     6 = System running without fusion algorithms
-   */
+    /* System Status (see section 4.3.58)
+       0 = Idle
+       1 = System Error
+       2 = Initializing Peripherals
+       3 = System Iniitalization
+       4 = Executing Self-Test
+       5 = Sensor fusio algorithm running
+       6 = System running without fusion algorithms
+     */
 
-  if (system_status != 0)
-    *system_status = read8(BNO055_SYS_STAT_ADDR);
+    if (system_status != 0)
+        *system_status = read8(BNO055_SYS_STAT_ADDR);
 
-  /* Self Test Results
-     1 = test passed, 0 = test failed
+    /* Self Test Results
+       1 = test passed, 0 = test failed
 
-     Bit 0 = Accelerometer self test
-     Bit 1 = Magnetometer self test
-     Bit 2 = Gyroscope self test
-     Bit 3 = MCU self test
+       Bit 0 = Accelerometer self test
+       Bit 1 = Magnetometer self test
+       Bit 2 = Gyroscope self test
+       Bit 3 = MCU self test
 
-     0x0F = all good!
-   */
+       0x0F = all good!
+     */
 
-  if (self_test_result != 0)
-    *self_test_result = read8(BNO055_SELFTEST_RESULT_ADDR);
+    if (self_test_result != 0)
+        *self_test_result = read8(BNO055_SELFTEST_RESULT_ADDR);
 
-  /* System Error (see section 4.3.59)
-     0 = No error
-     1 = Peripheral initialization error
-     2 = System initialization error
-     3 = Self test result failed
-     4 = Register map value out of range
-     5 = Register map address out of range
-     6 = Register map write error
-     7 = BNO low power mode not available for selected operat ion mode
-     8 = Accelerometer power mode not available
-     9 = Fusion algorithm configuration error
-     A = Sensor configuration error
-   */
+    /* System Error (see section 4.3.59)
+       0 = No error
+       1 = Peripheral initialization error
+       2 = System initialization error
+       3 = Self test result failed
+       4 = Register map value out of range
+       5 = Register map address out of range
+       6 = Register map write error
+       7 = BNO low power mode not available for selected operat ion mode
+       8 = Accelerometer power mode not available
+       9 = Fusion algorithm configuration error
+       A = Sensor configuration error
+     */
 
-  if (system_error != 0)
-    *system_error = read8(BNO055_SYS_ERR_ADDR);
+    if (system_error != 0)
+        *system_error = read8(BNO055_SYS_ERR_ADDR);
 
-  delay(200);
+    delay(200);
 }
 
 /*!
@@ -329,25 +309,25 @@ void IMU_BNO055::getSystemStatus(uint8_t* system_status,
  *          revision info
  */
 void IMU_BNO055::getRevInfo(adafruit_bno055_rev_info_t* info) {
-  uint8_t a, b;
+    uint8_t a, b;
 
-  memset(info, 0, sizeof(adafruit_bno055_rev_info_t));
+    memset(info, 0, sizeof(adafruit_bno055_rev_info_t));
 
-  /* Check the accelerometer revision */
-  info->accel_rev = read8(BNO055_ACCEL_REV_ID_ADDR);
+    /* Check the accelerometer revision */
+    info->accel_rev = read8(BNO055_ACCEL_REV_ID_ADDR);
 
-  /* Check the magnetometer revision */
-  info->mag_rev = read8(BNO055_MAG_REV_ID_ADDR);
+    /* Check the magnetometer revision */
+    info->mag_rev = read8(BNO055_MAG_REV_ID_ADDR);
 
-  /* Check the gyroscope revision */
-  info->gyro_rev = read8(BNO055_GYRO_REV_ID_ADDR);
+    /* Check the gyroscope revision */
+    info->gyro_rev = read8(BNO055_GYRO_REV_ID_ADDR);
 
-  /* Check the SW revision */
-  info->bl_rev = read8(BNO055_BL_REV_ID_ADDR);
+    /* Check the SW revision */
+    info->bl_rev = read8(BNO055_BL_REV_ID_ADDR);
 
-  a = read8(BNO055_SW_REV_ID_LSB_ADDR);
-  b = read8(BNO055_SW_REV_ID_MSB_ADDR);
-  info->sw_rev = (((uint16_t)b) << 8) | ((uint16_t)a);
+    a = read8(BNO055_SW_REV_ID_LSB_ADDR);
+    b = read8(BNO055_SW_REV_ID_MSB_ADDR);
+    info->sw_rev = (((uint16_t)b) << 8) | ((uint16_t)a);
 }
 
 /*!
@@ -366,20 +346,20 @@ void IMU_BNO055::getRevInfo(adafruit_bno055_rev_info_t* info) {
  *          Current calibration status of Magnetometer, read-only
  */
 void IMU_BNO055::getCalibration(uint8_t* sys, uint8_t* gyro,
-  uint8_t* accel, uint8_t* mag) {
-  uint8_t calData = read8(BNO055_CALIB_STAT_ADDR);
-  if (sys != NULL) {
-    *sys = (calData >> 6) & 0x03;
-  }
-  if (gyro != NULL) {
-    *gyro = (calData >> 4) & 0x03;
-  }
-  if (accel != NULL) {
-    *accel = (calData >> 2) & 0x03;
-  }
-  if (mag != NULL) {
-    *mag = calData & 0x03;
-  }
+    uint8_t* accel, uint8_t* mag) {
+    uint8_t calData = read8(BNO055_CALIB_STAT_ADDR);
+    if (sys != NULL) {
+        *sys = (calData >> 6) & 0x03;
+    }
+    if (gyro != NULL) {
+        *gyro = (calData >> 4) & 0x03;
+    }
+    if (accel != NULL) {
+        *accel = (calData >> 2) & 0x03;
+    }
+    if (mag != NULL) {
+        *mag = calData & 0x03;
+    }
 }
 
 /*!
@@ -387,8 +367,8 @@ void IMU_BNO055::getCalibration(uint8_t* sys, uint8_t* gyro,
  *  @return temperature in degrees celsius
  */
 int8_t IMU_BNO055::getTemp() {
-  int8_t temp = (int8_t)(read8(BNO055_TEMP_ADDR));
-  return temp;
+    int8_t temp = (int8_t)(read8(BNO055_TEMP_ADDR));
+    return temp;
 }
 
 /*!
@@ -404,64 +384,64 @@ int8_t IMU_BNO055::getTemp() {
  *  @return  vector from specified source
  */
 imu::Vector<3> IMU_BNO055::getVector(adafruit_vector_type_t vector_type) {
-  imu::Vector<3> xyz;
-  uint8_t buffer[6];
-  memset(buffer, 0, 6);
+    imu::Vector<3> xyz;
+    uint8_t buffer[6];
+    memset(buffer, 0, 6);
 
-  int16_t x, y, z;
-  x = y = z = 0;
+    int16_t x, y, z;
+    x = y = z = 0;
 
-  /* Read vector data (6 bytes) */
-  readLen((adafruit_bno055_reg_t)vector_type, buffer, 6);
+    /* Read vector data (6 bytes) */
+    readLen((adafruit_bno055_reg_t)vector_type, buffer, 6);
 
-  x = ((int16_t)buffer[0]) | (((int16_t)buffer[1]) << 8);
-  y = ((int16_t)buffer[2]) | (((int16_t)buffer[3]) << 8);
-  z = ((int16_t)buffer[4]) | (((int16_t)buffer[5]) << 8);
+    x = ((int16_t)buffer[0]) | (((int16_t)buffer[1]) << 8);
+    y = ((int16_t)buffer[2]) | (((int16_t)buffer[3]) << 8);
+    z = ((int16_t)buffer[4]) | (((int16_t)buffer[5]) << 8);
 
-  /*!
-   * Convert the value to an appropriate range (section 3.6.4)
-   * and assign the value to the Vector type
-   */
-  switch (vector_type) {
-  case VECTOR_MAGNETOMETER:
-    /* 1uT = 16 LSB */
-    xyz[0] = ((double)x) / 16.0;
-    xyz[1] = ((double)y) / 16.0;
-    xyz[2] = ((double)z) / 16.0;
-    break;
-  case VECTOR_GYROSCOPE:
-    /* 1dps = 16 LSB */
-    xyz[0] = ((double)x) / 16.0;
-    xyz[1] = ((double)y) / 16.0;
-    xyz[2] = ((double)z) / 16.0;
-    break;
-  case VECTOR_EULER:
-    /* 1 degree = 16 LSB */
-    xyz[0] = ((double)x) / 16.0;
-    xyz[1] = ((double)y) / 16.0;
-    xyz[2] = ((double)z) / 16.0;
-    break;
-  case VECTOR_ACCELEROMETER:
-    /* 1m/s^2 = 100 LSB */
-    xyz[0] = ((double)x) / 100.0;
-    xyz[1] = ((double)y) / 100.0;
-    xyz[2] = ((double)z) / 100.0;
-    break;
-  case VECTOR_LINEARACCEL:
-    /* 1m/s^2 = 100 LSB */
-    xyz[0] = ((double)x) / 100.0;
-    xyz[1] = ((double)y) / 100.0;
-    xyz[2] = ((double)z) / 100.0;
-    break;
-  case VECTOR_GRAVITY:
-    /* 1m/s^2 = 100 LSB */
-    xyz[0] = ((double)x) / 100.0;
-    xyz[1] = ((double)y) / 100.0;
-    xyz[2] = ((double)z) / 100.0;
-    break;
-  }
+    /*!
+     * Convert the value to an appropriate range (section 3.6.4)
+     * and assign the value to the Vector type
+     */
+    switch (vector_type) {
+    case VECTOR_MAGNETOMETER:
+        /* 1uT = 16 LSB */
+        xyz[0] = ((double)x) / 16.0;
+        xyz[1] = ((double)y) / 16.0;
+        xyz[2] = ((double)z) / 16.0;
+        break;
+    case VECTOR_GYROSCOPE:
+        /* 1dps = 16 LSB */
+        xyz[0] = ((double)x) / 16.0;
+        xyz[1] = ((double)y) / 16.0;
+        xyz[2] = ((double)z) / 16.0;
+        break;
+    case VECTOR_EULER:
+        /* 1 degree = 16 LSB */
+        xyz[0] = ((double)x) / 16.0;
+        xyz[1] = ((double)y) / 16.0;
+        xyz[2] = ((double)z) / 16.0;
+        break;
+    case VECTOR_ACCELEROMETER:
+        /* 1m/s^2 = 100 LSB */
+        xyz[0] = ((double)x) / 100.0;
+        xyz[1] = ((double)y) / 100.0;
+        xyz[2] = ((double)z) / 100.0;
+        break;
+    case VECTOR_LINEARACCEL:
+        /* 1m/s^2 = 100 LSB */
+        xyz[0] = ((double)x) / 100.0;
+        xyz[1] = ((double)y) / 100.0;
+        xyz[2] = ((double)z) / 100.0;
+        break;
+    case VECTOR_GRAVITY:
+        /* 1m/s^2 = 100 LSB */
+        xyz[0] = ((double)x) / 100.0;
+        xyz[1] = ((double)y) / 100.0;
+        xyz[2] = ((double)z) / 100.0;
+        break;
+    }
 
-  return xyz;
+    return xyz;
 }
 
 /*!
@@ -469,28 +449,28 @@ imu::Vector<3> IMU_BNO055::getVector(adafruit_vector_type_t vector_type) {
  *  @return quaternion reading
  */
 imu::Quaternion IMU_BNO055::getQuat() {
-  uint8_t buffer[8];
-  memset(buffer, 0, 8);
+    uint8_t buffer[8];
+    memset(buffer, 0, 8);
 
-  int16_t x, y, z, w;
-  x = y = z = w = 0;
+    int16_t x, y, z, w;
+    x = y = z = w = 0;
 
-  /* Read quat data (8 bytes) */
-  readLen(BNO055_QUATERNION_DATA_W_LSB_ADDR, buffer, 8);
-  w = (((uint16_t)buffer[1]) << 8) | ((uint16_t)buffer[0]);
-  x = (((uint16_t)buffer[3]) << 8) | ((uint16_t)buffer[2]);
-  y = (((uint16_t)buffer[5]) << 8) | ((uint16_t)buffer[4]);
-  z = (((uint16_t)buffer[7]) << 8) | ((uint16_t)buffer[6]);
+    /* Read quat data (8 bytes) */
+    readLen(BNO055_QUATERNION_DATA_W_LSB_ADDR, buffer, 8);
+    w = (((uint16_t)buffer[1]) << 8) | ((uint16_t)buffer[0]);
+    x = (((uint16_t)buffer[3]) << 8) | ((uint16_t)buffer[2]);
+    y = (((uint16_t)buffer[5]) << 8) | ((uint16_t)buffer[4]);
+    z = (((uint16_t)buffer[7]) << 8) | ((uint16_t)buffer[6]);
 
-  /*!
-   * Assign to Quaternion
-   * See
-   * https://cdn-shop.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf
-   * 3.6.5.5 Orientation (Quaternion)
-   */
-  const double scale = (1.0 / (1 << 14));
-  imu::Quaternion quat(scale * w, scale * x, scale * y, scale * z);
-  return quat;
+    /*!
+     * Assign to Quaternion
+     * See
+     * https://cdn-shop.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf
+     * 3.6.5.5 Orientation (Quaternion)
+     */
+    const double scale = (1.0 / (1 << 14));
+    imu::Quaternion quat(scale * w, scale * x, scale * y, scale * z);
+    return quat;
 }
 
 /*!
@@ -499,19 +479,19 @@ imu::Quaternion IMU_BNO055::getQuat() {
  *          Sensor description
  */
 void IMU_BNO055::getSensor(sensor_t* sensor) {
-  /* Clear the sensor_t object */
-  memset(sensor, 0, sizeof(sensor_t));
+    /* Clear the sensor_t object */
+    memset(sensor, 0, sizeof(sensor_t));
 
-  /* Insert the sensor name in the fixed length char array */
-  strncpy(sensor->name, "BNO055", sizeof(sensor->name) - 1);
-  sensor->name[sizeof(sensor->name) - 1] = 0;
-  sensor->version = 1;
-  sensor->sensor_id = _sensorID;
-  sensor->type = SENSOR_TYPE_ORIENTATION;
-  sensor->min_delay = 0;
-  sensor->max_value = 0.0F;
-  sensor->min_value = 0.0F;
-  sensor->resolution = 0.01F;
+    /* Insert the sensor name in the fixed length char array */
+    strncpy(sensor->name, "BNO055", sizeof(sensor->name) - 1);
+    sensor->name[sizeof(sensor->name) - 1] = 0;
+    sensor->version = 1;
+    sensor->sensor_id = _sensorID;
+    sensor->type = SENSOR_TYPE_ORIENTATION;
+    sensor->min_delay = 0;
+    sensor->max_value = 0.0F;
+    sensor->min_value = 0.0F;
+    sensor->resolution = 0.01F;
 }
 
 /*!
@@ -521,21 +501,21 @@ void IMU_BNO055::getSensor(sensor_t* sensor) {
  *  @return always returns true
  */
 bool IMU_BNO055::getEvent(sensors_event_t* event) {
-  /* Clear the event */
-  memset(event, 0, sizeof(sensors_event_t));
+    /* Clear the event */
+    memset(event, 0, sizeof(sensors_event_t));
 
-  event->version = sizeof(sensors_event_t);
-  event->sensor_id = _sensorID;
-  event->type = SENSOR_TYPE_ORIENTATION;
-  event->timestamp = millis();
+    event->version = sizeof(sensors_event_t);
+    event->sensor_id = _sensorID;
+    event->type = SENSOR_TYPE_ORIENTATION;
+    event->timestamp = millis();
 
-  /* Get a Euler angle sample for orientation */
-  imu::Vector<3> euler = getVector(IMU_BNO055::VECTOR_EULER);
-  event->orientation.x = euler.x();
-  event->orientation.y = euler.y();
-  event->orientation.z = euler.z();
+    /* Get a Euler angle sample for orientation */
+    imu::Vector<3> euler = getVector(IMU_BNO055::VECTOR_EULER);
+    event->orientation.x = euler.x();
+    event->orientation.y = euler.y();
+    event->orientation.z = euler.z();
 
-  return true;
+    return true;
 }
 
 /*!
@@ -547,66 +527,66 @@ bool IMU_BNO055::getEvent(sensors_event_t* event) {
  *  @return always returns true
  */
 bool IMU_BNO055::getEvent(sensors_event_t* event,
-  adafruit_vector_type_t vec_type) {
-  /* Clear the event */
-  memset(event, 0, sizeof(sensors_event_t));
+    adafruit_vector_type_t vec_type) {
+    /* Clear the event */
+    memset(event, 0, sizeof(sensors_event_t));
 
-  event->version = sizeof(sensors_event_t);
-  event->sensor_id = _sensorID;
-  event->timestamp = millis();
+    event->version = sizeof(sensors_event_t);
+    event->sensor_id = _sensorID;
+    event->timestamp = millis();
 
-  // read the data according to vec_type
-  imu::Vector<3> vec;
-  if (vec_type == IMU_BNO055::VECTOR_LINEARACCEL) {
-    event->type = SENSOR_TYPE_LINEAR_ACCELERATION;
-    vec = getVector(IMU_BNO055::VECTOR_LINEARACCEL);
+    // read the data according to vec_type
+    imu::Vector<3> vec;
+    if (vec_type == IMU_BNO055::VECTOR_LINEARACCEL) {
+        event->type = SENSOR_TYPE_LINEAR_ACCELERATION;
+        vec = getVector(IMU_BNO055::VECTOR_LINEARACCEL);
 
-    event->acceleration.x = vec.x();
-    event->acceleration.y = vec.y();
-    event->acceleration.z = vec.z();
-  }
-  else if (vec_type == IMU_BNO055::VECTOR_ACCELEROMETER) {
-    event->type = SENSOR_TYPE_ACCELEROMETER;
-    vec = getVector(IMU_BNO055::VECTOR_ACCELEROMETER);
+        event->acceleration.x = vec.x();
+        event->acceleration.y = vec.y();
+        event->acceleration.z = vec.z();
+    }
+    else if (vec_type == IMU_BNO055::VECTOR_ACCELEROMETER) {
+        event->type = SENSOR_TYPE_ACCELEROMETER;
+        vec = getVector(IMU_BNO055::VECTOR_ACCELEROMETER);
 
-    event->acceleration.x = vec.x();
-    event->acceleration.y = vec.y();
-    event->acceleration.z = vec.z();
-  }
-  else if (vec_type == IMU_BNO055::VECTOR_GRAVITY) {
-    event->type = SENSOR_TYPE_GRAVITY;
-    vec = getVector(IMU_BNO055::VECTOR_GRAVITY);
+        event->acceleration.x = vec.x();
+        event->acceleration.y = vec.y();
+        event->acceleration.z = vec.z();
+    }
+    else if (vec_type == IMU_BNO055::VECTOR_GRAVITY) {
+        event->type = SENSOR_TYPE_GRAVITY;
+        vec = getVector(IMU_BNO055::VECTOR_GRAVITY);
 
-    event->acceleration.x = vec.x();
-    event->acceleration.y = vec.y();
-    event->acceleration.z = vec.z();
-  }
-  else if (vec_type == IMU_BNO055::VECTOR_EULER) {
-    event->type = SENSOR_TYPE_ORIENTATION;
-    vec = getVector(IMU_BNO055::VECTOR_EULER);
+        event->acceleration.x = vec.x();
+        event->acceleration.y = vec.y();
+        event->acceleration.z = vec.z();
+    }
+    else if (vec_type == IMU_BNO055::VECTOR_EULER) {
+        event->type = SENSOR_TYPE_ORIENTATION;
+        vec = getVector(IMU_BNO055::VECTOR_EULER);
 
-    event->orientation.x = vec.x();
-    event->orientation.y = vec.y();
-    event->orientation.z = vec.z();
-  }
-  else if (vec_type == IMU_BNO055::VECTOR_GYROSCOPE) {
-    event->type = SENSOR_TYPE_GYROSCOPE;
-    vec = getVector(IMU_BNO055::VECTOR_GYROSCOPE);
+        event->orientation.x = vec.x();
+        event->orientation.y = vec.y();
+        event->orientation.z = vec.z();
+    }
+    else if (vec_type == IMU_BNO055::VECTOR_GYROSCOPE) {
+        event->type = SENSOR_TYPE_GYROSCOPE;
+        vec = getVector(IMU_BNO055::VECTOR_GYROSCOPE);
 
-    event->gyro.x = vec.x() * SENSORS_DPS_TO_RADS;
-    event->gyro.y = vec.y() * SENSORS_DPS_TO_RADS;
-    event->gyro.z = vec.z() * SENSORS_DPS_TO_RADS;
-  }
-  else if (vec_type == IMU_BNO055::VECTOR_MAGNETOMETER) {
-    event->type = SENSOR_TYPE_MAGNETIC_FIELD;
-    vec = getVector(IMU_BNO055::VECTOR_MAGNETOMETER);
+        event->gyro.x = vec.x() * SENSORS_DPS_TO_RADS;
+        event->gyro.y = vec.y() * SENSORS_DPS_TO_RADS;
+        event->gyro.z = vec.z() * SENSORS_DPS_TO_RADS;
+    }
+    else if (vec_type == IMU_BNO055::VECTOR_MAGNETOMETER) {
+        event->type = SENSOR_TYPE_MAGNETIC_FIELD;
+        vec = getVector(IMU_BNO055::VECTOR_MAGNETOMETER);
 
-    event->magnetic.x = vec.x();
-    event->magnetic.y = vec.y();
-    event->magnetic.z = vec.z();
-  }
+        event->magnetic.x = vec.x();
+        event->magnetic.y = vec.y();
+        event->magnetic.z = vec.z();
+    }
 
-  return true;
+    return true;
 }
 
 /*!
@@ -616,16 +596,16 @@ bool IMU_BNO055::getEvent(sensors_event_t* event,
  *  @return true if read is successful
  */
 bool IMU_BNO055::getSensorOffsets(uint8_t* calibData) {
-  if (isFullyCalibrated()) {
-    adafruit_bno055_opmode_t lastMode = _mode;
-    setMode(OPERATION_MODE_CONFIG);
+    if (isFullyCalibrated()) {
+        adafruit_bno055_opmode_t lastMode = _mode;
+        setMode(OPERATION_MODE_CONFIG);
 
-    readLen(ACCEL_OFFSET_X_LSB_ADDR, calibData, NUM_BNO055_OFFSET_REGISTERS);
+        readLen(ACCEL_OFFSET_X_LSB_ADDR, calibData, NUM_BNO055_OFFSET_REGISTERS);
 
-    setMode(lastMode);
-    return true;
-  }
-  return false;
+        setMode(lastMode);
+        return true;
+    }
+    return false;
 }
 
 /*!
@@ -635,58 +615,58 @@ bool IMU_BNO055::getSensorOffsets(uint8_t* calibData) {
  *  @return true if read is successful
  */
 bool IMU_BNO055::getSensorOffsets(
-  adafruit_bno055_offsets_t& offsets_type) {
-  if (isFullyCalibrated()) {
-    adafruit_bno055_opmode_t lastMode = _mode;
-    setMode(OPERATION_MODE_CONFIG);
-    delay(25);
+    adafruit_bno055_offsets_t& offsets_type) {
+    if (isFullyCalibrated()) {
+        adafruit_bno055_opmode_t lastMode = _mode;
+        setMode(OPERATION_MODE_CONFIG);
+        delay(25);
 
-    /* Accel offset range depends on the G-range:
-       +/-2g  = +/- 2000 mg
-       +/-4g  = +/- 4000 mg
-       +/-8g  = +/- 8000 mg
-       +/-1§g = +/- 16000 mg */
-    offsets_type.accel_offset_x = (read8(ACCEL_OFFSET_X_MSB_ADDR) << 8) |
-      (read8(ACCEL_OFFSET_X_LSB_ADDR));
-    offsets_type.accel_offset_y = (read8(ACCEL_OFFSET_Y_MSB_ADDR) << 8) |
-      (read8(ACCEL_OFFSET_Y_LSB_ADDR));
-    offsets_type.accel_offset_z = (read8(ACCEL_OFFSET_Z_MSB_ADDR) << 8) |
-      (read8(ACCEL_OFFSET_Z_LSB_ADDR));
+        /* Accel offset range depends on the G-range:
+           +/-2g  = +/- 2000 mg
+           +/-4g  = +/- 4000 mg
+           +/-8g  = +/- 8000 mg
+           +/-1§g = +/- 16000 mg */
+        offsets_type.accel_offset_x = (read8(ACCEL_OFFSET_X_MSB_ADDR) << 8) |
+            (read8(ACCEL_OFFSET_X_LSB_ADDR));
+        offsets_type.accel_offset_y = (read8(ACCEL_OFFSET_Y_MSB_ADDR) << 8) |
+            (read8(ACCEL_OFFSET_Y_LSB_ADDR));
+        offsets_type.accel_offset_z = (read8(ACCEL_OFFSET_Z_MSB_ADDR) << 8) |
+            (read8(ACCEL_OFFSET_Z_LSB_ADDR));
 
-    /* Magnetometer offset range = +/- 6400 LSB where 1uT = 16 LSB */
-    offsets_type.mag_offset_x =
-      (read8(MAG_OFFSET_X_MSB_ADDR) << 8) | (read8(MAG_OFFSET_X_LSB_ADDR));
-    offsets_type.mag_offset_y =
-      (read8(MAG_OFFSET_Y_MSB_ADDR) << 8) | (read8(MAG_OFFSET_Y_LSB_ADDR));
-    offsets_type.mag_offset_z =
-      (read8(MAG_OFFSET_Z_MSB_ADDR) << 8) | (read8(MAG_OFFSET_Z_LSB_ADDR));
+        /* Magnetometer offset range = +/- 6400 LSB where 1uT = 16 LSB */
+        offsets_type.mag_offset_x =
+            (read8(MAG_OFFSET_X_MSB_ADDR) << 8) | (read8(MAG_OFFSET_X_LSB_ADDR));
+        offsets_type.mag_offset_y =
+            (read8(MAG_OFFSET_Y_MSB_ADDR) << 8) | (read8(MAG_OFFSET_Y_LSB_ADDR));
+        offsets_type.mag_offset_z =
+            (read8(MAG_OFFSET_Z_MSB_ADDR) << 8) | (read8(MAG_OFFSET_Z_LSB_ADDR));
 
-    /* Gyro offset range depends on the DPS range:
-      2000 dps = +/- 32000 LSB
-      1000 dps = +/- 16000 LSB
-       500 dps = +/- 8000 LSB
-       250 dps = +/- 4000 LSB
-       125 dps = +/- 2000 LSB
-       ... where 1 DPS = 16 LSB */
-    offsets_type.gyro_offset_x =
-      (read8(GYRO_OFFSET_X_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_X_LSB_ADDR));
-    offsets_type.gyro_offset_y =
-      (read8(GYRO_OFFSET_Y_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_Y_LSB_ADDR));
-    offsets_type.gyro_offset_z =
-      (read8(GYRO_OFFSET_Z_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_Z_LSB_ADDR));
+        /* Gyro offset range depends on the DPS range:
+          2000 dps = +/- 32000 LSB
+          1000 dps = +/- 16000 LSB
+           500 dps = +/- 8000 LSB
+           250 dps = +/- 4000 LSB
+           125 dps = +/- 2000 LSB
+           ... where 1 DPS = 16 LSB */
+        offsets_type.gyro_offset_x =
+            (read8(GYRO_OFFSET_X_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_X_LSB_ADDR));
+        offsets_type.gyro_offset_y =
+            (read8(GYRO_OFFSET_Y_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_Y_LSB_ADDR));
+        offsets_type.gyro_offset_z =
+            (read8(GYRO_OFFSET_Z_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_Z_LSB_ADDR));
 
-    /* Accelerometer radius = +/- 1000 LSB */
-    offsets_type.accel_radius =
-      (read8(ACCEL_RADIUS_MSB_ADDR) << 8) | (read8(ACCEL_RADIUS_LSB_ADDR));
+        /* Accelerometer radius = +/- 1000 LSB */
+        offsets_type.accel_radius =
+            (read8(ACCEL_RADIUS_MSB_ADDR) << 8) | (read8(ACCEL_RADIUS_LSB_ADDR));
 
-    /* Magnetometer radius = +/- 960 LSB */
-    offsets_type.mag_radius =
-      (read8(MAG_RADIUS_MSB_ADDR) << 8) | (read8(MAG_RADIUS_LSB_ADDR));
+        /* Magnetometer radius = +/- 960 LSB */
+        offsets_type.mag_radius =
+            (read8(MAG_RADIUS_MSB_ADDR) << 8) | (read8(MAG_RADIUS_LSB_ADDR));
 
-    setMode(lastMode);
-    return true;
-  }
-  return false;
+        setMode(lastMode);
+        return true;
+    }
+    return false;
 }
 
 /*!
@@ -695,44 +675,44 @@ bool IMU_BNO055::getSensorOffsets(
  *          calibration data
  */
 void IMU_BNO055::setSensorOffsets(const uint8_t* calibData) {
-  adafruit_bno055_opmode_t lastMode = _mode;
-  setMode(OPERATION_MODE_CONFIG);
-  delay(25);
+    adafruit_bno055_opmode_t lastMode = _mode;
+    setMode(OPERATION_MODE_CONFIG);
+    delay(25);
 
-  /* Note: Configuration will take place only when user writes to the last
-     byte of each config data pair (ex. ACCEL_OFFSET_Z_MSB_ADDR, etc.).
-     Therefore the last byte must be written whenever the user wants to
-     changes the configuration. */
+    /* Note: Configuration will take place only when user writes to the last
+       byte of each config data pair (ex. ACCEL_OFFSET_Z_MSB_ADDR, etc.).
+       Therefore the last byte must be written whenever the user wants to
+       changes the configuration. */
 
-     /* A writeLen() would make this much cleaner */
-  write8(ACCEL_OFFSET_X_LSB_ADDR, calibData[0]);
-  write8(ACCEL_OFFSET_X_MSB_ADDR, calibData[1]);
-  write8(ACCEL_OFFSET_Y_LSB_ADDR, calibData[2]);
-  write8(ACCEL_OFFSET_Y_MSB_ADDR, calibData[3]);
-  write8(ACCEL_OFFSET_Z_LSB_ADDR, calibData[4]);
-  write8(ACCEL_OFFSET_Z_MSB_ADDR, calibData[5]);
+       /* A writeLen() would make this much cleaner */
+    write8(ACCEL_OFFSET_X_LSB_ADDR, calibData[0]);
+    write8(ACCEL_OFFSET_X_MSB_ADDR, calibData[1]);
+    write8(ACCEL_OFFSET_Y_LSB_ADDR, calibData[2]);
+    write8(ACCEL_OFFSET_Y_MSB_ADDR, calibData[3]);
+    write8(ACCEL_OFFSET_Z_LSB_ADDR, calibData[4]);
+    write8(ACCEL_OFFSET_Z_MSB_ADDR, calibData[5]);
 
-  write8(MAG_OFFSET_X_LSB_ADDR, calibData[6]);
-  write8(MAG_OFFSET_X_MSB_ADDR, calibData[7]);
-  write8(MAG_OFFSET_Y_LSB_ADDR, calibData[8]);
-  write8(MAG_OFFSET_Y_MSB_ADDR, calibData[9]);
-  write8(MAG_OFFSET_Z_LSB_ADDR, calibData[10]);
-  write8(MAG_OFFSET_Z_MSB_ADDR, calibData[11]);
+    write8(MAG_OFFSET_X_LSB_ADDR, calibData[6]);
+    write8(MAG_OFFSET_X_MSB_ADDR, calibData[7]);
+    write8(MAG_OFFSET_Y_LSB_ADDR, calibData[8]);
+    write8(MAG_OFFSET_Y_MSB_ADDR, calibData[9]);
+    write8(MAG_OFFSET_Z_LSB_ADDR, calibData[10]);
+    write8(MAG_OFFSET_Z_MSB_ADDR, calibData[11]);
 
-  write8(GYRO_OFFSET_X_LSB_ADDR, calibData[12]);
-  write8(GYRO_OFFSET_X_MSB_ADDR, calibData[13]);
-  write8(GYRO_OFFSET_Y_LSB_ADDR, calibData[14]);
-  write8(GYRO_OFFSET_Y_MSB_ADDR, calibData[15]);
-  write8(GYRO_OFFSET_Z_LSB_ADDR, calibData[16]);
-  write8(GYRO_OFFSET_Z_MSB_ADDR, calibData[17]);
+    write8(GYRO_OFFSET_X_LSB_ADDR, calibData[12]);
+    write8(GYRO_OFFSET_X_MSB_ADDR, calibData[13]);
+    write8(GYRO_OFFSET_Y_LSB_ADDR, calibData[14]);
+    write8(GYRO_OFFSET_Y_MSB_ADDR, calibData[15]);
+    write8(GYRO_OFFSET_Z_LSB_ADDR, calibData[16]);
+    write8(GYRO_OFFSET_Z_MSB_ADDR, calibData[17]);
 
-  write8(ACCEL_RADIUS_LSB_ADDR, calibData[18]);
-  write8(ACCEL_RADIUS_MSB_ADDR, calibData[19]);
+    write8(ACCEL_RADIUS_LSB_ADDR, calibData[18]);
+    write8(ACCEL_RADIUS_MSB_ADDR, calibData[19]);
 
-  write8(MAG_RADIUS_LSB_ADDR, calibData[20]);
-  write8(MAG_RADIUS_MSB_ADDR, calibData[21]);
+    write8(MAG_RADIUS_LSB_ADDR, calibData[20]);
+    write8(MAG_RADIUS_MSB_ADDR, calibData[21]);
 
-  setMode(lastMode);
+    setMode(lastMode);
 }
 
 /*!
@@ -751,44 +731,44 @@ void IMU_BNO055::setSensorOffsets(const uint8_t* calibData) {
  *          gyro_offset_z  = gyroscrope offset z
  */
 void IMU_BNO055::setSensorOffsets(
-  const adafruit_bno055_offsets_t& offsets_type) {
-  adafruit_bno055_opmode_t lastMode = _mode;
-  setMode(OPERATION_MODE_CONFIG);
-  delay(25);
+    const adafruit_bno055_offsets_t& offsets_type) {
+    adafruit_bno055_opmode_t lastMode = _mode;
+    setMode(OPERATION_MODE_CONFIG);
+    delay(25);
 
-  /* Note: Configuration will take place only when user writes to the last
-     byte of each config data pair (ex. ACCEL_OFFSET_Z_MSB_ADDR, etc.).
-     Therefore the last byte must be written whenever the user wants to
-     changes the configuration. */
+    /* Note: Configuration will take place only when user writes to the last
+       byte of each config data pair (ex. ACCEL_OFFSET_Z_MSB_ADDR, etc.).
+       Therefore the last byte must be written whenever the user wants to
+       changes the configuration. */
 
-  write8(ACCEL_OFFSET_X_LSB_ADDR, (offsets_type.accel_offset_x) & 0x0FF);
-  write8(ACCEL_OFFSET_X_MSB_ADDR, (offsets_type.accel_offset_x >> 8) & 0x0FF);
-  write8(ACCEL_OFFSET_Y_LSB_ADDR, (offsets_type.accel_offset_y) & 0x0FF);
-  write8(ACCEL_OFFSET_Y_MSB_ADDR, (offsets_type.accel_offset_y >> 8) & 0x0FF);
-  write8(ACCEL_OFFSET_Z_LSB_ADDR, (offsets_type.accel_offset_z) & 0x0FF);
-  write8(ACCEL_OFFSET_Z_MSB_ADDR, (offsets_type.accel_offset_z >> 8) & 0x0FF);
+    write8(ACCEL_OFFSET_X_LSB_ADDR, (offsets_type.accel_offset_x) & 0x0FF);
+    write8(ACCEL_OFFSET_X_MSB_ADDR, (offsets_type.accel_offset_x >> 8) & 0x0FF);
+    write8(ACCEL_OFFSET_Y_LSB_ADDR, (offsets_type.accel_offset_y) & 0x0FF);
+    write8(ACCEL_OFFSET_Y_MSB_ADDR, (offsets_type.accel_offset_y >> 8) & 0x0FF);
+    write8(ACCEL_OFFSET_Z_LSB_ADDR, (offsets_type.accel_offset_z) & 0x0FF);
+    write8(ACCEL_OFFSET_Z_MSB_ADDR, (offsets_type.accel_offset_z >> 8) & 0x0FF);
 
-  write8(MAG_OFFSET_X_LSB_ADDR, (offsets_type.mag_offset_x) & 0x0FF);
-  write8(MAG_OFFSET_X_MSB_ADDR, (offsets_type.mag_offset_x >> 8) & 0x0FF);
-  write8(MAG_OFFSET_Y_LSB_ADDR, (offsets_type.mag_offset_y) & 0x0FF);
-  write8(MAG_OFFSET_Y_MSB_ADDR, (offsets_type.mag_offset_y >> 8) & 0x0FF);
-  write8(MAG_OFFSET_Z_LSB_ADDR, (offsets_type.mag_offset_z) & 0x0FF);
-  write8(MAG_OFFSET_Z_MSB_ADDR, (offsets_type.mag_offset_z >> 8) & 0x0FF);
+    write8(MAG_OFFSET_X_LSB_ADDR, (offsets_type.mag_offset_x) & 0x0FF);
+    write8(MAG_OFFSET_X_MSB_ADDR, (offsets_type.mag_offset_x >> 8) & 0x0FF);
+    write8(MAG_OFFSET_Y_LSB_ADDR, (offsets_type.mag_offset_y) & 0x0FF);
+    write8(MAG_OFFSET_Y_MSB_ADDR, (offsets_type.mag_offset_y >> 8) & 0x0FF);
+    write8(MAG_OFFSET_Z_LSB_ADDR, (offsets_type.mag_offset_z) & 0x0FF);
+    write8(MAG_OFFSET_Z_MSB_ADDR, (offsets_type.mag_offset_z >> 8) & 0x0FF);
 
-  write8(GYRO_OFFSET_X_LSB_ADDR, (offsets_type.gyro_offset_x) & 0x0FF);
-  write8(GYRO_OFFSET_X_MSB_ADDR, (offsets_type.gyro_offset_x >> 8) & 0x0FF);
-  write8(GYRO_OFFSET_Y_LSB_ADDR, (offsets_type.gyro_offset_y) & 0x0FF);
-  write8(GYRO_OFFSET_Y_MSB_ADDR, (offsets_type.gyro_offset_y >> 8) & 0x0FF);
-  write8(GYRO_OFFSET_Z_LSB_ADDR, (offsets_type.gyro_offset_z) & 0x0FF);
-  write8(GYRO_OFFSET_Z_MSB_ADDR, (offsets_type.gyro_offset_z >> 8) & 0x0FF);
+    write8(GYRO_OFFSET_X_LSB_ADDR, (offsets_type.gyro_offset_x) & 0x0FF);
+    write8(GYRO_OFFSET_X_MSB_ADDR, (offsets_type.gyro_offset_x >> 8) & 0x0FF);
+    write8(GYRO_OFFSET_Y_LSB_ADDR, (offsets_type.gyro_offset_y) & 0x0FF);
+    write8(GYRO_OFFSET_Y_MSB_ADDR, (offsets_type.gyro_offset_y >> 8) & 0x0FF);
+    write8(GYRO_OFFSET_Z_LSB_ADDR, (offsets_type.gyro_offset_z) & 0x0FF);
+    write8(GYRO_OFFSET_Z_MSB_ADDR, (offsets_type.gyro_offset_z >> 8) & 0x0FF);
 
-  write8(ACCEL_RADIUS_LSB_ADDR, (offsets_type.accel_radius) & 0x0FF);
-  write8(ACCEL_RADIUS_MSB_ADDR, (offsets_type.accel_radius >> 8) & 0x0FF);
+    write8(ACCEL_RADIUS_LSB_ADDR, (offsets_type.accel_radius) & 0x0FF);
+    write8(ACCEL_RADIUS_MSB_ADDR, (offsets_type.accel_radius >> 8) & 0x0FF);
 
-  write8(MAG_RADIUS_LSB_ADDR, (offsets_type.mag_radius) & 0x0FF);
-  write8(MAG_RADIUS_MSB_ADDR, (offsets_type.mag_radius >> 8) & 0x0FF);
+    write8(MAG_RADIUS_LSB_ADDR, (offsets_type.mag_radius) & 0x0FF);
+    write8(MAG_RADIUS_MSB_ADDR, (offsets_type.mag_radius >> 8) & 0x0FF);
 
-  setMode(lastMode);
+    setMode(lastMode);
 }
 
 /*!
@@ -796,82 +776,82 @@ void IMU_BNO055::setSensorOffsets(
  *  @return status of calibration
  */
 bool IMU_BNO055::isFullyCalibrated() {
-  uint8_t system, gyro, accel, mag;
-  getCalibration(&system, &gyro, &accel, &mag);
+    uint8_t system, gyro, accel, mag;
+    getCalibration(&system, &gyro, &accel, &mag);
 
-  switch (_mode) {
-  case OPERATION_MODE_ACCONLY:
-    return (accel == 3);
-  case OPERATION_MODE_MAGONLY:
-    return (mag == 3);
-  case OPERATION_MODE_GYRONLY:
-  case OPERATION_MODE_M4G: /* No magnetometer calibration required. */
-    return (gyro == 3);
-  case OPERATION_MODE_ACCMAG:
-  case OPERATION_MODE_COMPASS:
-    return (accel == 3 && mag == 3);
-  case OPERATION_MODE_ACCGYRO:
-  case OPERATION_MODE_IMUPLUS:
-    return (accel == 3 && gyro == 3);
-  case OPERATION_MODE_MAGGYRO:
-    return (mag == 3 && gyro == 3);
-  default:
-    return (system == 3 && gyro == 3 && accel == 3 && mag == 3);
-  }
+    switch (_mode) {
+    case OPERATION_MODE_ACCONLY:
+        return (accel == 3);
+    case OPERATION_MODE_MAGONLY:
+        return (mag == 3);
+    case OPERATION_MODE_GYRONLY:
+    case OPERATION_MODE_M4G: /* No magnetometer calibration required. */
+        return (gyro == 3);
+    case OPERATION_MODE_ACCMAG:
+    case OPERATION_MODE_COMPASS:
+        return (accel == 3 && mag == 3);
+    case OPERATION_MODE_ACCGYRO:
+    case OPERATION_MODE_IMUPLUS:
+        return (accel == 3 && gyro == 3);
+    case OPERATION_MODE_MAGGYRO:
+        return (mag == 3 && gyro == 3);
+    default:
+        return (system == 3 && gyro == 3 && accel == 3 && mag == 3);
+    }
 }
 
 /*!
  *  @brief  Enter Suspend mode (i.e., sleep)
  */
 void IMU_BNO055::enterSuspendMode() {
-  adafruit_bno055_opmode_t modeback = _mode;
+    adafruit_bno055_opmode_t modeback = _mode;
 
-  /* Switch to config mode (just in case since this is the default) */
-  setMode(OPERATION_MODE_CONFIG);
-  delay(25);
-  write8(BNO055_PWR_MODE_ADDR, 0x02);
-  /* Set the requested operating mode (see section 3.3) */
-  setMode(modeback);
-  delay(20);
+    /* Switch to config mode (just in case since this is the default) */
+    setMode(OPERATION_MODE_CONFIG);
+    delay(25);
+    write8(BNO055_PWR_MODE_ADDR, 0x02);
+    /* Set the requested operating mode (see section 3.3) */
+    setMode(modeback);
+    delay(20);
 }
 
 /*!
  *  @brief  Enter Normal mode (i.e., wake)
  */
 void IMU_BNO055::enterNormalMode() {
-  adafruit_bno055_opmode_t modeback = _mode;
+    adafruit_bno055_opmode_t modeback = _mode;
 
-  /* Switch to config mode (just in case since this is the default) */
-  setMode(OPERATION_MODE_CONFIG);
-  delay(25);
-  write8(BNO055_PWR_MODE_ADDR, 0x00);
-  /* Set the requested operating mode (see section 3.3) */
-  setMode(modeback);
-  delay(20);
+    /* Switch to config mode (just in case since this is the default) */
+    setMode(OPERATION_MODE_CONFIG);
+    delay(25);
+    write8(BNO055_PWR_MODE_ADDR, 0x00);
+    /* Set the requested operating mode (see section 3.3) */
+    setMode(modeback);
+    delay(20);
 }
 
 /*!
  *  @brief  Writes an 8 bit value over I2C
  */
 bool IMU_BNO055::write8(adafruit_bno055_reg_t reg, byte value) {
-  uint8_t buffer[2] = { (uint8_t)reg, (uint8_t)value };
-  return i2c_dev->write(buffer, 2);
+    uint8_t buffer[2] = { (uint8_t)reg, (uint8_t)value };
+    return i2c_dev->write(buffer, 2);
 }
 
 /*!
  *  @brief  Reads an 8 bit value over I2C
  */
 byte IMU_BNO055::read8(adafruit_bno055_reg_t reg) {
-  uint8_t buffer[1] = { reg };
-  i2c_dev->write_then_read(buffer, 1, buffer, 1);
-  return (byte)buffer[0];
+    uint8_t buffer[1] = { reg };
+    i2c_dev->write_then_read(buffer, 1, buffer, 1);
+    return (byte)buffer[0];
 }
 
 /*!
  *  @brief  Reads the specified number of bytes over I2C
  */
 bool IMU_BNO055::readLen(adafruit_bno055_reg_t reg, byte* buffer,
-  uint8_t len) {
-  uint8_t reg_buf[1] = { (uint8_t)reg };
-  return i2c_dev->write_then_read(reg_buf, 1, buffer, len);
+    uint8_t len) {
+    uint8_t reg_buf[1] = { (uint8_t)reg };
+    return i2c_dev->write_then_read(reg_buf, 1, buffer, len);
 }

--- a/examples/ahrs_telemetry/imu_bno055.cpp
+++ b/examples/ahrs_telemetry/imu_bno055.cpp
@@ -1,0 +1,877 @@
+/**
+ * @file imu_bno055.cpp
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief An IMU driver library for the BNO055, based on Adafruit's BNO055 library.
+ * @version 0.2.0
+ * @date 2023-02-08
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+#include "Arduino.h"
+
+#include <limits.h>
+#include <math.h>
+
+#include "imu_bno055.h"
+
+ /*!
+  *  @brief  Instantiates a new IMU_BNO055 class
+  *  @param  sensorID
+  *          sensor ID
+  *  @param  address
+  *          i2c address
+  *  @param  theWire
+  *          Wire object
+  */
+IMU_BNO055::IMU_BNO055(int32_t sensorID, uint8_t address,
+  I2C* theWire) {
+  // BNO055 clock stretches for 500us or more!
+#ifdef ESP8266
+  theWire->setClockStretchLimit(1000); // Allow for 1000us of clock stretching
+#endif
+
+  _sensorID = sensorID;
+  i2c_dev = new BusIO_I2C_Target(address, theWire);
+}
+
+/*!
+ *  @brief  Sets up the HW
+ *  @param  mode
+ *          mode values
+ *           [OPERATION_MODE_CONFIG,
+ *            OPERATION_MODE_ACCONLY,
+ *            OPERATION_MODE_MAGONLY,
+ *            OPERATION_MODE_GYRONLY,
+ *            OPERATION_MODE_ACCMAG,
+ *            OPERATION_MODE_ACCGYRO,
+ *            OPERATION_MODE_MAGGYRO,
+ *            OPERATION_MODE_AMG,
+ *            OPERATION_MODE_IMUPLUS,
+ *            OPERATION_MODE_COMPASS,
+ *            OPERATION_MODE_M4G,
+ *            OPERATION_MODE_NDOF_FMC_OFF,
+ *            OPERATION_MODE_NDOF]
+ *  @return true if process is successful
+ */
+bool IMU_BNO055::begin(adafruit_bno055_opmode_t mode) {
+  Serial.println("BNO055: begin()");
+
+  // Start without a detection
+  i2c_dev->begin(false);
+
+#if defined(TARGET_RP2040)
+  // philhower core seems to work with this speed?
+  i2c_dev->setSpeed(50000);
+#endif
+
+  Serial.println("BNO055: begin() - i2c_dev->begin()");
+  // can take 850 ms to boot!
+  int timeout = 850; // in ms
+  while (timeout > 0) {
+    if (i2c_dev->begin()) {
+      Serial.println("BNO055: begin() - i2c_dev->begin() - success");
+      break;
+    }
+    // wasnt detected... we'll retry!
+    delay(10);
+    timeout -= 10;
+  }
+  if (timeout <= 0)
+  {
+    Serial.println("BNO055: begin() - i2c_dev->begin() - timeout");
+    return false;
+  }
+
+  /* Make sure we have the right device */
+  Serial.println("BNO055: begin() - check chip ID");
+  uint8_t id = read8(BNO055_CHIP_ID_ADDR);
+  if (id != BNO055_ID) {
+    Serial.println("BNO055: begin() - check chip ID - start boot");
+    delay(1000); // hold on for boot
+    id = read8(BNO055_CHIP_ID_ADDR);
+    Serial.println("BNO055: begin() - check chip ID - end boot");
+    if (id != BNO055_ID) {
+      Serial.println("BNO055: begin() - check chip ID - failed");
+      return false; // still not? ok bail
+    }
+    Serial.println("BNO055: begin() - check chip ID - success");
+  }
+
+  /* Switch to config mode (just in case since this is the default) */
+  Serial.println("BNO055: begin() - set mode - config");
+  setMode(OPERATION_MODE_CONFIG);
+  Serial.println("BNO055: begin() - set mode - success");
+
+  /* Reset */
+  Serial.println("BNO055: begin() - reset");
+  write8(BNO055_SYS_TRIGGER_ADDR, 0x20);
+  /* Delay incrased to 30ms due to power issues https://tinyurl.com/y375z699 */
+  delay(30);
+  Serial.println("BNO055: begin() - reset - waiting for boot");
+  while (read8(BNO055_CHIP_ID_ADDR) != BNO055_ID) {
+    delay(10);
+  }
+  delay(50);
+  Serial.println("BNO055: begin() - reset - success");
+
+  /* Set to normal power mode */
+  Serial.println("BNO055: begin() - set power mode");
+  write8(BNO055_PWR_MODE_ADDR, POWER_MODE_NORMAL);
+  delay(10);
+  Serial.println("BNO055: begin() - set power mode - success");
+
+  write8(BNO055_PAGE_ID_ADDR, 0);
+
+  /* Set the output units */
+  /*
+  uint8_t unitsel = (0 << 7) | // Orientation = Android
+                    (0 << 4) | // Temperature = Celsius
+                    (0 << 2) | // Euler = Degrees
+                    (1 << 1) | // Gyro = Rads
+                    (0 << 0);  // Accelerometer = m/s^2
+  write8(BNO055_UNIT_SEL_ADDR, unitsel);
+  */
+
+  /* Configure axis mapping (see section 3.4) */
+  /*
+  write8(BNO055_AXIS_MAP_CONFIG_ADDR, REMAP_CONFIG_P2); // P0-P7, Default is P1
+  delay(10);
+  write8(BNO055_AXIS_MAP_SIGN_ADDR, REMAP_SIGN_P2); // P0-P7, Default is P1
+  delay(10);
+  */
+
+  write8(BNO055_SYS_TRIGGER_ADDR, 0x0);
+  delay(10);
+  /* Set the requested operating mode (see section 3.3) */
+  Serial.println("BNO055: begin() - set mode - requested");
+  setMode(mode);
+  delay(20);
+
+  Serial.println("BNO055: begin() - success");
+
+  return true;
+}
+
+/*!
+ *  @brief  Puts the chip in the specified operating mode
+ *  @param  mode
+ *          mode values
+ *           [OPERATION_MODE_CONFIG,
+ *            OPERATION_MODE_ACCONLY,
+ *            OPERATION_MODE_MAGONLY,
+ *            OPERATION_MODE_GYRONLY,
+ *            OPERATION_MODE_ACCMAG,
+ *            OPERATION_MODE_ACCGYRO,
+ *            OPERATION_MODE_MAGGYRO,
+ *            OPERATION_MODE_AMG,
+ *            OPERATION_MODE_IMUPLUS,
+ *            OPERATION_MODE_COMPASS,
+ *            OPERATION_MODE_M4G,
+ *            OPERATION_MODE_NDOF_FMC_OFF,
+ *            OPERATION_MODE_NDOF]
+ */
+void IMU_BNO055::setMode(adafruit_bno055_opmode_t mode) {
+  _mode = mode;
+  write8(BNO055_OPR_MODE_ADDR, _mode);
+  delay(30);
+}
+
+/*!
+ *  @brief  Gets the current operating mode of the chip
+ *  @return  operating_mode in integer which can be mapped in Section 3.3
+ *           for example: a return of 12 (0X0C) => NDOF
+ */
+adafruit_bno055_opmode_t IMU_BNO055::getMode() {
+  return (adafruit_bno055_opmode_t)read8(BNO055_OPR_MODE_ADDR);
+}
+
+/*!
+ *  @brief  Changes the chip's axis remap
+ *  @param  remapcode
+ *          remap code possible values
+ *          [REMAP_CONFIG_P0
+ *           REMAP_CONFIG_P1 (default)
+ *           REMAP_CONFIG_P2
+ *           REMAP_CONFIG_P3
+ *           REMAP_CONFIG_P4
+ *           REMAP_CONFIG_P5
+ *           REMAP_CONFIG_P6
+ *           REMAP_CONFIG_P7]
+ */
+void IMU_BNO055::setAxisRemap(
+  adafruit_bno055_axis_remap_config_t remapcode) {
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_AXIS_MAP_CONFIG_ADDR, remapcode);
+  delay(10);
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+}
+
+/*!
+ *  @brief  Changes the chip's axis signs
+ *  @param  remapsign
+ *          remap sign possible values
+ *          [REMAP_SIGN_P0
+ *           REMAP_SIGN_P1 (default)
+ *           REMAP_SIGN_P2
+ *           REMAP_SIGN_P3
+ *           REMAP_SIGN_P4
+ *           REMAP_SIGN_P5
+ *           REMAP_SIGN_P6
+ *           REMAP_SIGN_P7]
+ */
+void IMU_BNO055::setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign) {
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_AXIS_MAP_SIGN_ADDR, remapsign);
+  delay(10);
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+}
+
+/*!
+ *  @brief  Use the external 32.768KHz crystal
+ *  @param  usextal
+ *          use external crystal boolean
+ */
+void IMU_BNO055::setExtCrystalUse(boolean usextal) {
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  /* Switch to config mode (just in case since this is the default) */
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_PAGE_ID_ADDR, 0);
+  if (usextal) {
+    write8(BNO055_SYS_TRIGGER_ADDR, 0x80);
+  }
+  else {
+    write8(BNO055_SYS_TRIGGER_ADDR, 0x00);
+  }
+  delay(10);
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+}
+
+/*!
+ *   @brief  Gets the latest system status info
+ *   @param  system_status
+ *           system status info
+ *   @param  self_test_result
+ *           self test result
+ *   @param  system_error
+ *           system error info
+ */
+void IMU_BNO055::getSystemStatus(uint8_t* system_status,
+  uint8_t* self_test_result,
+  uint8_t* system_error) {
+  write8(BNO055_PAGE_ID_ADDR, 0);
+
+  /* System Status (see section 4.3.58)
+     0 = Idle
+     1 = System Error
+     2 = Initializing Peripherals
+     3 = System Iniitalization
+     4 = Executing Self-Test
+     5 = Sensor fusio algorithm running
+     6 = System running without fusion algorithms
+   */
+
+  if (system_status != 0)
+    *system_status = read8(BNO055_SYS_STAT_ADDR);
+
+  /* Self Test Results
+     1 = test passed, 0 = test failed
+
+     Bit 0 = Accelerometer self test
+     Bit 1 = Magnetometer self test
+     Bit 2 = Gyroscope self test
+     Bit 3 = MCU self test
+
+     0x0F = all good!
+   */
+
+  if (self_test_result != 0)
+    *self_test_result = read8(BNO055_SELFTEST_RESULT_ADDR);
+
+  /* System Error (see section 4.3.59)
+     0 = No error
+     1 = Peripheral initialization error
+     2 = System initialization error
+     3 = Self test result failed
+     4 = Register map value out of range
+     5 = Register map address out of range
+     6 = Register map write error
+     7 = BNO low power mode not available for selected operat ion mode
+     8 = Accelerometer power mode not available
+     9 = Fusion algorithm configuration error
+     A = Sensor configuration error
+   */
+
+  if (system_error != 0)
+    *system_error = read8(BNO055_SYS_ERR_ADDR);
+
+  delay(200);
+}
+
+/*!
+ *  @brief  Gets the chip revision numbers
+ *  @param  info
+ *          revision info
+ */
+void IMU_BNO055::getRevInfo(adafruit_bno055_rev_info_t* info) {
+  uint8_t a, b;
+
+  memset(info, 0, sizeof(adafruit_bno055_rev_info_t));
+
+  /* Check the accelerometer revision */
+  info->accel_rev = read8(BNO055_ACCEL_REV_ID_ADDR);
+
+  /* Check the magnetometer revision */
+  info->mag_rev = read8(BNO055_MAG_REV_ID_ADDR);
+
+  /* Check the gyroscope revision */
+  info->gyro_rev = read8(BNO055_GYRO_REV_ID_ADDR);
+
+  /* Check the SW revision */
+  info->bl_rev = read8(BNO055_BL_REV_ID_ADDR);
+
+  a = read8(BNO055_SW_REV_ID_LSB_ADDR);
+  b = read8(BNO055_SW_REV_ID_MSB_ADDR);
+  info->sw_rev = (((uint16_t)b) << 8) | ((uint16_t)a);
+}
+
+/*!
+ *  @brief  Gets current calibration state.  Each value should be a uint8_t
+ *          pointer and it will be set to 0 if not calibrated and 3 if
+ *          fully calibrated.
+ *          See section 34.3.54
+ *  @param  sys
+ *          Current system calibration status, depends on status of all sensors,
+ * read-only
+ *  @param  gyro
+ *          Current calibration status of Gyroscope, read-only
+ *  @param  accel
+ *          Current calibration status of Accelerometer, read-only
+ *  @param  mag
+ *          Current calibration status of Magnetometer, read-only
+ */
+void IMU_BNO055::getCalibration(uint8_t* sys, uint8_t* gyro,
+  uint8_t* accel, uint8_t* mag) {
+  uint8_t calData = read8(BNO055_CALIB_STAT_ADDR);
+  if (sys != NULL) {
+    *sys = (calData >> 6) & 0x03;
+  }
+  if (gyro != NULL) {
+    *gyro = (calData >> 4) & 0x03;
+  }
+  if (accel != NULL) {
+    *accel = (calData >> 2) & 0x03;
+  }
+  if (mag != NULL) {
+    *mag = calData & 0x03;
+  }
+}
+
+/*!
+ *  @brief  Gets the temperature in degrees celsius
+ *  @return temperature in degrees celsius
+ */
+int8_t IMU_BNO055::getTemp() {
+  int8_t temp = (int8_t)(read8(BNO055_TEMP_ADDR));
+  return temp;
+}
+
+/*!
+ *  @brief   Gets a vector reading from the specified source
+ *  @param   vector_type
+ *           possible vector type values
+ *           [VECTOR_ACCELEROMETER
+ *            VECTOR_MAGNETOMETER
+ *            VECTOR_GYROSCOPE
+ *            VECTOR_EULER
+ *            VECTOR_LINEARACCEL
+ *            VECTOR_GRAVITY]
+ *  @return  vector from specified source
+ */
+imu::Vector<3> IMU_BNO055::getVector(adafruit_vector_type_t vector_type) {
+  imu::Vector<3> xyz;
+  uint8_t buffer[6];
+  memset(buffer, 0, 6);
+
+  int16_t x, y, z;
+  x = y = z = 0;
+
+  /* Read vector data (6 bytes) */
+  readLen((adafruit_bno055_reg_t)vector_type, buffer, 6);
+
+  x = ((int16_t)buffer[0]) | (((int16_t)buffer[1]) << 8);
+  y = ((int16_t)buffer[2]) | (((int16_t)buffer[3]) << 8);
+  z = ((int16_t)buffer[4]) | (((int16_t)buffer[5]) << 8);
+
+  /*!
+   * Convert the value to an appropriate range (section 3.6.4)
+   * and assign the value to the Vector type
+   */
+  switch (vector_type) {
+  case VECTOR_MAGNETOMETER:
+    /* 1uT = 16 LSB */
+    xyz[0] = ((double)x) / 16.0;
+    xyz[1] = ((double)y) / 16.0;
+    xyz[2] = ((double)z) / 16.0;
+    break;
+  case VECTOR_GYROSCOPE:
+    /* 1dps = 16 LSB */
+    xyz[0] = ((double)x) / 16.0;
+    xyz[1] = ((double)y) / 16.0;
+    xyz[2] = ((double)z) / 16.0;
+    break;
+  case VECTOR_EULER:
+    /* 1 degree = 16 LSB */
+    xyz[0] = ((double)x) / 16.0;
+    xyz[1] = ((double)y) / 16.0;
+    xyz[2] = ((double)z) / 16.0;
+    break;
+  case VECTOR_ACCELEROMETER:
+    /* 1m/s^2 = 100 LSB */
+    xyz[0] = ((double)x) / 100.0;
+    xyz[1] = ((double)y) / 100.0;
+    xyz[2] = ((double)z) / 100.0;
+    break;
+  case VECTOR_LINEARACCEL:
+    /* 1m/s^2 = 100 LSB */
+    xyz[0] = ((double)x) / 100.0;
+    xyz[1] = ((double)y) / 100.0;
+    xyz[2] = ((double)z) / 100.0;
+    break;
+  case VECTOR_GRAVITY:
+    /* 1m/s^2 = 100 LSB */
+    xyz[0] = ((double)x) / 100.0;
+    xyz[1] = ((double)y) / 100.0;
+    xyz[2] = ((double)z) / 100.0;
+    break;
+  }
+
+  return xyz;
+}
+
+/*!
+ *  @brief  Gets a quaternion reading from the specified source
+ *  @return quaternion reading
+ */
+imu::Quaternion IMU_BNO055::getQuat() {
+  uint8_t buffer[8];
+  memset(buffer, 0, 8);
+
+  int16_t x, y, z, w;
+  x = y = z = w = 0;
+
+  /* Read quat data (8 bytes) */
+  readLen(BNO055_QUATERNION_DATA_W_LSB_ADDR, buffer, 8);
+  w = (((uint16_t)buffer[1]) << 8) | ((uint16_t)buffer[0]);
+  x = (((uint16_t)buffer[3]) << 8) | ((uint16_t)buffer[2]);
+  y = (((uint16_t)buffer[5]) << 8) | ((uint16_t)buffer[4]);
+  z = (((uint16_t)buffer[7]) << 8) | ((uint16_t)buffer[6]);
+
+  /*!
+   * Assign to Quaternion
+   * See
+   * https://cdn-shop.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf
+   * 3.6.5.5 Orientation (Quaternion)
+   */
+  const double scale = (1.0 / (1 << 14));
+  imu::Quaternion quat(scale * w, scale * x, scale * y, scale * z);
+  return quat;
+}
+
+/*!
+ *  @brief  Provides the sensor_t data for this sensor
+ *  @param  sensor
+ *          Sensor description
+ */
+void IMU_BNO055::getSensor(sensor_t* sensor) {
+  /* Clear the sensor_t object */
+  memset(sensor, 0, sizeof(sensor_t));
+
+  /* Insert the sensor name in the fixed length char array */
+  strncpy(sensor->name, "BNO055", sizeof(sensor->name) - 1);
+  sensor->name[sizeof(sensor->name) - 1] = 0;
+  sensor->version = 1;
+  sensor->sensor_id = _sensorID;
+  sensor->type = SENSOR_TYPE_ORIENTATION;
+  sensor->min_delay = 0;
+  sensor->max_value = 0.0F;
+  sensor->min_value = 0.0F;
+  sensor->resolution = 0.01F;
+}
+
+/*!
+ *  @brief  Reads the sensor and returns the data as a sensors_event_t
+ *  @param  event
+ *          Event description
+ *  @return always returns true
+ */
+bool IMU_BNO055::getEvent(sensors_event_t* event) {
+  /* Clear the event */
+  memset(event, 0, sizeof(sensors_event_t));
+
+  event->version = sizeof(sensors_event_t);
+  event->sensor_id = _sensorID;
+  event->type = SENSOR_TYPE_ORIENTATION;
+  event->timestamp = millis();
+
+  /* Get a Euler angle sample for orientation */
+  imu::Vector<3> euler = getVector(IMU_BNO055::VECTOR_EULER);
+  event->orientation.x = euler.x();
+  event->orientation.y = euler.y();
+  event->orientation.z = euler.z();
+
+  return true;
+}
+
+/*!
+ *  @brief  Reads the sensor and returns the data as a sensors_event_t
+ *  @param  event
+ *          Event description
+ *  @param  vec_type
+ *          specify the type of reading
+ *  @return always returns true
+ */
+bool IMU_BNO055::getEvent(sensors_event_t* event,
+  adafruit_vector_type_t vec_type) {
+  /* Clear the event */
+  memset(event, 0, sizeof(sensors_event_t));
+
+  event->version = sizeof(sensors_event_t);
+  event->sensor_id = _sensorID;
+  event->timestamp = millis();
+
+  // read the data according to vec_type
+  imu::Vector<3> vec;
+  if (vec_type == IMU_BNO055::VECTOR_LINEARACCEL) {
+    event->type = SENSOR_TYPE_LINEAR_ACCELERATION;
+    vec = getVector(IMU_BNO055::VECTOR_LINEARACCEL);
+
+    event->acceleration.x = vec.x();
+    event->acceleration.y = vec.y();
+    event->acceleration.z = vec.z();
+  }
+  else if (vec_type == IMU_BNO055::VECTOR_ACCELEROMETER) {
+    event->type = SENSOR_TYPE_ACCELEROMETER;
+    vec = getVector(IMU_BNO055::VECTOR_ACCELEROMETER);
+
+    event->acceleration.x = vec.x();
+    event->acceleration.y = vec.y();
+    event->acceleration.z = vec.z();
+  }
+  else if (vec_type == IMU_BNO055::VECTOR_GRAVITY) {
+    event->type = SENSOR_TYPE_GRAVITY;
+    vec = getVector(IMU_BNO055::VECTOR_GRAVITY);
+
+    event->acceleration.x = vec.x();
+    event->acceleration.y = vec.y();
+    event->acceleration.z = vec.z();
+  }
+  else if (vec_type == IMU_BNO055::VECTOR_EULER) {
+    event->type = SENSOR_TYPE_ORIENTATION;
+    vec = getVector(IMU_BNO055::VECTOR_EULER);
+
+    event->orientation.x = vec.x();
+    event->orientation.y = vec.y();
+    event->orientation.z = vec.z();
+  }
+  else if (vec_type == IMU_BNO055::VECTOR_GYROSCOPE) {
+    event->type = SENSOR_TYPE_GYROSCOPE;
+    vec = getVector(IMU_BNO055::VECTOR_GYROSCOPE);
+
+    event->gyro.x = vec.x() * SENSORS_DPS_TO_RADS;
+    event->gyro.y = vec.y() * SENSORS_DPS_TO_RADS;
+    event->gyro.z = vec.z() * SENSORS_DPS_TO_RADS;
+  }
+  else if (vec_type == IMU_BNO055::VECTOR_MAGNETOMETER) {
+    event->type = SENSOR_TYPE_MAGNETIC_FIELD;
+    vec = getVector(IMU_BNO055::VECTOR_MAGNETOMETER);
+
+    event->magnetic.x = vec.x();
+    event->magnetic.y = vec.y();
+    event->magnetic.z = vec.z();
+  }
+
+  return true;
+}
+
+/*!
+ *  @brief  Reads the sensor's offset registers into a byte array
+ *  @param  calibData
+ *          Calibration offset (buffer size should be 22)
+ *  @return true if read is successful
+ */
+bool IMU_BNO055::getSensorOffsets(uint8_t* calibData) {
+  if (isFullyCalibrated()) {
+    adafruit_bno055_opmode_t lastMode = _mode;
+    setMode(OPERATION_MODE_CONFIG);
+
+    readLen(ACCEL_OFFSET_X_LSB_ADDR, calibData, NUM_BNO055_OFFSET_REGISTERS);
+
+    setMode(lastMode);
+    return true;
+  }
+  return false;
+}
+
+/*!
+ *  @brief  Reads the sensor's offset registers into an offset struct
+ *  @param  offsets_type
+ *          type of offsets
+ *  @return true if read is successful
+ */
+bool IMU_BNO055::getSensorOffsets(
+  adafruit_bno055_offsets_t& offsets_type) {
+  if (isFullyCalibrated()) {
+    adafruit_bno055_opmode_t lastMode = _mode;
+    setMode(OPERATION_MODE_CONFIG);
+    delay(25);
+
+    /* Accel offset range depends on the G-range:
+       +/-2g  = +/- 2000 mg
+       +/-4g  = +/- 4000 mg
+       +/-8g  = +/- 8000 mg
+       +/-1§g = +/- 16000 mg */
+    offsets_type.accel_offset_x = (read8(ACCEL_OFFSET_X_MSB_ADDR) << 8) |
+      (read8(ACCEL_OFFSET_X_LSB_ADDR));
+    offsets_type.accel_offset_y = (read8(ACCEL_OFFSET_Y_MSB_ADDR) << 8) |
+      (read8(ACCEL_OFFSET_Y_LSB_ADDR));
+    offsets_type.accel_offset_z = (read8(ACCEL_OFFSET_Z_MSB_ADDR) << 8) |
+      (read8(ACCEL_OFFSET_Z_LSB_ADDR));
+
+    /* Magnetometer offset range = +/- 6400 LSB where 1uT = 16 LSB */
+    offsets_type.mag_offset_x =
+      (read8(MAG_OFFSET_X_MSB_ADDR) << 8) | (read8(MAG_OFFSET_X_LSB_ADDR));
+    offsets_type.mag_offset_y =
+      (read8(MAG_OFFSET_Y_MSB_ADDR) << 8) | (read8(MAG_OFFSET_Y_LSB_ADDR));
+    offsets_type.mag_offset_z =
+      (read8(MAG_OFFSET_Z_MSB_ADDR) << 8) | (read8(MAG_OFFSET_Z_LSB_ADDR));
+
+    /* Gyro offset range depends on the DPS range:
+      2000 dps = +/- 32000 LSB
+      1000 dps = +/- 16000 LSB
+       500 dps = +/- 8000 LSB
+       250 dps = +/- 4000 LSB
+       125 dps = +/- 2000 LSB
+       ... where 1 DPS = 16 LSB */
+    offsets_type.gyro_offset_x =
+      (read8(GYRO_OFFSET_X_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_X_LSB_ADDR));
+    offsets_type.gyro_offset_y =
+      (read8(GYRO_OFFSET_Y_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_Y_LSB_ADDR));
+    offsets_type.gyro_offset_z =
+      (read8(GYRO_OFFSET_Z_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_Z_LSB_ADDR));
+
+    /* Accelerometer radius = +/- 1000 LSB */
+    offsets_type.accel_radius =
+      (read8(ACCEL_RADIUS_MSB_ADDR) << 8) | (read8(ACCEL_RADIUS_LSB_ADDR));
+
+    /* Magnetometer radius = +/- 960 LSB */
+    offsets_type.mag_radius =
+      (read8(MAG_RADIUS_MSB_ADDR) << 8) | (read8(MAG_RADIUS_LSB_ADDR));
+
+    setMode(lastMode);
+    return true;
+  }
+  return false;
+}
+
+/*!
+ *  @brief  Writes an array of calibration values to the sensor's offset
+ *  @param  calibData
+ *          calibration data
+ */
+void IMU_BNO055::setSensorOffsets(const uint8_t* calibData) {
+  adafruit_bno055_opmode_t lastMode = _mode;
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+
+  /* Note: Configuration will take place only when user writes to the last
+     byte of each config data pair (ex. ACCEL_OFFSET_Z_MSB_ADDR, etc.).
+     Therefore the last byte must be written whenever the user wants to
+     changes the configuration. */
+
+     /* A writeLen() would make this much cleaner */
+  write8(ACCEL_OFFSET_X_LSB_ADDR, calibData[0]);
+  write8(ACCEL_OFFSET_X_MSB_ADDR, calibData[1]);
+  write8(ACCEL_OFFSET_Y_LSB_ADDR, calibData[2]);
+  write8(ACCEL_OFFSET_Y_MSB_ADDR, calibData[3]);
+  write8(ACCEL_OFFSET_Z_LSB_ADDR, calibData[4]);
+  write8(ACCEL_OFFSET_Z_MSB_ADDR, calibData[5]);
+
+  write8(MAG_OFFSET_X_LSB_ADDR, calibData[6]);
+  write8(MAG_OFFSET_X_MSB_ADDR, calibData[7]);
+  write8(MAG_OFFSET_Y_LSB_ADDR, calibData[8]);
+  write8(MAG_OFFSET_Y_MSB_ADDR, calibData[9]);
+  write8(MAG_OFFSET_Z_LSB_ADDR, calibData[10]);
+  write8(MAG_OFFSET_Z_MSB_ADDR, calibData[11]);
+
+  write8(GYRO_OFFSET_X_LSB_ADDR, calibData[12]);
+  write8(GYRO_OFFSET_X_MSB_ADDR, calibData[13]);
+  write8(GYRO_OFFSET_Y_LSB_ADDR, calibData[14]);
+  write8(GYRO_OFFSET_Y_MSB_ADDR, calibData[15]);
+  write8(GYRO_OFFSET_Z_LSB_ADDR, calibData[16]);
+  write8(GYRO_OFFSET_Z_MSB_ADDR, calibData[17]);
+
+  write8(ACCEL_RADIUS_LSB_ADDR, calibData[18]);
+  write8(ACCEL_RADIUS_MSB_ADDR, calibData[19]);
+
+  write8(MAG_RADIUS_LSB_ADDR, calibData[20]);
+  write8(MAG_RADIUS_MSB_ADDR, calibData[21]);
+
+  setMode(lastMode);
+}
+
+/*!
+ *  @brief  Writes to the sensor's offset registers from an offset struct
+ *  @param  offsets_type
+ *          accel_offset_x = acceleration offset x
+ *          accel_offset_y = acceleration offset y
+ *          accel_offset_z = acceleration offset z
+ *
+ *          mag_offset_x   = magnetometer offset x
+ *          mag_offset_y   = magnetometer offset y
+ *          mag_offset_z   = magnetometer offset z
+ *
+ *          gyro_offset_x  = gyroscrope offset x
+ *          gyro_offset_y  = gyroscrope offset y
+ *          gyro_offset_z  = gyroscrope offset z
+ */
+void IMU_BNO055::setSensorOffsets(
+  const adafruit_bno055_offsets_t& offsets_type) {
+  adafruit_bno055_opmode_t lastMode = _mode;
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+
+  /* Note: Configuration will take place only when user writes to the last
+     byte of each config data pair (ex. ACCEL_OFFSET_Z_MSB_ADDR, etc.).
+     Therefore the last byte must be written whenever the user wants to
+     changes the configuration. */
+
+  write8(ACCEL_OFFSET_X_LSB_ADDR, (offsets_type.accel_offset_x) & 0x0FF);
+  write8(ACCEL_OFFSET_X_MSB_ADDR, (offsets_type.accel_offset_x >> 8) & 0x0FF);
+  write8(ACCEL_OFFSET_Y_LSB_ADDR, (offsets_type.accel_offset_y) & 0x0FF);
+  write8(ACCEL_OFFSET_Y_MSB_ADDR, (offsets_type.accel_offset_y >> 8) & 0x0FF);
+  write8(ACCEL_OFFSET_Z_LSB_ADDR, (offsets_type.accel_offset_z) & 0x0FF);
+  write8(ACCEL_OFFSET_Z_MSB_ADDR, (offsets_type.accel_offset_z >> 8) & 0x0FF);
+
+  write8(MAG_OFFSET_X_LSB_ADDR, (offsets_type.mag_offset_x) & 0x0FF);
+  write8(MAG_OFFSET_X_MSB_ADDR, (offsets_type.mag_offset_x >> 8) & 0x0FF);
+  write8(MAG_OFFSET_Y_LSB_ADDR, (offsets_type.mag_offset_y) & 0x0FF);
+  write8(MAG_OFFSET_Y_MSB_ADDR, (offsets_type.mag_offset_y >> 8) & 0x0FF);
+  write8(MAG_OFFSET_Z_LSB_ADDR, (offsets_type.mag_offset_z) & 0x0FF);
+  write8(MAG_OFFSET_Z_MSB_ADDR, (offsets_type.mag_offset_z >> 8) & 0x0FF);
+
+  write8(GYRO_OFFSET_X_LSB_ADDR, (offsets_type.gyro_offset_x) & 0x0FF);
+  write8(GYRO_OFFSET_X_MSB_ADDR, (offsets_type.gyro_offset_x >> 8) & 0x0FF);
+  write8(GYRO_OFFSET_Y_LSB_ADDR, (offsets_type.gyro_offset_y) & 0x0FF);
+  write8(GYRO_OFFSET_Y_MSB_ADDR, (offsets_type.gyro_offset_y >> 8) & 0x0FF);
+  write8(GYRO_OFFSET_Z_LSB_ADDR, (offsets_type.gyro_offset_z) & 0x0FF);
+  write8(GYRO_OFFSET_Z_MSB_ADDR, (offsets_type.gyro_offset_z >> 8) & 0x0FF);
+
+  write8(ACCEL_RADIUS_LSB_ADDR, (offsets_type.accel_radius) & 0x0FF);
+  write8(ACCEL_RADIUS_MSB_ADDR, (offsets_type.accel_radius >> 8) & 0x0FF);
+
+  write8(MAG_RADIUS_LSB_ADDR, (offsets_type.mag_radius) & 0x0FF);
+  write8(MAG_RADIUS_MSB_ADDR, (offsets_type.mag_radius >> 8) & 0x0FF);
+
+  setMode(lastMode);
+}
+
+/*!
+ *  @brief  Checks of all cal status values are set to 3 (fully calibrated)
+ *  @return status of calibration
+ */
+bool IMU_BNO055::isFullyCalibrated() {
+  uint8_t system, gyro, accel, mag;
+  getCalibration(&system, &gyro, &accel, &mag);
+
+  switch (_mode) {
+  case OPERATION_MODE_ACCONLY:
+    return (accel == 3);
+  case OPERATION_MODE_MAGONLY:
+    return (mag == 3);
+  case OPERATION_MODE_GYRONLY:
+  case OPERATION_MODE_M4G: /* No magnetometer calibration required. */
+    return (gyro == 3);
+  case OPERATION_MODE_ACCMAG:
+  case OPERATION_MODE_COMPASS:
+    return (accel == 3 && mag == 3);
+  case OPERATION_MODE_ACCGYRO:
+  case OPERATION_MODE_IMUPLUS:
+    return (accel == 3 && gyro == 3);
+  case OPERATION_MODE_MAGGYRO:
+    return (mag == 3 && gyro == 3);
+  default:
+    return (system == 3 && gyro == 3 && accel == 3 && mag == 3);
+  }
+}
+
+/*!
+ *  @brief  Enter Suspend mode (i.e., sleep)
+ */
+void IMU_BNO055::enterSuspendMode() {
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  /* Switch to config mode (just in case since this is the default) */
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_PWR_MODE_ADDR, 0x02);
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+}
+
+/*!
+ *  @brief  Enter Normal mode (i.e., wake)
+ */
+void IMU_BNO055::enterNormalMode() {
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  /* Switch to config mode (just in case since this is the default) */
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_PWR_MODE_ADDR, 0x00);
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+}
+
+/*!
+ *  @brief  Writes an 8 bit value over I2C
+ */
+bool IMU_BNO055::write8(adafruit_bno055_reg_t reg, byte value) {
+  uint8_t buffer[2] = { (uint8_t)reg, (uint8_t)value };
+  return i2c_dev->write(buffer, 2);
+}
+
+/*!
+ *  @brief  Reads an 8 bit value over I2C
+ */
+byte IMU_BNO055::read8(adafruit_bno055_reg_t reg) {
+  uint8_t buffer[1] = { reg };
+  i2c_dev->write_then_read(buffer, 1, buffer, 1);
+  return (byte)buffer[0];
+}
+
+/*!
+ *  @brief  Reads the specified number of bytes over I2C
+ */
+bool IMU_BNO055::readLen(adafruit_bno055_reg_t reg, byte* buffer,
+  uint8_t len) {
+  uint8_t reg_buf[1] = { (uint8_t)reg };
+  return i2c_dev->write_then_read(reg_buf, 1, buffer, len);
+}

--- a/examples/ahrs_telemetry/imu_bno055.h
+++ b/examples/ahrs_telemetry/imu_bno055.h
@@ -17,7 +17,7 @@
 #include "busio_i2c_target.h"
 #include "unified_sensor.h"
 
-/** BNO055 Address A **/
+ /** BNO055 Address A **/
 #define BNO055_ADDRESS_A (0x28)
 /** BNO055 Address B **/
 #define BNO055_ADDRESS_B (0x29)
@@ -29,287 +29,287 @@
 
 /** A structure to represent offsets **/
 typedef struct {
-  int16_t accel_offset_x; /**< x acceleration offset */
-  int16_t accel_offset_y; /**< y acceleration offset */
-  int16_t accel_offset_z; /**< z acceleration offset */
+    int16_t accel_offset_x; /**< x acceleration offset */
+    int16_t accel_offset_y; /**< y acceleration offset */
+    int16_t accel_offset_z; /**< z acceleration offset */
 
-  int16_t mag_offset_x; /**< x magnetometer offset */
-  int16_t mag_offset_y; /**< y magnetometer offset */
-  int16_t mag_offset_z; /**< z magnetometer offset */
+    int16_t mag_offset_x; /**< x magnetometer offset */
+    int16_t mag_offset_y; /**< y magnetometer offset */
+    int16_t mag_offset_z; /**< z magnetometer offset */
 
-  int16_t gyro_offset_x; /**< x gyroscrope offset */
-  int16_t gyro_offset_y; /**< y gyroscrope offset */
-  int16_t gyro_offset_z; /**< z gyroscrope offset */
+    int16_t gyro_offset_x; /**< x gyroscrope offset */
+    int16_t gyro_offset_y; /**< y gyroscrope offset */
+    int16_t gyro_offset_z; /**< z gyroscrope offset */
 
-  int16_t accel_radius; /**< acceleration radius */
+    int16_t accel_radius; /**< acceleration radius */
 
-  int16_t mag_radius; /**< magnetometer radius */
+    int16_t mag_radius; /**< magnetometer radius */
 } adafruit_bno055_offsets_t;
 
 /** Operation mode settings **/
 typedef enum {
-  OPERATION_MODE_CONFIG = 0X00,
-  OPERATION_MODE_ACCONLY = 0X01,
-  OPERATION_MODE_MAGONLY = 0X02,
-  OPERATION_MODE_GYRONLY = 0X03,
-  OPERATION_MODE_ACCMAG = 0X04,
-  OPERATION_MODE_ACCGYRO = 0X05,
-  OPERATION_MODE_MAGGYRO = 0X06,
-  OPERATION_MODE_AMG = 0X07,
-  OPERATION_MODE_IMUPLUS = 0X08,
-  OPERATION_MODE_COMPASS = 0X09,
-  OPERATION_MODE_M4G = 0X0A,
-  OPERATION_MODE_NDOF_FMC_OFF = 0X0B,
-  OPERATION_MODE_NDOF = 0X0C
+    OPERATION_MODE_CONFIG = 0X00,
+    OPERATION_MODE_ACCONLY = 0X01,
+    OPERATION_MODE_MAGONLY = 0X02,
+    OPERATION_MODE_GYRONLY = 0X03,
+    OPERATION_MODE_ACCMAG = 0X04,
+    OPERATION_MODE_ACCGYRO = 0X05,
+    OPERATION_MODE_MAGGYRO = 0X06,
+    OPERATION_MODE_AMG = 0X07,
+    OPERATION_MODE_IMUPLUS = 0X08,
+    OPERATION_MODE_COMPASS = 0X09,
+    OPERATION_MODE_M4G = 0X0A,
+    OPERATION_MODE_NDOF_FMC_OFF = 0X0B,
+    OPERATION_MODE_NDOF = 0X0C
 } adafruit_bno055_opmode_t;
 
 /*!
  *  @brief  Class that stores state and functions for interacting with
  *          BNO055 Sensor
  */
-class IMU_BNO055 : public Unified_Sensor {
+class IMU_BNO055: public Unified_Sensor {
 public:
-  /** BNO055 Registers **/
-  typedef enum {
-    /* Page id register definition */
-    BNO055_PAGE_ID_ADDR = 0X07,
+    /** BNO055 Registers **/
+    typedef enum {
+        /* Page id register definition */
+        BNO055_PAGE_ID_ADDR = 0X07,
 
-    /* PAGE0 REGISTER DEFINITION START*/
-    BNO055_CHIP_ID_ADDR = 0x00,
-    BNO055_ACCEL_REV_ID_ADDR = 0x01,
-    BNO055_MAG_REV_ID_ADDR = 0x02,
-    BNO055_GYRO_REV_ID_ADDR = 0x03,
-    BNO055_SW_REV_ID_LSB_ADDR = 0x04,
-    BNO055_SW_REV_ID_MSB_ADDR = 0x05,
-    BNO055_BL_REV_ID_ADDR = 0X06,
+        /* PAGE0 REGISTER DEFINITION START*/
+        BNO055_CHIP_ID_ADDR = 0x00,
+        BNO055_ACCEL_REV_ID_ADDR = 0x01,
+        BNO055_MAG_REV_ID_ADDR = 0x02,
+        BNO055_GYRO_REV_ID_ADDR = 0x03,
+        BNO055_SW_REV_ID_LSB_ADDR = 0x04,
+        BNO055_SW_REV_ID_MSB_ADDR = 0x05,
+        BNO055_BL_REV_ID_ADDR = 0X06,
 
-    /* Accel data register */
-    BNO055_ACCEL_DATA_X_LSB_ADDR = 0X08,
-    BNO055_ACCEL_DATA_X_MSB_ADDR = 0X09,
-    BNO055_ACCEL_DATA_Y_LSB_ADDR = 0X0A,
-    BNO055_ACCEL_DATA_Y_MSB_ADDR = 0X0B,
-    BNO055_ACCEL_DATA_Z_LSB_ADDR = 0X0C,
-    BNO055_ACCEL_DATA_Z_MSB_ADDR = 0X0D,
+        /* Accel data register */
+        BNO055_ACCEL_DATA_X_LSB_ADDR = 0X08,
+        BNO055_ACCEL_DATA_X_MSB_ADDR = 0X09,
+        BNO055_ACCEL_DATA_Y_LSB_ADDR = 0X0A,
+        BNO055_ACCEL_DATA_Y_MSB_ADDR = 0X0B,
+        BNO055_ACCEL_DATA_Z_LSB_ADDR = 0X0C,
+        BNO055_ACCEL_DATA_Z_MSB_ADDR = 0X0D,
 
-    /* Mag data register */
-    BNO055_MAG_DATA_X_LSB_ADDR = 0X0E,
-    BNO055_MAG_DATA_X_MSB_ADDR = 0X0F,
-    BNO055_MAG_DATA_Y_LSB_ADDR = 0X10,
-    BNO055_MAG_DATA_Y_MSB_ADDR = 0X11,
-    BNO055_MAG_DATA_Z_LSB_ADDR = 0X12,
-    BNO055_MAG_DATA_Z_MSB_ADDR = 0X13,
+        /* Mag data register */
+        BNO055_MAG_DATA_X_LSB_ADDR = 0X0E,
+        BNO055_MAG_DATA_X_MSB_ADDR = 0X0F,
+        BNO055_MAG_DATA_Y_LSB_ADDR = 0X10,
+        BNO055_MAG_DATA_Y_MSB_ADDR = 0X11,
+        BNO055_MAG_DATA_Z_LSB_ADDR = 0X12,
+        BNO055_MAG_DATA_Z_MSB_ADDR = 0X13,
 
-    /* Gyro data registers */
-    BNO055_GYRO_DATA_X_LSB_ADDR = 0X14,
-    BNO055_GYRO_DATA_X_MSB_ADDR = 0X15,
-    BNO055_GYRO_DATA_Y_LSB_ADDR = 0X16,
-    BNO055_GYRO_DATA_Y_MSB_ADDR = 0X17,
-    BNO055_GYRO_DATA_Z_LSB_ADDR = 0X18,
-    BNO055_GYRO_DATA_Z_MSB_ADDR = 0X19,
+        /* Gyro data registers */
+        BNO055_GYRO_DATA_X_LSB_ADDR = 0X14,
+        BNO055_GYRO_DATA_X_MSB_ADDR = 0X15,
+        BNO055_GYRO_DATA_Y_LSB_ADDR = 0X16,
+        BNO055_GYRO_DATA_Y_MSB_ADDR = 0X17,
+        BNO055_GYRO_DATA_Z_LSB_ADDR = 0X18,
+        BNO055_GYRO_DATA_Z_MSB_ADDR = 0X19,
 
-    /* Euler data registers */
-    BNO055_EULER_H_LSB_ADDR = 0X1A,
-    BNO055_EULER_H_MSB_ADDR = 0X1B,
-    BNO055_EULER_R_LSB_ADDR = 0X1C,
-    BNO055_EULER_R_MSB_ADDR = 0X1D,
-    BNO055_EULER_P_LSB_ADDR = 0X1E,
-    BNO055_EULER_P_MSB_ADDR = 0X1F,
+        /* Euler data registers */
+        BNO055_EULER_H_LSB_ADDR = 0X1A,
+        BNO055_EULER_H_MSB_ADDR = 0X1B,
+        BNO055_EULER_R_LSB_ADDR = 0X1C,
+        BNO055_EULER_R_MSB_ADDR = 0X1D,
+        BNO055_EULER_P_LSB_ADDR = 0X1E,
+        BNO055_EULER_P_MSB_ADDR = 0X1F,
 
-    /* Quaternion data registers */
-    BNO055_QUATERNION_DATA_W_LSB_ADDR = 0X20,
-    BNO055_QUATERNION_DATA_W_MSB_ADDR = 0X21,
-    BNO055_QUATERNION_DATA_X_LSB_ADDR = 0X22,
-    BNO055_QUATERNION_DATA_X_MSB_ADDR = 0X23,
-    BNO055_QUATERNION_DATA_Y_LSB_ADDR = 0X24,
-    BNO055_QUATERNION_DATA_Y_MSB_ADDR = 0X25,
-    BNO055_QUATERNION_DATA_Z_LSB_ADDR = 0X26,
-    BNO055_QUATERNION_DATA_Z_MSB_ADDR = 0X27,
+        /* Quaternion data registers */
+        BNO055_QUATERNION_DATA_W_LSB_ADDR = 0X20,
+        BNO055_QUATERNION_DATA_W_MSB_ADDR = 0X21,
+        BNO055_QUATERNION_DATA_X_LSB_ADDR = 0X22,
+        BNO055_QUATERNION_DATA_X_MSB_ADDR = 0X23,
+        BNO055_QUATERNION_DATA_Y_LSB_ADDR = 0X24,
+        BNO055_QUATERNION_DATA_Y_MSB_ADDR = 0X25,
+        BNO055_QUATERNION_DATA_Z_LSB_ADDR = 0X26,
+        BNO055_QUATERNION_DATA_Z_MSB_ADDR = 0X27,
 
-    /* Linear acceleration data registers */
-    BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR = 0X28,
-    BNO055_LINEAR_ACCEL_DATA_X_MSB_ADDR = 0X29,
-    BNO055_LINEAR_ACCEL_DATA_Y_LSB_ADDR = 0X2A,
-    BNO055_LINEAR_ACCEL_DATA_Y_MSB_ADDR = 0X2B,
-    BNO055_LINEAR_ACCEL_DATA_Z_LSB_ADDR = 0X2C,
-    BNO055_LINEAR_ACCEL_DATA_Z_MSB_ADDR = 0X2D,
+        /* Linear acceleration data registers */
+        BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR = 0X28,
+        BNO055_LINEAR_ACCEL_DATA_X_MSB_ADDR = 0X29,
+        BNO055_LINEAR_ACCEL_DATA_Y_LSB_ADDR = 0X2A,
+        BNO055_LINEAR_ACCEL_DATA_Y_MSB_ADDR = 0X2B,
+        BNO055_LINEAR_ACCEL_DATA_Z_LSB_ADDR = 0X2C,
+        BNO055_LINEAR_ACCEL_DATA_Z_MSB_ADDR = 0X2D,
 
-    /* Gravity data registers */
-    BNO055_GRAVITY_DATA_X_LSB_ADDR = 0X2E,
-    BNO055_GRAVITY_DATA_X_MSB_ADDR = 0X2F,
-    BNO055_GRAVITY_DATA_Y_LSB_ADDR = 0X30,
-    BNO055_GRAVITY_DATA_Y_MSB_ADDR = 0X31,
-    BNO055_GRAVITY_DATA_Z_LSB_ADDR = 0X32,
-    BNO055_GRAVITY_DATA_Z_MSB_ADDR = 0X33,
+        /* Gravity data registers */
+        BNO055_GRAVITY_DATA_X_LSB_ADDR = 0X2E,
+        BNO055_GRAVITY_DATA_X_MSB_ADDR = 0X2F,
+        BNO055_GRAVITY_DATA_Y_LSB_ADDR = 0X30,
+        BNO055_GRAVITY_DATA_Y_MSB_ADDR = 0X31,
+        BNO055_GRAVITY_DATA_Z_LSB_ADDR = 0X32,
+        BNO055_GRAVITY_DATA_Z_MSB_ADDR = 0X33,
 
-    /* Temperature data register */
-    BNO055_TEMP_ADDR = 0X34,
+        /* Temperature data register */
+        BNO055_TEMP_ADDR = 0X34,
 
-    /* Status registers */
-    BNO055_CALIB_STAT_ADDR = 0X35,
-    BNO055_SELFTEST_RESULT_ADDR = 0X36,
-    BNO055_INTR_STAT_ADDR = 0X37,
+        /* Status registers */
+        BNO055_CALIB_STAT_ADDR = 0X35,
+        BNO055_SELFTEST_RESULT_ADDR = 0X36,
+        BNO055_INTR_STAT_ADDR = 0X37,
 
-    BNO055_SYS_CLK_STAT_ADDR = 0X38,
-    BNO055_SYS_STAT_ADDR = 0X39,
-    BNO055_SYS_ERR_ADDR = 0X3A,
+        BNO055_SYS_CLK_STAT_ADDR = 0X38,
+        BNO055_SYS_STAT_ADDR = 0X39,
+        BNO055_SYS_ERR_ADDR = 0X3A,
 
-    /* Unit selection register */
-    BNO055_UNIT_SEL_ADDR = 0X3B,
+        /* Unit selection register */
+        BNO055_UNIT_SEL_ADDR = 0X3B,
 
-    /* Mode registers */
-    BNO055_OPR_MODE_ADDR = 0X3D,
-    BNO055_PWR_MODE_ADDR = 0X3E,
+        /* Mode registers */
+        BNO055_OPR_MODE_ADDR = 0X3D,
+        BNO055_PWR_MODE_ADDR = 0X3E,
 
-    BNO055_SYS_TRIGGER_ADDR = 0X3F,
-    BNO055_TEMP_SOURCE_ADDR = 0X40,
+        BNO055_SYS_TRIGGER_ADDR = 0X3F,
+        BNO055_TEMP_SOURCE_ADDR = 0X40,
 
-    /* Axis remap registers */
-    BNO055_AXIS_MAP_CONFIG_ADDR = 0X41,
-    BNO055_AXIS_MAP_SIGN_ADDR = 0X42,
+        /* Axis remap registers */
+        BNO055_AXIS_MAP_CONFIG_ADDR = 0X41,
+        BNO055_AXIS_MAP_SIGN_ADDR = 0X42,
 
-    /* SIC registers */
-    BNO055_SIC_MATRIX_0_LSB_ADDR = 0X43,
-    BNO055_SIC_MATRIX_0_MSB_ADDR = 0X44,
-    BNO055_SIC_MATRIX_1_LSB_ADDR = 0X45,
-    BNO055_SIC_MATRIX_1_MSB_ADDR = 0X46,
-    BNO055_SIC_MATRIX_2_LSB_ADDR = 0X47,
-    BNO055_SIC_MATRIX_2_MSB_ADDR = 0X48,
-    BNO055_SIC_MATRIX_3_LSB_ADDR = 0X49,
-    BNO055_SIC_MATRIX_3_MSB_ADDR = 0X4A,
-    BNO055_SIC_MATRIX_4_LSB_ADDR = 0X4B,
-    BNO055_SIC_MATRIX_4_MSB_ADDR = 0X4C,
-    BNO055_SIC_MATRIX_5_LSB_ADDR = 0X4D,
-    BNO055_SIC_MATRIX_5_MSB_ADDR = 0X4E,
-    BNO055_SIC_MATRIX_6_LSB_ADDR = 0X4F,
-    BNO055_SIC_MATRIX_6_MSB_ADDR = 0X50,
-    BNO055_SIC_MATRIX_7_LSB_ADDR = 0X51,
-    BNO055_SIC_MATRIX_7_MSB_ADDR = 0X52,
-    BNO055_SIC_MATRIX_8_LSB_ADDR = 0X53,
-    BNO055_SIC_MATRIX_8_MSB_ADDR = 0X54,
+        /* SIC registers */
+        BNO055_SIC_MATRIX_0_LSB_ADDR = 0X43,
+        BNO055_SIC_MATRIX_0_MSB_ADDR = 0X44,
+        BNO055_SIC_MATRIX_1_LSB_ADDR = 0X45,
+        BNO055_SIC_MATRIX_1_MSB_ADDR = 0X46,
+        BNO055_SIC_MATRIX_2_LSB_ADDR = 0X47,
+        BNO055_SIC_MATRIX_2_MSB_ADDR = 0X48,
+        BNO055_SIC_MATRIX_3_LSB_ADDR = 0X49,
+        BNO055_SIC_MATRIX_3_MSB_ADDR = 0X4A,
+        BNO055_SIC_MATRIX_4_LSB_ADDR = 0X4B,
+        BNO055_SIC_MATRIX_4_MSB_ADDR = 0X4C,
+        BNO055_SIC_MATRIX_5_LSB_ADDR = 0X4D,
+        BNO055_SIC_MATRIX_5_MSB_ADDR = 0X4E,
+        BNO055_SIC_MATRIX_6_LSB_ADDR = 0X4F,
+        BNO055_SIC_MATRIX_6_MSB_ADDR = 0X50,
+        BNO055_SIC_MATRIX_7_LSB_ADDR = 0X51,
+        BNO055_SIC_MATRIX_7_MSB_ADDR = 0X52,
+        BNO055_SIC_MATRIX_8_LSB_ADDR = 0X53,
+        BNO055_SIC_MATRIX_8_MSB_ADDR = 0X54,
 
-    /* Accelerometer Offset registers */
-    ACCEL_OFFSET_X_LSB_ADDR = 0X55,
-    ACCEL_OFFSET_X_MSB_ADDR = 0X56,
-    ACCEL_OFFSET_Y_LSB_ADDR = 0X57,
-    ACCEL_OFFSET_Y_MSB_ADDR = 0X58,
-    ACCEL_OFFSET_Z_LSB_ADDR = 0X59,
-    ACCEL_OFFSET_Z_MSB_ADDR = 0X5A,
+        /* Accelerometer Offset registers */
+        ACCEL_OFFSET_X_LSB_ADDR = 0X55,
+        ACCEL_OFFSET_X_MSB_ADDR = 0X56,
+        ACCEL_OFFSET_Y_LSB_ADDR = 0X57,
+        ACCEL_OFFSET_Y_MSB_ADDR = 0X58,
+        ACCEL_OFFSET_Z_LSB_ADDR = 0X59,
+        ACCEL_OFFSET_Z_MSB_ADDR = 0X5A,
 
-    /* Magnetometer Offset registers */
-    MAG_OFFSET_X_LSB_ADDR = 0X5B,
-    MAG_OFFSET_X_MSB_ADDR = 0X5C,
-    MAG_OFFSET_Y_LSB_ADDR = 0X5D,
-    MAG_OFFSET_Y_MSB_ADDR = 0X5E,
-    MAG_OFFSET_Z_LSB_ADDR = 0X5F,
-    MAG_OFFSET_Z_MSB_ADDR = 0X60,
+        /* Magnetometer Offset registers */
+        MAG_OFFSET_X_LSB_ADDR = 0X5B,
+        MAG_OFFSET_X_MSB_ADDR = 0X5C,
+        MAG_OFFSET_Y_LSB_ADDR = 0X5D,
+        MAG_OFFSET_Y_MSB_ADDR = 0X5E,
+        MAG_OFFSET_Z_LSB_ADDR = 0X5F,
+        MAG_OFFSET_Z_MSB_ADDR = 0X60,
 
-    /* Gyroscope Offset register s*/
-    GYRO_OFFSET_X_LSB_ADDR = 0X61,
-    GYRO_OFFSET_X_MSB_ADDR = 0X62,
-    GYRO_OFFSET_Y_LSB_ADDR = 0X63,
-    GYRO_OFFSET_Y_MSB_ADDR = 0X64,
-    GYRO_OFFSET_Z_LSB_ADDR = 0X65,
-    GYRO_OFFSET_Z_MSB_ADDR = 0X66,
+        /* Gyroscope Offset register s*/
+        GYRO_OFFSET_X_LSB_ADDR = 0X61,
+        GYRO_OFFSET_X_MSB_ADDR = 0X62,
+        GYRO_OFFSET_Y_LSB_ADDR = 0X63,
+        GYRO_OFFSET_Y_MSB_ADDR = 0X64,
+        GYRO_OFFSET_Z_LSB_ADDR = 0X65,
+        GYRO_OFFSET_Z_MSB_ADDR = 0X66,
 
-    /* Radius registers */
-    ACCEL_RADIUS_LSB_ADDR = 0X67,
-    ACCEL_RADIUS_MSB_ADDR = 0X68,
-    MAG_RADIUS_LSB_ADDR = 0X69,
-    MAG_RADIUS_MSB_ADDR = 0X6A
-  } adafruit_bno055_reg_t;
+        /* Radius registers */
+        ACCEL_RADIUS_LSB_ADDR = 0X67,
+        ACCEL_RADIUS_MSB_ADDR = 0X68,
+        MAG_RADIUS_LSB_ADDR = 0X69,
+        MAG_RADIUS_MSB_ADDR = 0X6A
+    } adafruit_bno055_reg_t;
 
-  /** BNO055 power settings */
-  typedef enum {
-    POWER_MODE_NORMAL = 0X00,
-    POWER_MODE_LOWPOWER = 0X01,
-    POWER_MODE_SUSPEND = 0X02
-  } adafruit_bno055_powermode_t;
+    /** BNO055 power settings */
+    typedef enum {
+        POWER_MODE_NORMAL = 0X00,
+        POWER_MODE_LOWPOWER = 0X01,
+        POWER_MODE_SUSPEND = 0X02
+    } adafruit_bno055_powermode_t;
 
-  /** Remap settings **/
-  typedef enum {
-    REMAP_CONFIG_P0 = 0x21,
-    REMAP_CONFIG_P1 = 0x24, // default
-    REMAP_CONFIG_P2 = 0x24,
-    REMAP_CONFIG_P3 = 0x21,
-    REMAP_CONFIG_P4 = 0x24,
-    REMAP_CONFIG_P5 = 0x21,
-    REMAP_CONFIG_P6 = 0x21,
-    REMAP_CONFIG_P7 = 0x24
-  } adafruit_bno055_axis_remap_config_t;
+    /** Remap settings **/
+    typedef enum {
+        REMAP_CONFIG_P0 = 0x21,
+        REMAP_CONFIG_P1 = 0x24, // default
+        REMAP_CONFIG_P2 = 0x24,
+        REMAP_CONFIG_P3 = 0x21,
+        REMAP_CONFIG_P4 = 0x24,
+        REMAP_CONFIG_P5 = 0x21,
+        REMAP_CONFIG_P6 = 0x21,
+        REMAP_CONFIG_P7 = 0x24
+    } adafruit_bno055_axis_remap_config_t;
 
-  /** Remap Signs **/
-  typedef enum {
-    REMAP_SIGN_P0 = 0x04,
-    REMAP_SIGN_P1 = 0x00, // default
-    REMAP_SIGN_P2 = 0x06,
-    REMAP_SIGN_P3 = 0x02,
-    REMAP_SIGN_P4 = 0x03,
-    REMAP_SIGN_P5 = 0x01,
-    REMAP_SIGN_P6 = 0x07,
-    REMAP_SIGN_P7 = 0x05
-  } adafruit_bno055_axis_remap_sign_t;
+    /** Remap Signs **/
+    typedef enum {
+        REMAP_SIGN_P0 = 0x04,
+        REMAP_SIGN_P1 = 0x00, // default
+        REMAP_SIGN_P2 = 0x06,
+        REMAP_SIGN_P3 = 0x02,
+        REMAP_SIGN_P4 = 0x03,
+        REMAP_SIGN_P5 = 0x01,
+        REMAP_SIGN_P6 = 0x07,
+        REMAP_SIGN_P7 = 0x05
+    } adafruit_bno055_axis_remap_sign_t;
 
-  /** A structure to represent revisions **/
-  typedef struct {
-    uint8_t accel_rev; /**< acceleration rev */
-    uint8_t mag_rev;   /**< magnetometer rev */
-    uint8_t gyro_rev;  /**< gyroscrope rev */
-    uint16_t sw_rev;   /**< SW rev */
-    uint8_t bl_rev;    /**< bootloader rev */
-  } adafruit_bno055_rev_info_t;
+    /** A structure to represent revisions **/
+    typedef struct {
+        uint8_t accel_rev; /**< acceleration rev */
+        uint8_t mag_rev;   /**< magnetometer rev */
+        uint8_t gyro_rev;  /**< gyroscrope rev */
+        uint16_t sw_rev;   /**< SW rev */
+        uint8_t bl_rev;    /**< bootloader rev */
+    } adafruit_bno055_rev_info_t;
 
-  /** Vector Mappings **/
-  typedef enum {
-    VECTOR_ACCELEROMETER = BNO055_ACCEL_DATA_X_LSB_ADDR,
-    VECTOR_MAGNETOMETER = BNO055_MAG_DATA_X_LSB_ADDR,
-    VECTOR_GYROSCOPE = BNO055_GYRO_DATA_X_LSB_ADDR,
-    VECTOR_EULER = BNO055_EULER_H_LSB_ADDR,
-    VECTOR_LINEARACCEL = BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR,
-    VECTOR_GRAVITY = BNO055_GRAVITY_DATA_X_LSB_ADDR
-  } adafruit_vector_type_t;
+    /** Vector Mappings **/
+    typedef enum {
+        VECTOR_ACCELEROMETER = BNO055_ACCEL_DATA_X_LSB_ADDR,
+        VECTOR_MAGNETOMETER = BNO055_MAG_DATA_X_LSB_ADDR,
+        VECTOR_GYROSCOPE = BNO055_GYRO_DATA_X_LSB_ADDR,
+        VECTOR_EULER = BNO055_EULER_H_LSB_ADDR,
+        VECTOR_LINEARACCEL = BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR,
+        VECTOR_GRAVITY = BNO055_GRAVITY_DATA_X_LSB_ADDR
+    } adafruit_vector_type_t;
 
-  IMU_BNO055(int32_t sensorID = -1, uint8_t address = BNO055_ADDRESS_A,
-                  I2C *theWire = &Wire);
+    IMU_BNO055(int32_t sensorID = -1, uint8_t address = BNO055_ADDRESS_A,
+        I2C* theWire = &Wire);
 
-  bool begin(adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF);
-  void setMode(adafruit_bno055_opmode_t mode);
-  adafruit_bno055_opmode_t getMode();
-  void setAxisRemap(adafruit_bno055_axis_remap_config_t remapcode);
-  void setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign);
-  void getRevInfo(adafruit_bno055_rev_info_t *);
-  void setExtCrystalUse(boolean usextal);
-  void getSystemStatus(uint8_t *system_status, uint8_t *self_test_result,
-                       uint8_t *system_error);
-  void getCalibration(uint8_t *system, uint8_t *gyro, uint8_t *accel,
-                      uint8_t *mag);
+    bool begin(adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF);
+    void setMode(adafruit_bno055_opmode_t mode);
+    adafruit_bno055_opmode_t getMode();
+    void setAxisRemap(adafruit_bno055_axis_remap_config_t remapcode);
+    void setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign);
+    void getRevInfo(adafruit_bno055_rev_info_t*);
+    void setExtCrystalUse(boolean usextal);
+    void getSystemStatus(uint8_t* system_status, uint8_t* self_test_result,
+        uint8_t* system_error);
+    void getCalibration(uint8_t* system, uint8_t* gyro, uint8_t* accel,
+        uint8_t* mag);
 
-  imu::Vector<3> getVector(adafruit_vector_type_t vector_type);
-  imu::Quaternion getQuat();
-  int8_t getTemp();
+    imu::Vector<3> getVector(adafruit_vector_type_t vector_type);
+    imu::Quaternion getQuat();
+    int8_t getTemp();
 
-  /* Unified_Sensor implementation */
-  bool getEvent(sensors_event_t *);
-  bool getEvent(sensors_event_t *, adafruit_vector_type_t);
-  void getSensor(sensor_t *);
+    /* Unified_Sensor implementation */
+    bool getEvent(sensors_event_t*);
+    bool getEvent(sensors_event_t*, adafruit_vector_type_t);
+    void getSensor(sensor_t*);
 
-  /* Functions to deal with raw calibration data */
-  bool getSensorOffsets(uint8_t *calibData);
-  bool getSensorOffsets(adafruit_bno055_offsets_t &offsets_type);
-  void setSensorOffsets(const uint8_t *calibData);
-  void setSensorOffsets(const adafruit_bno055_offsets_t &offsets_type);
-  bool isFullyCalibrated();
+    /* Functions to deal with raw calibration data */
+    bool getSensorOffsets(uint8_t* calibData);
+    bool getSensorOffsets(adafruit_bno055_offsets_t& offsets_type);
+    void setSensorOffsets(const uint8_t* calibData);
+    void setSensorOffsets(const adafruit_bno055_offsets_t& offsets_type);
+    bool isFullyCalibrated();
 
-  /* Power managments functions */
-  void enterSuspendMode();
-  void enterNormalMode();
+    /* Power managments functions */
+    void enterSuspendMode();
+    void enterNormalMode();
 
 private:
-  byte read8(adafruit_bno055_reg_t);
-  bool readLen(adafruit_bno055_reg_t, byte *buffer, uint8_t len);
-  bool write8(adafruit_bno055_reg_t, byte value);
+    byte read8(adafruit_bno055_reg_t);
+    bool readLen(adafruit_bno055_reg_t, byte* buffer, uint8_t len);
+    bool write8(adafruit_bno055_reg_t, byte value);
 
-  BusIO_I2C_Target *i2c_dev = NULL; ///< Pointer to I2C bus interface
+    BusIO_I2C_Target* i2c_dev = NULL; ///< Pointer to I2C bus interface
 
-  int32_t _sensorID;
-  adafruit_bno055_opmode_t _mode;
+    int32_t _sensorID;
+    adafruit_bno055_opmode_t _mode;
 };

--- a/examples/ahrs_telemetry/imu_bno055.h
+++ b/examples/ahrs_telemetry/imu_bno055.h
@@ -1,0 +1,315 @@
+/**
+ * @file imu_bno055.h
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief An IMU driver library for the BNO055, based on Adafruit's BNO055 library.
+ * @version 0.2.0
+ * @date 2023-02-08
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+#pragma once
+
+#include "Arduino.h"
+
+#include "imu_imumaths.h"
+#include "busio_i2c_target.h"
+#include "unified_sensor.h"
+
+/** BNO055 Address A **/
+#define BNO055_ADDRESS_A (0x28)
+/** BNO055 Address B **/
+#define BNO055_ADDRESS_B (0x29)
+/** BNO055 ID **/
+#define BNO055_ID (0xA0)
+
+/** Offsets registers **/
+#define NUM_BNO055_OFFSET_REGISTERS (22)
+
+/** A structure to represent offsets **/
+typedef struct {
+  int16_t accel_offset_x; /**< x acceleration offset */
+  int16_t accel_offset_y; /**< y acceleration offset */
+  int16_t accel_offset_z; /**< z acceleration offset */
+
+  int16_t mag_offset_x; /**< x magnetometer offset */
+  int16_t mag_offset_y; /**< y magnetometer offset */
+  int16_t mag_offset_z; /**< z magnetometer offset */
+
+  int16_t gyro_offset_x; /**< x gyroscrope offset */
+  int16_t gyro_offset_y; /**< y gyroscrope offset */
+  int16_t gyro_offset_z; /**< z gyroscrope offset */
+
+  int16_t accel_radius; /**< acceleration radius */
+
+  int16_t mag_radius; /**< magnetometer radius */
+} adafruit_bno055_offsets_t;
+
+/** Operation mode settings **/
+typedef enum {
+  OPERATION_MODE_CONFIG = 0X00,
+  OPERATION_MODE_ACCONLY = 0X01,
+  OPERATION_MODE_MAGONLY = 0X02,
+  OPERATION_MODE_GYRONLY = 0X03,
+  OPERATION_MODE_ACCMAG = 0X04,
+  OPERATION_MODE_ACCGYRO = 0X05,
+  OPERATION_MODE_MAGGYRO = 0X06,
+  OPERATION_MODE_AMG = 0X07,
+  OPERATION_MODE_IMUPLUS = 0X08,
+  OPERATION_MODE_COMPASS = 0X09,
+  OPERATION_MODE_M4G = 0X0A,
+  OPERATION_MODE_NDOF_FMC_OFF = 0X0B,
+  OPERATION_MODE_NDOF = 0X0C
+} adafruit_bno055_opmode_t;
+
+/*!
+ *  @brief  Class that stores state and functions for interacting with
+ *          BNO055 Sensor
+ */
+class IMU_BNO055 : public Unified_Sensor {
+public:
+  /** BNO055 Registers **/
+  typedef enum {
+    /* Page id register definition */
+    BNO055_PAGE_ID_ADDR = 0X07,
+
+    /* PAGE0 REGISTER DEFINITION START*/
+    BNO055_CHIP_ID_ADDR = 0x00,
+    BNO055_ACCEL_REV_ID_ADDR = 0x01,
+    BNO055_MAG_REV_ID_ADDR = 0x02,
+    BNO055_GYRO_REV_ID_ADDR = 0x03,
+    BNO055_SW_REV_ID_LSB_ADDR = 0x04,
+    BNO055_SW_REV_ID_MSB_ADDR = 0x05,
+    BNO055_BL_REV_ID_ADDR = 0X06,
+
+    /* Accel data register */
+    BNO055_ACCEL_DATA_X_LSB_ADDR = 0X08,
+    BNO055_ACCEL_DATA_X_MSB_ADDR = 0X09,
+    BNO055_ACCEL_DATA_Y_LSB_ADDR = 0X0A,
+    BNO055_ACCEL_DATA_Y_MSB_ADDR = 0X0B,
+    BNO055_ACCEL_DATA_Z_LSB_ADDR = 0X0C,
+    BNO055_ACCEL_DATA_Z_MSB_ADDR = 0X0D,
+
+    /* Mag data register */
+    BNO055_MAG_DATA_X_LSB_ADDR = 0X0E,
+    BNO055_MAG_DATA_X_MSB_ADDR = 0X0F,
+    BNO055_MAG_DATA_Y_LSB_ADDR = 0X10,
+    BNO055_MAG_DATA_Y_MSB_ADDR = 0X11,
+    BNO055_MAG_DATA_Z_LSB_ADDR = 0X12,
+    BNO055_MAG_DATA_Z_MSB_ADDR = 0X13,
+
+    /* Gyro data registers */
+    BNO055_GYRO_DATA_X_LSB_ADDR = 0X14,
+    BNO055_GYRO_DATA_X_MSB_ADDR = 0X15,
+    BNO055_GYRO_DATA_Y_LSB_ADDR = 0X16,
+    BNO055_GYRO_DATA_Y_MSB_ADDR = 0X17,
+    BNO055_GYRO_DATA_Z_LSB_ADDR = 0X18,
+    BNO055_GYRO_DATA_Z_MSB_ADDR = 0X19,
+
+    /* Euler data registers */
+    BNO055_EULER_H_LSB_ADDR = 0X1A,
+    BNO055_EULER_H_MSB_ADDR = 0X1B,
+    BNO055_EULER_R_LSB_ADDR = 0X1C,
+    BNO055_EULER_R_MSB_ADDR = 0X1D,
+    BNO055_EULER_P_LSB_ADDR = 0X1E,
+    BNO055_EULER_P_MSB_ADDR = 0X1F,
+
+    /* Quaternion data registers */
+    BNO055_QUATERNION_DATA_W_LSB_ADDR = 0X20,
+    BNO055_QUATERNION_DATA_W_MSB_ADDR = 0X21,
+    BNO055_QUATERNION_DATA_X_LSB_ADDR = 0X22,
+    BNO055_QUATERNION_DATA_X_MSB_ADDR = 0X23,
+    BNO055_QUATERNION_DATA_Y_LSB_ADDR = 0X24,
+    BNO055_QUATERNION_DATA_Y_MSB_ADDR = 0X25,
+    BNO055_QUATERNION_DATA_Z_LSB_ADDR = 0X26,
+    BNO055_QUATERNION_DATA_Z_MSB_ADDR = 0X27,
+
+    /* Linear acceleration data registers */
+    BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR = 0X28,
+    BNO055_LINEAR_ACCEL_DATA_X_MSB_ADDR = 0X29,
+    BNO055_LINEAR_ACCEL_DATA_Y_LSB_ADDR = 0X2A,
+    BNO055_LINEAR_ACCEL_DATA_Y_MSB_ADDR = 0X2B,
+    BNO055_LINEAR_ACCEL_DATA_Z_LSB_ADDR = 0X2C,
+    BNO055_LINEAR_ACCEL_DATA_Z_MSB_ADDR = 0X2D,
+
+    /* Gravity data registers */
+    BNO055_GRAVITY_DATA_X_LSB_ADDR = 0X2E,
+    BNO055_GRAVITY_DATA_X_MSB_ADDR = 0X2F,
+    BNO055_GRAVITY_DATA_Y_LSB_ADDR = 0X30,
+    BNO055_GRAVITY_DATA_Y_MSB_ADDR = 0X31,
+    BNO055_GRAVITY_DATA_Z_LSB_ADDR = 0X32,
+    BNO055_GRAVITY_DATA_Z_MSB_ADDR = 0X33,
+
+    /* Temperature data register */
+    BNO055_TEMP_ADDR = 0X34,
+
+    /* Status registers */
+    BNO055_CALIB_STAT_ADDR = 0X35,
+    BNO055_SELFTEST_RESULT_ADDR = 0X36,
+    BNO055_INTR_STAT_ADDR = 0X37,
+
+    BNO055_SYS_CLK_STAT_ADDR = 0X38,
+    BNO055_SYS_STAT_ADDR = 0X39,
+    BNO055_SYS_ERR_ADDR = 0X3A,
+
+    /* Unit selection register */
+    BNO055_UNIT_SEL_ADDR = 0X3B,
+
+    /* Mode registers */
+    BNO055_OPR_MODE_ADDR = 0X3D,
+    BNO055_PWR_MODE_ADDR = 0X3E,
+
+    BNO055_SYS_TRIGGER_ADDR = 0X3F,
+    BNO055_TEMP_SOURCE_ADDR = 0X40,
+
+    /* Axis remap registers */
+    BNO055_AXIS_MAP_CONFIG_ADDR = 0X41,
+    BNO055_AXIS_MAP_SIGN_ADDR = 0X42,
+
+    /* SIC registers */
+    BNO055_SIC_MATRIX_0_LSB_ADDR = 0X43,
+    BNO055_SIC_MATRIX_0_MSB_ADDR = 0X44,
+    BNO055_SIC_MATRIX_1_LSB_ADDR = 0X45,
+    BNO055_SIC_MATRIX_1_MSB_ADDR = 0X46,
+    BNO055_SIC_MATRIX_2_LSB_ADDR = 0X47,
+    BNO055_SIC_MATRIX_2_MSB_ADDR = 0X48,
+    BNO055_SIC_MATRIX_3_LSB_ADDR = 0X49,
+    BNO055_SIC_MATRIX_3_MSB_ADDR = 0X4A,
+    BNO055_SIC_MATRIX_4_LSB_ADDR = 0X4B,
+    BNO055_SIC_MATRIX_4_MSB_ADDR = 0X4C,
+    BNO055_SIC_MATRIX_5_LSB_ADDR = 0X4D,
+    BNO055_SIC_MATRIX_5_MSB_ADDR = 0X4E,
+    BNO055_SIC_MATRIX_6_LSB_ADDR = 0X4F,
+    BNO055_SIC_MATRIX_6_MSB_ADDR = 0X50,
+    BNO055_SIC_MATRIX_7_LSB_ADDR = 0X51,
+    BNO055_SIC_MATRIX_7_MSB_ADDR = 0X52,
+    BNO055_SIC_MATRIX_8_LSB_ADDR = 0X53,
+    BNO055_SIC_MATRIX_8_MSB_ADDR = 0X54,
+
+    /* Accelerometer Offset registers */
+    ACCEL_OFFSET_X_LSB_ADDR = 0X55,
+    ACCEL_OFFSET_X_MSB_ADDR = 0X56,
+    ACCEL_OFFSET_Y_LSB_ADDR = 0X57,
+    ACCEL_OFFSET_Y_MSB_ADDR = 0X58,
+    ACCEL_OFFSET_Z_LSB_ADDR = 0X59,
+    ACCEL_OFFSET_Z_MSB_ADDR = 0X5A,
+
+    /* Magnetometer Offset registers */
+    MAG_OFFSET_X_LSB_ADDR = 0X5B,
+    MAG_OFFSET_X_MSB_ADDR = 0X5C,
+    MAG_OFFSET_Y_LSB_ADDR = 0X5D,
+    MAG_OFFSET_Y_MSB_ADDR = 0X5E,
+    MAG_OFFSET_Z_LSB_ADDR = 0X5F,
+    MAG_OFFSET_Z_MSB_ADDR = 0X60,
+
+    /* Gyroscope Offset register s*/
+    GYRO_OFFSET_X_LSB_ADDR = 0X61,
+    GYRO_OFFSET_X_MSB_ADDR = 0X62,
+    GYRO_OFFSET_Y_LSB_ADDR = 0X63,
+    GYRO_OFFSET_Y_MSB_ADDR = 0X64,
+    GYRO_OFFSET_Z_LSB_ADDR = 0X65,
+    GYRO_OFFSET_Z_MSB_ADDR = 0X66,
+
+    /* Radius registers */
+    ACCEL_RADIUS_LSB_ADDR = 0X67,
+    ACCEL_RADIUS_MSB_ADDR = 0X68,
+    MAG_RADIUS_LSB_ADDR = 0X69,
+    MAG_RADIUS_MSB_ADDR = 0X6A
+  } adafruit_bno055_reg_t;
+
+  /** BNO055 power settings */
+  typedef enum {
+    POWER_MODE_NORMAL = 0X00,
+    POWER_MODE_LOWPOWER = 0X01,
+    POWER_MODE_SUSPEND = 0X02
+  } adafruit_bno055_powermode_t;
+
+  /** Remap settings **/
+  typedef enum {
+    REMAP_CONFIG_P0 = 0x21,
+    REMAP_CONFIG_P1 = 0x24, // default
+    REMAP_CONFIG_P2 = 0x24,
+    REMAP_CONFIG_P3 = 0x21,
+    REMAP_CONFIG_P4 = 0x24,
+    REMAP_CONFIG_P5 = 0x21,
+    REMAP_CONFIG_P6 = 0x21,
+    REMAP_CONFIG_P7 = 0x24
+  } adafruit_bno055_axis_remap_config_t;
+
+  /** Remap Signs **/
+  typedef enum {
+    REMAP_SIGN_P0 = 0x04,
+    REMAP_SIGN_P1 = 0x00, // default
+    REMAP_SIGN_P2 = 0x06,
+    REMAP_SIGN_P3 = 0x02,
+    REMAP_SIGN_P4 = 0x03,
+    REMAP_SIGN_P5 = 0x01,
+    REMAP_SIGN_P6 = 0x07,
+    REMAP_SIGN_P7 = 0x05
+  } adafruit_bno055_axis_remap_sign_t;
+
+  /** A structure to represent revisions **/
+  typedef struct {
+    uint8_t accel_rev; /**< acceleration rev */
+    uint8_t mag_rev;   /**< magnetometer rev */
+    uint8_t gyro_rev;  /**< gyroscrope rev */
+    uint16_t sw_rev;   /**< SW rev */
+    uint8_t bl_rev;    /**< bootloader rev */
+  } adafruit_bno055_rev_info_t;
+
+  /** Vector Mappings **/
+  typedef enum {
+    VECTOR_ACCELEROMETER = BNO055_ACCEL_DATA_X_LSB_ADDR,
+    VECTOR_MAGNETOMETER = BNO055_MAG_DATA_X_LSB_ADDR,
+    VECTOR_GYROSCOPE = BNO055_GYRO_DATA_X_LSB_ADDR,
+    VECTOR_EULER = BNO055_EULER_H_LSB_ADDR,
+    VECTOR_LINEARACCEL = BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR,
+    VECTOR_GRAVITY = BNO055_GRAVITY_DATA_X_LSB_ADDR
+  } adafruit_vector_type_t;
+
+  IMU_BNO055(int32_t sensorID = -1, uint8_t address = BNO055_ADDRESS_A,
+                  I2C *theWire = &Wire);
+
+  bool begin(adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF);
+  void setMode(adafruit_bno055_opmode_t mode);
+  adafruit_bno055_opmode_t getMode();
+  void setAxisRemap(adafruit_bno055_axis_remap_config_t remapcode);
+  void setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign);
+  void getRevInfo(adafruit_bno055_rev_info_t *);
+  void setExtCrystalUse(boolean usextal);
+  void getSystemStatus(uint8_t *system_status, uint8_t *self_test_result,
+                       uint8_t *system_error);
+  void getCalibration(uint8_t *system, uint8_t *gyro, uint8_t *accel,
+                      uint8_t *mag);
+
+  imu::Vector<3> getVector(adafruit_vector_type_t vector_type);
+  imu::Quaternion getQuat();
+  int8_t getTemp();
+
+  /* Unified_Sensor implementation */
+  bool getEvent(sensors_event_t *);
+  bool getEvent(sensors_event_t *, adafruit_vector_type_t);
+  void getSensor(sensor_t *);
+
+  /* Functions to deal with raw calibration data */
+  bool getSensorOffsets(uint8_t *calibData);
+  bool getSensorOffsets(adafruit_bno055_offsets_t &offsets_type);
+  void setSensorOffsets(const uint8_t *calibData);
+  void setSensorOffsets(const adafruit_bno055_offsets_t &offsets_type);
+  bool isFullyCalibrated();
+
+  /* Power managments functions */
+  void enterSuspendMode();
+  void enterNormalMode();
+
+private:
+  byte read8(adafruit_bno055_reg_t);
+  bool readLen(adafruit_bno055_reg_t, byte *buffer, uint8_t len);
+  bool write8(adafruit_bno055_reg_t, byte value);
+
+  BusIO_I2C_Target *i2c_dev = NULL; ///< Pointer to I2C bus interface
+
+  int32_t _sensorID;
+  adafruit_bno055_opmode_t _mode;
+};

--- a/examples/ahrs_telemetry/imu_imumaths.h
+++ b/examples/ahrs_telemetry/imu_imumaths.h
@@ -1,0 +1,28 @@
+
+//  Inertial Measurement Unit Maths Library
+//
+//  Copyright 2013-2021 Sam Cowen <samuel.cowen@camelsoftware.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//  DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include "imu_matrix.h"
+#include "imu_quaternion.h"
+#include "imu_vector.h"

--- a/examples/ahrs_telemetry/imu_matrix.h
+++ b/examples/ahrs_telemetry/imu_matrix.h
@@ -1,0 +1,182 @@
+//  Inertial Measurement Unit Maths Library
+//
+//  Copyright 2013-2021 Sam Cowen <samuel.cowen@camelsoftware.com>
+//  Bug fixes and cleanups by Gé Vissers (gvissers@gmail.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//  DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+#include "imu_vector.h"
+
+namespace imu {
+
+template <uint8_t N> class Matrix {
+public:
+  Matrix() { memset(_cell_data, 0, N * N * sizeof(double)); }
+
+  Matrix(const Matrix &m) {
+    for (int ij = 0; ij < N * N; ++ij) {
+      _cell_data[ij] = m._cell_data[ij];
+    }
+  }
+
+  ~Matrix() {}
+
+  Matrix &operator=(const Matrix &m) {
+    for (int ij = 0; ij < N * N; ++ij) {
+      _cell_data[ij] = m._cell_data[ij];
+    }
+    return *this;
+  }
+
+  Vector<N> row_to_vector(int i) const {
+    Vector<N> ret;
+    for (int j = 0; j < N; j++) {
+      ret[j] = cell(i, j);
+    }
+    return ret;
+  }
+
+  Vector<N> col_to_vector(int j) const {
+    Vector<N> ret;
+    for (int i = 0; i < N; i++) {
+      ret[i] = cell(i, j);
+    }
+    return ret;
+  }
+
+  void vector_to_row(const Vector<N> &v, int i) {
+    for (int j = 0; j < N; j++) {
+      cell(i, j) = v[j];
+    }
+  }
+
+  void vector_to_col(const Vector<N> &v, int j) {
+    for (int i = 0; i < N; i++) {
+      cell(i, j) = v[i];
+    }
+  }
+
+  double operator()(int i, int j) const { return cell(i, j); }
+  double &operator()(int i, int j) { return cell(i, j); }
+
+  double cell(int i, int j) const { return _cell_data[i * N + j]; }
+  double &cell(int i, int j) { return _cell_data[i * N + j]; }
+
+  Matrix operator+(const Matrix &m) const {
+    Matrix ret;
+    for (int ij = 0; ij < N * N; ++ij) {
+      ret._cell_data[ij] = _cell_data[ij] + m._cell_data[ij];
+    }
+    return ret;
+  }
+
+  Matrix operator-(const Matrix &m) const {
+    Matrix ret;
+    for (int ij = 0; ij < N * N; ++ij) {
+      ret._cell_data[ij] = _cell_data[ij] - m._cell_data[ij];
+    }
+    return ret;
+  }
+
+  Matrix operator*(double scalar) const {
+    Matrix ret;
+    for (int ij = 0; ij < N * N; ++ij) {
+      ret._cell_data[ij] = _cell_data[ij] * scalar;
+    }
+    return ret;
+  }
+
+  Matrix operator*(const Matrix &m) const {
+    Matrix ret;
+    for (int i = 0; i < N; i++) {
+      Vector<N> row = row_to_vector(i);
+      for (int j = 0; j < N; j++) {
+        ret(i, j) = row.dot(m.col_to_vector(j));
+      }
+    }
+    return ret;
+  }
+
+  Matrix transpose() const {
+    Matrix ret;
+    for (int i = 0; i < N; i++) {
+      for (int j = 0; j < N; j++) {
+        ret(j, i) = cell(i, j);
+      }
+    }
+    return ret;
+  }
+
+  Matrix<N - 1> minor_matrix(int row, int col) const {
+    Matrix<N - 1> ret;
+    for (int i = 0, im = 0; i < N; i++) {
+      if (i == row)
+        continue;
+
+      for (int j = 0, jm = 0; j < N; j++) {
+        if (j != col) {
+          ret(im, jm++) = cell(i, j);
+        }
+      }
+      im++;
+    }
+    return ret;
+  }
+
+  double determinant() const {
+    // specialization for N == 1 given below this class
+    double det = 0.0, sign = 1.0;
+    for (int i = 0; i < N; ++i, sign = -sign)
+      det += sign * cell(0, i) * minor_matrix(0, i).determinant();
+    return det;
+  }
+
+  Matrix invert() const {
+    Matrix ret;
+    double det = determinant();
+
+    for (int i = 0; i < N; i++) {
+      for (int j = 0; j < N; j++) {
+        ret(i, j) = minor_matrix(j, i).determinant() / det;
+        if ((i + j) % 2 == 1)
+          ret(i, j) = -ret(i, j);
+      }
+    }
+    return ret;
+  }
+
+  double trace() const {
+    double tr = 0.0;
+    for (int i = 0; i < N; ++i)
+      tr += cell(i, i);
+    return tr;
+  }
+
+private:
+  double _cell_data[N * N];
+};
+
+template <> inline double Matrix<1>::determinant() const { return cell(0, 0); }
+
+}; // namespace imu

--- a/examples/ahrs_telemetry/imu_matrix.h
+++ b/examples/ahrs_telemetry/imu_matrix.h
@@ -30,153 +30,153 @@
 
 namespace imu {
 
-template <uint8_t N> class Matrix {
-public:
-  Matrix() { memset(_cell_data, 0, N * N * sizeof(double)); }
+    template <uint8_t N> class Matrix {
+    public:
+        Matrix() { memset(_cell_data, 0, N * N * sizeof(double)); }
 
-  Matrix(const Matrix &m) {
-    for (int ij = 0; ij < N * N; ++ij) {
-      _cell_data[ij] = m._cell_data[ij];
-    }
-  }
-
-  ~Matrix() {}
-
-  Matrix &operator=(const Matrix &m) {
-    for (int ij = 0; ij < N * N; ++ij) {
-      _cell_data[ij] = m._cell_data[ij];
-    }
-    return *this;
-  }
-
-  Vector<N> row_to_vector(int i) const {
-    Vector<N> ret;
-    for (int j = 0; j < N; j++) {
-      ret[j] = cell(i, j);
-    }
-    return ret;
-  }
-
-  Vector<N> col_to_vector(int j) const {
-    Vector<N> ret;
-    for (int i = 0; i < N; i++) {
-      ret[i] = cell(i, j);
-    }
-    return ret;
-  }
-
-  void vector_to_row(const Vector<N> &v, int i) {
-    for (int j = 0; j < N; j++) {
-      cell(i, j) = v[j];
-    }
-  }
-
-  void vector_to_col(const Vector<N> &v, int j) {
-    for (int i = 0; i < N; i++) {
-      cell(i, j) = v[i];
-    }
-  }
-
-  double operator()(int i, int j) const { return cell(i, j); }
-  double &operator()(int i, int j) { return cell(i, j); }
-
-  double cell(int i, int j) const { return _cell_data[i * N + j]; }
-  double &cell(int i, int j) { return _cell_data[i * N + j]; }
-
-  Matrix operator+(const Matrix &m) const {
-    Matrix ret;
-    for (int ij = 0; ij < N * N; ++ij) {
-      ret._cell_data[ij] = _cell_data[ij] + m._cell_data[ij];
-    }
-    return ret;
-  }
-
-  Matrix operator-(const Matrix &m) const {
-    Matrix ret;
-    for (int ij = 0; ij < N * N; ++ij) {
-      ret._cell_data[ij] = _cell_data[ij] - m._cell_data[ij];
-    }
-    return ret;
-  }
-
-  Matrix operator*(double scalar) const {
-    Matrix ret;
-    for (int ij = 0; ij < N * N; ++ij) {
-      ret._cell_data[ij] = _cell_data[ij] * scalar;
-    }
-    return ret;
-  }
-
-  Matrix operator*(const Matrix &m) const {
-    Matrix ret;
-    for (int i = 0; i < N; i++) {
-      Vector<N> row = row_to_vector(i);
-      for (int j = 0; j < N; j++) {
-        ret(i, j) = row.dot(m.col_to_vector(j));
-      }
-    }
-    return ret;
-  }
-
-  Matrix transpose() const {
-    Matrix ret;
-    for (int i = 0; i < N; i++) {
-      for (int j = 0; j < N; j++) {
-        ret(j, i) = cell(i, j);
-      }
-    }
-    return ret;
-  }
-
-  Matrix<N - 1> minor_matrix(int row, int col) const {
-    Matrix<N - 1> ret;
-    for (int i = 0, im = 0; i < N; i++) {
-      if (i == row)
-        continue;
-
-      for (int j = 0, jm = 0; j < N; j++) {
-        if (j != col) {
-          ret(im, jm++) = cell(i, j);
+        Matrix(const Matrix& m) {
+            for (int ij = 0; ij < N * N; ++ij) {
+                _cell_data[ij] = m._cell_data[ij];
+            }
         }
-      }
-      im++;
-    }
-    return ret;
-  }
 
-  double determinant() const {
-    // specialization for N == 1 given below this class
-    double det = 0.0, sign = 1.0;
-    for (int i = 0; i < N; ++i, sign = -sign)
-      det += sign * cell(0, i) * minor_matrix(0, i).determinant();
-    return det;
-  }
+        ~Matrix() {}
 
-  Matrix invert() const {
-    Matrix ret;
-    double det = determinant();
+        Matrix& operator=(const Matrix& m) {
+            for (int ij = 0; ij < N * N; ++ij) {
+                _cell_data[ij] = m._cell_data[ij];
+            }
+            return *this;
+        }
 
-    for (int i = 0; i < N; i++) {
-      for (int j = 0; j < N; j++) {
-        ret(i, j) = minor_matrix(j, i).determinant() / det;
-        if ((i + j) % 2 == 1)
-          ret(i, j) = -ret(i, j);
-      }
-    }
-    return ret;
-  }
+        Vector<N> row_to_vector(int i) const {
+            Vector<N> ret;
+            for (int j = 0; j < N; j++) {
+                ret[j] = cell(i, j);
+            }
+            return ret;
+        }
 
-  double trace() const {
-    double tr = 0.0;
-    for (int i = 0; i < N; ++i)
-      tr += cell(i, i);
-    return tr;
-  }
+        Vector<N> col_to_vector(int j) const {
+            Vector<N> ret;
+            for (int i = 0; i < N; i++) {
+                ret[i] = cell(i, j);
+            }
+            return ret;
+        }
 
-private:
-  double _cell_data[N * N];
-};
+        void vector_to_row(const Vector<N>& v, int i) {
+            for (int j = 0; j < N; j++) {
+                cell(i, j) = v[j];
+            }
+        }
 
-template <> inline double Matrix<1>::determinant() const { return cell(0, 0); }
+        void vector_to_col(const Vector<N>& v, int j) {
+            for (int i = 0; i < N; i++) {
+                cell(i, j) = v[i];
+            }
+        }
+
+        double operator()(int i, int j) const { return cell(i, j); }
+        double& operator()(int i, int j) { return cell(i, j); }
+
+        double cell(int i, int j) const { return _cell_data[i * N + j]; }
+        double& cell(int i, int j) { return _cell_data[i * N + j]; }
+
+        Matrix operator+(const Matrix& m) const {
+            Matrix ret;
+            for (int ij = 0; ij < N * N; ++ij) {
+                ret._cell_data[ij] = _cell_data[ij] + m._cell_data[ij];
+            }
+            return ret;
+        }
+
+        Matrix operator-(const Matrix& m) const {
+            Matrix ret;
+            for (int ij = 0; ij < N * N; ++ij) {
+                ret._cell_data[ij] = _cell_data[ij] - m._cell_data[ij];
+            }
+            return ret;
+        }
+
+        Matrix operator*(double scalar) const {
+            Matrix ret;
+            for (int ij = 0; ij < N * N; ++ij) {
+                ret._cell_data[ij] = _cell_data[ij] * scalar;
+            }
+            return ret;
+        }
+
+        Matrix operator*(const Matrix& m) const {
+            Matrix ret;
+            for (int i = 0; i < N; i++) {
+                Vector<N> row = row_to_vector(i);
+                for (int j = 0; j < N; j++) {
+                    ret(i, j) = row.dot(m.col_to_vector(j));
+                }
+            }
+            return ret;
+        }
+
+        Matrix transpose() const {
+            Matrix ret;
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    ret(j, i) = cell(i, j);
+                }
+            }
+            return ret;
+        }
+
+        Matrix<N - 1> minor_matrix(int row, int col) const {
+            Matrix<N - 1> ret;
+            for (int i = 0, im = 0; i < N; i++) {
+                if (i == row)
+                    continue;
+
+                for (int j = 0, jm = 0; j < N; j++) {
+                    if (j != col) {
+                        ret(im, jm++) = cell(i, j);
+                    }
+                }
+                im++;
+            }
+            return ret;
+        }
+
+        double determinant() const {
+            // specialization for N == 1 given below this class
+            double det = 0.0, sign = 1.0;
+            for (int i = 0; i < N; ++i, sign = -sign)
+                det += sign * cell(0, i) * minor_matrix(0, i).determinant();
+            return det;
+        }
+
+        Matrix invert() const {
+            Matrix ret;
+            double det = determinant();
+
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    ret(i, j) = minor_matrix(j, i).determinant() / det;
+                    if ((i + j) % 2 == 1)
+                        ret(i, j) = -ret(i, j);
+                }
+            }
+            return ret;
+        }
+
+        double trace() const {
+            double tr = 0.0;
+            for (int i = 0; i < N; ++i)
+                tr += cell(i, i);
+            return tr;
+        }
+
+    private:
+        double _cell_data[N * N];
+    };
+
+    template <> inline double Matrix<1>::determinant() const { return cell(0, 0); }
 
 }; // namespace imu

--- a/examples/ahrs_telemetry/imu_quaternion.h
+++ b/examples/ahrs_telemetry/imu_quaternion.h
@@ -30,180 +30,183 @@
 
 namespace imu {
 
-class Quaternion {
-public:
-  Quaternion() : _w(1.0), _x(0.0), _y(0.0), _z(0.0) {}
+    class Quaternion {
+    public:
+        Quaternion(): _w(1.0), _x(0.0), _y(0.0), _z(0.0) {}
 
-  Quaternion(double w, double x, double y, double z)
-      : _w(w), _x(x), _y(y), _z(z) {}
+        Quaternion(double w, double x, double y, double z)
+            : _w(w), _x(x), _y(y), _z(z) {}
 
-  Quaternion(double w, Vector<3> vec)
-      : _w(w), _x(vec.x()), _y(vec.y()), _z(vec.z()) {}
+        Quaternion(double w, Vector<3> vec)
+            : _w(w), _x(vec.x()), _y(vec.y()), _z(vec.z()) {}
 
-  double &w() { return _w; }
-  double &x() { return _x; }
-  double &y() { return _y; }
-  double &z() { return _z; }
+        double& w() { return _w; }
+        double& x() { return _x; }
+        double& y() { return _y; }
+        double& z() { return _z; }
 
-  double w() const { return _w; }
-  double x() const { return _x; }
-  double y() const { return _y; }
-  double z() const { return _z; }
+        double w() const { return _w; }
+        double x() const { return _x; }
+        double y() const { return _y; }
+        double z() const { return _z; }
 
-  double magnitude() const {
-    return sqrt(_w * _w + _x * _x + _y * _y + _z * _z);
-  }
+        double magnitude() const {
+            return sqrt(_w * _w + _x * _x + _y * _y + _z * _z);
+        }
 
-  void normalize() {
-    double mag = magnitude();
-    *this = this->scale(1 / mag);
-  }
+        void normalize() {
+            double mag = magnitude();
+            *this = this->scale(1 / mag);
+        }
 
-  Quaternion conjugate() const { return Quaternion(_w, -_x, -_y, -_z); }
+        Quaternion conjugate() const { return Quaternion(_w, -_x, -_y, -_z); }
 
-  void fromAxisAngle(const Vector<3> &axis, double theta) {
-    _w = cos(theta / 2);
-    // only need to calculate sine of half theta once
-    double sht = sin(theta / 2);
-    _x = axis.x() * sht;
-    _y = axis.y() * sht;
-    _z = axis.z() * sht;
-  }
+        void fromAxisAngle(const Vector<3>& axis, double theta) {
+            _w = cos(theta / 2);
+            // only need to calculate sine of half theta once
+            double sht = sin(theta / 2);
+            _x = axis.x() * sht;
+            _y = axis.y() * sht;
+            _z = axis.z() * sht;
+        }
 
-  void fromMatrix(const Matrix<3> &m) {
-    double tr = m.trace();
+        void fromMatrix(const Matrix<3>& m) {
+            double tr = m.trace();
 
-    double S;
-    if (tr > 0) {
-      S = sqrt(tr + 1.0) * 2;
-      _w = 0.25 * S;
-      _x = (m(2, 1) - m(1, 2)) / S;
-      _y = (m(0, 2) - m(2, 0)) / S;
-      _z = (m(1, 0) - m(0, 1)) / S;
-    } else if (m(0, 0) > m(1, 1) && m(0, 0) > m(2, 2)) {
-      S = sqrt(1.0 + m(0, 0) - m(1, 1) - m(2, 2)) * 2;
-      _w = (m(2, 1) - m(1, 2)) / S;
-      _x = 0.25 * S;
-      _y = (m(0, 1) + m(1, 0)) / S;
-      _z = (m(0, 2) + m(2, 0)) / S;
-    } else if (m(1, 1) > m(2, 2)) {
-      S = sqrt(1.0 + m(1, 1) - m(0, 0) - m(2, 2)) * 2;
-      _w = (m(0, 2) - m(2, 0)) / S;
-      _x = (m(0, 1) + m(1, 0)) / S;
-      _y = 0.25 * S;
-      _z = (m(1, 2) + m(2, 1)) / S;
-    } else {
-      S = sqrt(1.0 + m(2, 2) - m(0, 0) - m(1, 1)) * 2;
-      _w = (m(1, 0) - m(0, 1)) / S;
-      _x = (m(0, 2) + m(2, 0)) / S;
-      _y = (m(1, 2) + m(2, 1)) / S;
-      _z = 0.25 * S;
-    }
-  }
+            double S;
+            if (tr > 0) {
+                S = sqrt(tr + 1.0) * 2;
+                _w = 0.25 * S;
+                _x = (m(2, 1) - m(1, 2)) / S;
+                _y = (m(0, 2) - m(2, 0)) / S;
+                _z = (m(1, 0) - m(0, 1)) / S;
+            }
+            else if (m(0, 0) > m(1, 1) && m(0, 0) > m(2, 2)) {
+                S = sqrt(1.0 + m(0, 0) - m(1, 1) - m(2, 2)) * 2;
+                _w = (m(2, 1) - m(1, 2)) / S;
+                _x = 0.25 * S;
+                _y = (m(0, 1) + m(1, 0)) / S;
+                _z = (m(0, 2) + m(2, 0)) / S;
+            }
+            else if (m(1, 1) > m(2, 2)) {
+                S = sqrt(1.0 + m(1, 1) - m(0, 0) - m(2, 2)) * 2;
+                _w = (m(0, 2) - m(2, 0)) / S;
+                _x = (m(0, 1) + m(1, 0)) / S;
+                _y = 0.25 * S;
+                _z = (m(1, 2) + m(2, 1)) / S;
+            }
+            else {
+                S = sqrt(1.0 + m(2, 2) - m(0, 0) - m(1, 1)) * 2;
+                _w = (m(1, 0) - m(0, 1)) / S;
+                _x = (m(0, 2) + m(2, 0)) / S;
+                _y = (m(1, 2) + m(2, 1)) / S;
+                _z = 0.25 * S;
+            }
+        }
 
-  void toAxisAngle(Vector<3> &axis, double &angle) const {
-    double sqw = sqrt(1 - _w * _w);
-    if (sqw == 0) // it's a singularity and divide by zero, avoid
-      return;
+        void toAxisAngle(Vector<3>& axis, double& angle) const {
+            double sqw = sqrt(1 - _w * _w);
+            if (sqw == 0) // it's a singularity and divide by zero, avoid
+                return;
 
-    angle = 2 * acos(_w);
-    axis.x() = _x / sqw;
-    axis.y() = _y / sqw;
-    axis.z() = _z / sqw;
-  }
+            angle = 2 * acos(_w);
+            axis.x() = _x / sqw;
+            axis.y() = _y / sqw;
+            axis.z() = _z / sqw;
+        }
 
-  Matrix<3> toMatrix() const {
-    Matrix<3> ret;
-    ret.cell(0, 0) = 1 - 2 * _y * _y - 2 * _z * _z;
-    ret.cell(0, 1) = 2 * _x * _y - 2 * _w * _z;
-    ret.cell(0, 2) = 2 * _x * _z + 2 * _w * _y;
+        Matrix<3> toMatrix() const {
+            Matrix<3> ret;
+            ret.cell(0, 0) = 1 - 2 * _y * _y - 2 * _z * _z;
+            ret.cell(0, 1) = 2 * _x * _y - 2 * _w * _z;
+            ret.cell(0, 2) = 2 * _x * _z + 2 * _w * _y;
 
-    ret.cell(1, 0) = 2 * _x * _y + 2 * _w * _z;
-    ret.cell(1, 1) = 1 - 2 * _x * _x - 2 * _z * _z;
-    ret.cell(1, 2) = 2 * _y * _z - 2 * _w * _x;
+            ret.cell(1, 0) = 2 * _x * _y + 2 * _w * _z;
+            ret.cell(1, 1) = 1 - 2 * _x * _x - 2 * _z * _z;
+            ret.cell(1, 2) = 2 * _y * _z - 2 * _w * _x;
 
-    ret.cell(2, 0) = 2 * _x * _z - 2 * _w * _y;
-    ret.cell(2, 1) = 2 * _y * _z + 2 * _w * _x;
-    ret.cell(2, 2) = 1 - 2 * _x * _x - 2 * _y * _y;
-    return ret;
-  }
+            ret.cell(2, 0) = 2 * _x * _z - 2 * _w * _y;
+            ret.cell(2, 1) = 2 * _y * _z + 2 * _w * _x;
+            ret.cell(2, 2) = 1 - 2 * _x * _x - 2 * _y * _y;
+            return ret;
+        }
 
-  // Returns euler angles that represent the quaternion.  Angles are
-  // returned in rotation order and right-handed about the specified
-  // axes:
-  //
-  //   v[0] is applied 1st about z (ie, roll)
-  //   v[1] is applied 2nd about y (ie, pitch)
-  //   v[2] is applied 3rd about x (ie, yaw)
-  //
-  // Note that this means result.x() is not a rotation about x;
-  // similarly for result.z().
-  //
-  Vector<3> toEuler() const {
-    Vector<3> ret;
-    double sqw = _w * _w;
-    double sqx = _x * _x;
-    double sqy = _y * _y;
-    double sqz = _z * _z;
+        // Returns euler angles that represent the quaternion.  Angles are
+        // returned in rotation order and right-handed about the specified
+        // axes:
+        //
+        //   v[0] is applied 1st about z (ie, roll)
+        //   v[1] is applied 2nd about y (ie, pitch)
+        //   v[2] is applied 3rd about x (ie, yaw)
+        //
+        // Note that this means result.x() is not a rotation about x;
+        // similarly for result.z().
+        //
+        Vector<3> toEuler() const {
+            Vector<3> ret;
+            double sqw = _w * _w;
+            double sqx = _x * _x;
+            double sqy = _y * _y;
+            double sqz = _z * _z;
 
-    ret.x() = atan2(2.0 * (_x * _y + _z * _w), (sqx - sqy - sqz + sqw));
-    ret.y() = asin(-2.0 * (_x * _z - _y * _w) / (sqx + sqy + sqz + sqw));
-    ret.z() = atan2(2.0 * (_y * _z + _x * _w), (-sqx - sqy + sqz + sqw));
+            ret.x() = atan2(2.0 * (_x * _y + _z * _w), (sqx - sqy - sqz + sqw));
+            ret.y() = asin(-2.0 * (_x * _z - _y * _w) / (sqx + sqy + sqz + sqw));
+            ret.z() = atan2(2.0 * (_y * _z + _x * _w), (-sqx - sqy + sqz + sqw));
 
-    return ret;
-  }
+            return ret;
+        }
 
-  Vector<3> toAngularVelocity(double dt) const {
-    Vector<3> ret;
-    Quaternion one(1.0, 0.0, 0.0, 0.0);
-    Quaternion delta = one - *this;
-    Quaternion r = (delta / dt);
-    r = r * 2;
-    r = r * one;
+        Vector<3> toAngularVelocity(double dt) const {
+            Vector<3> ret;
+            Quaternion one(1.0, 0.0, 0.0, 0.0);
+            Quaternion delta = one - *this;
+            Quaternion r = (delta / dt);
+            r = r * 2;
+            r = r * one;
 
-    ret.x() = r.x();
-    ret.y() = r.y();
-    ret.z() = r.z();
-    return ret;
-  }
+            ret.x() = r.x();
+            ret.y() = r.y();
+            ret.z() = r.z();
+            return ret;
+        }
 
-  Vector<3> rotateVector(const Vector<2> &v) const {
-    return rotateVector(Vector<3>(v.x(), v.y()));
-  }
+        Vector<3> rotateVector(const Vector<2>& v) const {
+            return rotateVector(Vector<3>(v.x(), v.y()));
+        }
 
-  Vector<3> rotateVector(const Vector<3> &v) const {
-    Vector<3> qv(_x, _y, _z);
-    Vector<3> t = qv.cross(v) * 2.0;
-    return v + t * _w + qv.cross(t);
-  }
+        Vector<3> rotateVector(const Vector<3>& v) const {
+            Vector<3> qv(_x, _y, _z);
+            Vector<3> t = qv.cross(v) * 2.0;
+            return v + t * _w + qv.cross(t);
+        }
 
-  Quaternion operator*(const Quaternion &q) const {
-    return Quaternion(_w * q._w - _x * q._x - _y * q._y - _z * q._z,
-                      _w * q._x + _x * q._w + _y * q._z - _z * q._y,
-                      _w * q._y - _x * q._z + _y * q._w + _z * q._x,
-                      _w * q._z + _x * q._y - _y * q._x + _z * q._w);
-  }
+        Quaternion operator*(const Quaternion& q) const {
+            return Quaternion(_w * q._w - _x * q._x - _y * q._y - _z * q._z,
+                _w * q._x + _x * q._w + _y * q._z - _z * q._y,
+                _w * q._y - _x * q._z + _y * q._w + _z * q._x,
+                _w * q._z + _x * q._y - _y * q._x + _z * q._w);
+        }
 
-  Quaternion operator+(const Quaternion &q) const {
-    return Quaternion(_w + q._w, _x + q._x, _y + q._y, _z + q._z);
-  }
+        Quaternion operator+(const Quaternion& q) const {
+            return Quaternion(_w + q._w, _x + q._x, _y + q._y, _z + q._z);
+        }
 
-  Quaternion operator-(const Quaternion &q) const {
-    return Quaternion(_w - q._w, _x - q._x, _y - q._y, _z - q._z);
-  }
+        Quaternion operator-(const Quaternion& q) const {
+            return Quaternion(_w - q._w, _x - q._x, _y - q._y, _z - q._z);
+        }
 
-  Quaternion operator/(double scalar) const {
-    return Quaternion(_w / scalar, _x / scalar, _y / scalar, _z / scalar);
-  }
+        Quaternion operator/(double scalar) const {
+            return Quaternion(_w / scalar, _x / scalar, _y / scalar, _z / scalar);
+        }
 
-  Quaternion operator*(double scalar) const { return scale(scalar); }
+        Quaternion operator*(double scalar) const { return scale(scalar); }
 
-  Quaternion scale(double scalar) const {
-    return Quaternion(_w * scalar, _x * scalar, _y * scalar, _z * scalar);
-  }
+        Quaternion scale(double scalar) const {
+            return Quaternion(_w * scalar, _x * scalar, _y * scalar, _z * scalar);
+        }
 
-private:
-  double _w, _x, _y, _z;
-};
+    private:
+        double _w, _x, _y, _z;
+    };
 
 } // namespace imu

--- a/examples/ahrs_telemetry/imu_quaternion.h
+++ b/examples/ahrs_telemetry/imu_quaternion.h
@@ -1,0 +1,209 @@
+//  Inertial Measurement Unit Maths Library
+//
+//  Copyright 2013-2021 Sam Cowen <samuel.cowen@camelsoftware.com>
+//  Bug fixes and cleanups by Gé Vissers (gvissers@gmail.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//  DEALINGS IN THE SOFTWARE.
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "imu_matrix.h"
+
+namespace imu {
+
+class Quaternion {
+public:
+  Quaternion() : _w(1.0), _x(0.0), _y(0.0), _z(0.0) {}
+
+  Quaternion(double w, double x, double y, double z)
+      : _w(w), _x(x), _y(y), _z(z) {}
+
+  Quaternion(double w, Vector<3> vec)
+      : _w(w), _x(vec.x()), _y(vec.y()), _z(vec.z()) {}
+
+  double &w() { return _w; }
+  double &x() { return _x; }
+  double &y() { return _y; }
+  double &z() { return _z; }
+
+  double w() const { return _w; }
+  double x() const { return _x; }
+  double y() const { return _y; }
+  double z() const { return _z; }
+
+  double magnitude() const {
+    return sqrt(_w * _w + _x * _x + _y * _y + _z * _z);
+  }
+
+  void normalize() {
+    double mag = magnitude();
+    *this = this->scale(1 / mag);
+  }
+
+  Quaternion conjugate() const { return Quaternion(_w, -_x, -_y, -_z); }
+
+  void fromAxisAngle(const Vector<3> &axis, double theta) {
+    _w = cos(theta / 2);
+    // only need to calculate sine of half theta once
+    double sht = sin(theta / 2);
+    _x = axis.x() * sht;
+    _y = axis.y() * sht;
+    _z = axis.z() * sht;
+  }
+
+  void fromMatrix(const Matrix<3> &m) {
+    double tr = m.trace();
+
+    double S;
+    if (tr > 0) {
+      S = sqrt(tr + 1.0) * 2;
+      _w = 0.25 * S;
+      _x = (m(2, 1) - m(1, 2)) / S;
+      _y = (m(0, 2) - m(2, 0)) / S;
+      _z = (m(1, 0) - m(0, 1)) / S;
+    } else if (m(0, 0) > m(1, 1) && m(0, 0) > m(2, 2)) {
+      S = sqrt(1.0 + m(0, 0) - m(1, 1) - m(2, 2)) * 2;
+      _w = (m(2, 1) - m(1, 2)) / S;
+      _x = 0.25 * S;
+      _y = (m(0, 1) + m(1, 0)) / S;
+      _z = (m(0, 2) + m(2, 0)) / S;
+    } else if (m(1, 1) > m(2, 2)) {
+      S = sqrt(1.0 + m(1, 1) - m(0, 0) - m(2, 2)) * 2;
+      _w = (m(0, 2) - m(2, 0)) / S;
+      _x = (m(0, 1) + m(1, 0)) / S;
+      _y = 0.25 * S;
+      _z = (m(1, 2) + m(2, 1)) / S;
+    } else {
+      S = sqrt(1.0 + m(2, 2) - m(0, 0) - m(1, 1)) * 2;
+      _w = (m(1, 0) - m(0, 1)) / S;
+      _x = (m(0, 2) + m(2, 0)) / S;
+      _y = (m(1, 2) + m(2, 1)) / S;
+      _z = 0.25 * S;
+    }
+  }
+
+  void toAxisAngle(Vector<3> &axis, double &angle) const {
+    double sqw = sqrt(1 - _w * _w);
+    if (sqw == 0) // it's a singularity and divide by zero, avoid
+      return;
+
+    angle = 2 * acos(_w);
+    axis.x() = _x / sqw;
+    axis.y() = _y / sqw;
+    axis.z() = _z / sqw;
+  }
+
+  Matrix<3> toMatrix() const {
+    Matrix<3> ret;
+    ret.cell(0, 0) = 1 - 2 * _y * _y - 2 * _z * _z;
+    ret.cell(0, 1) = 2 * _x * _y - 2 * _w * _z;
+    ret.cell(0, 2) = 2 * _x * _z + 2 * _w * _y;
+
+    ret.cell(1, 0) = 2 * _x * _y + 2 * _w * _z;
+    ret.cell(1, 1) = 1 - 2 * _x * _x - 2 * _z * _z;
+    ret.cell(1, 2) = 2 * _y * _z - 2 * _w * _x;
+
+    ret.cell(2, 0) = 2 * _x * _z - 2 * _w * _y;
+    ret.cell(2, 1) = 2 * _y * _z + 2 * _w * _x;
+    ret.cell(2, 2) = 1 - 2 * _x * _x - 2 * _y * _y;
+    return ret;
+  }
+
+  // Returns euler angles that represent the quaternion.  Angles are
+  // returned in rotation order and right-handed about the specified
+  // axes:
+  //
+  //   v[0] is applied 1st about z (ie, roll)
+  //   v[1] is applied 2nd about y (ie, pitch)
+  //   v[2] is applied 3rd about x (ie, yaw)
+  //
+  // Note that this means result.x() is not a rotation about x;
+  // similarly for result.z().
+  //
+  Vector<3> toEuler() const {
+    Vector<3> ret;
+    double sqw = _w * _w;
+    double sqx = _x * _x;
+    double sqy = _y * _y;
+    double sqz = _z * _z;
+
+    ret.x() = atan2(2.0 * (_x * _y + _z * _w), (sqx - sqy - sqz + sqw));
+    ret.y() = asin(-2.0 * (_x * _z - _y * _w) / (sqx + sqy + sqz + sqw));
+    ret.z() = atan2(2.0 * (_y * _z + _x * _w), (-sqx - sqy + sqz + sqw));
+
+    return ret;
+  }
+
+  Vector<3> toAngularVelocity(double dt) const {
+    Vector<3> ret;
+    Quaternion one(1.0, 0.0, 0.0, 0.0);
+    Quaternion delta = one - *this;
+    Quaternion r = (delta / dt);
+    r = r * 2;
+    r = r * one;
+
+    ret.x() = r.x();
+    ret.y() = r.y();
+    ret.z() = r.z();
+    return ret;
+  }
+
+  Vector<3> rotateVector(const Vector<2> &v) const {
+    return rotateVector(Vector<3>(v.x(), v.y()));
+  }
+
+  Vector<3> rotateVector(const Vector<3> &v) const {
+    Vector<3> qv(_x, _y, _z);
+    Vector<3> t = qv.cross(v) * 2.0;
+    return v + t * _w + qv.cross(t);
+  }
+
+  Quaternion operator*(const Quaternion &q) const {
+    return Quaternion(_w * q._w - _x * q._x - _y * q._y - _z * q._z,
+                      _w * q._x + _x * q._w + _y * q._z - _z * q._y,
+                      _w * q._y - _x * q._z + _y * q._w + _z * q._x,
+                      _w * q._z + _x * q._y - _y * q._x + _z * q._w);
+  }
+
+  Quaternion operator+(const Quaternion &q) const {
+    return Quaternion(_w + q._w, _x + q._x, _y + q._y, _z + q._z);
+  }
+
+  Quaternion operator-(const Quaternion &q) const {
+    return Quaternion(_w - q._w, _x - q._x, _y - q._y, _z - q._z);
+  }
+
+  Quaternion operator/(double scalar) const {
+    return Quaternion(_w / scalar, _x / scalar, _y / scalar, _z / scalar);
+  }
+
+  Quaternion operator*(double scalar) const { return scale(scalar); }
+
+  Quaternion scale(double scalar) const {
+    return Quaternion(_w * scalar, _x * scalar, _y * scalar, _z * scalar);
+  }
+
+private:
+  double _w, _x, _y, _z;
+};
+
+} // namespace imu

--- a/examples/ahrs_telemetry/imu_vector.h
+++ b/examples/ahrs_telemetry/imu_vector.h
@@ -29,153 +29,153 @@
 
 namespace imu {
 
-template <uint8_t N> class Vector {
-public:
-  Vector() { memset(p_vec, 0, sizeof(double) * N); }
+    template <uint8_t N> class Vector {
+    public:
+        Vector() { memset(p_vec, 0, sizeof(double) * N); }
 
-  Vector(double a) {
-    memset(p_vec, 0, sizeof(double) * N);
-    p_vec[0] = a;
-  }
+        Vector(double a) {
+            memset(p_vec, 0, sizeof(double) * N);
+            p_vec[0] = a;
+        }
 
-  Vector(double a, double b) {
-    memset(p_vec, 0, sizeof(double) * N);
-    p_vec[0] = a;
-    p_vec[1] = b;
-  }
+        Vector(double a, double b) {
+            memset(p_vec, 0, sizeof(double) * N);
+            p_vec[0] = a;
+            p_vec[1] = b;
+        }
 
-  Vector(double a, double b, double c) {
-    memset(p_vec, 0, sizeof(double) * N);
-    p_vec[0] = a;
-    p_vec[1] = b;
-    p_vec[2] = c;
-  }
+        Vector(double a, double b, double c) {
+            memset(p_vec, 0, sizeof(double) * N);
+            p_vec[0] = a;
+            p_vec[1] = b;
+            p_vec[2] = c;
+        }
 
-  Vector(double a, double b, double c, double d) {
-    memset(p_vec, 0, sizeof(double) * N);
-    p_vec[0] = a;
-    p_vec[1] = b;
-    p_vec[2] = c;
-    p_vec[3] = d;
-  }
+        Vector(double a, double b, double c, double d) {
+            memset(p_vec, 0, sizeof(double) * N);
+            p_vec[0] = a;
+            p_vec[1] = b;
+            p_vec[2] = c;
+            p_vec[3] = d;
+        }
 
-  Vector(const Vector<N> &v) {
-    for (int x = 0; x < N; x++)
-      p_vec[x] = v.p_vec[x];
-  }
+        Vector(const Vector<N>& v) {
+            for (int x = 0; x < N; x++)
+                p_vec[x] = v.p_vec[x];
+        }
 
-  ~Vector() {}
+        ~Vector() {}
 
-  uint8_t n() { return N; }
+        uint8_t n() { return N; }
 
-  double magnitude() const {
-    double res = 0;
-    for (int i = 0; i < N; i++)
-      res += p_vec[i] * p_vec[i];
+        double magnitude() const {
+            double res = 0;
+            for (int i = 0; i < N; i++)
+                res += p_vec[i] * p_vec[i];
 
-    return sqrt(res);
-  }
+            return sqrt(res);
+        }
 
-  void normalize() {
-    double mag = magnitude();
-    if (isnan(mag) || mag == 0.0)
-      return;
+        void normalize() {
+            double mag = magnitude();
+            if (isnan(mag) || mag == 0.0)
+                return;
 
-    for (int i = 0; i < N; i++)
-      p_vec[i] /= mag;
-  }
+            for (int i = 0; i < N; i++)
+                p_vec[i] /= mag;
+        }
 
-  double dot(const Vector &v) const {
-    double ret = 0;
-    for (int i = 0; i < N; i++)
-      ret += p_vec[i] * v.p_vec[i];
+        double dot(const Vector& v) const {
+            double ret = 0;
+            for (int i = 0; i < N; i++)
+                ret += p_vec[i] * v.p_vec[i];
 
-    return ret;
-  }
+            return ret;
+        }
 
-  // The cross product is only valid for vectors with 3 dimensions,
-  // with the exception of higher dimensional stuff that is beyond
-  // the intended scope of this library.
-  // Only a definition for N==3 is given below this class, using
-  // cross() with another value for N will result in a link error.
-  Vector cross(const Vector &v) const;
+        // The cross product is only valid for vectors with 3 dimensions,
+        // with the exception of higher dimensional stuff that is beyond
+        // the intended scope of this library.
+        // Only a definition for N==3 is given below this class, using
+        // cross() with another value for N will result in a link error.
+        Vector cross(const Vector& v) const;
 
-  Vector scale(double scalar) const {
-    Vector ret;
-    for (int i = 0; i < N; i++)
-      ret.p_vec[i] = p_vec[i] * scalar;
-    return ret;
-  }
+        Vector scale(double scalar) const {
+            Vector ret;
+            for (int i = 0; i < N; i++)
+                ret.p_vec[i] = p_vec[i] * scalar;
+            return ret;
+        }
 
-  Vector invert() const {
-    Vector ret;
-    for (int i = 0; i < N; i++)
-      ret.p_vec[i] = -p_vec[i];
-    return ret;
-  }
+        Vector invert() const {
+            Vector ret;
+            for (int i = 0; i < N; i++)
+                ret.p_vec[i] = -p_vec[i];
+            return ret;
+        }
 
-  Vector &operator=(const Vector &v) {
-    for (int x = 0; x < N; x++)
-      p_vec[x] = v.p_vec[x];
-    return *this;
-  }
+        Vector& operator=(const Vector& v) {
+            for (int x = 0; x < N; x++)
+                p_vec[x] = v.p_vec[x];
+            return *this;
+        }
 
-  double &operator[](int n) { return p_vec[n]; }
+        double& operator[](int n) { return p_vec[n]; }
 
-  double operator[](int n) const { return p_vec[n]; }
+        double operator[](int n) const { return p_vec[n]; }
 
-  double &operator()(int n) { return p_vec[n]; }
+        double& operator()(int n) { return p_vec[n]; }
 
-  double operator()(int n) const { return p_vec[n]; }
+        double operator()(int n) const { return p_vec[n]; }
 
-  Vector operator+(const Vector &v) const {
-    Vector ret;
-    for (int i = 0; i < N; i++)
-      ret.p_vec[i] = p_vec[i] + v.p_vec[i];
-    return ret;
-  }
+        Vector operator+(const Vector& v) const {
+            Vector ret;
+            for (int i = 0; i < N; i++)
+                ret.p_vec[i] = p_vec[i] + v.p_vec[i];
+            return ret;
+        }
 
-  Vector operator-(const Vector &v) const {
-    Vector ret;
-    for (int i = 0; i < N; i++)
-      ret.p_vec[i] = p_vec[i] - v.p_vec[i];
-    return ret;
-  }
+        Vector operator-(const Vector& v) const {
+            Vector ret;
+            for (int i = 0; i < N; i++)
+                ret.p_vec[i] = p_vec[i] - v.p_vec[i];
+            return ret;
+        }
 
-  Vector operator*(double scalar) const { return scale(scalar); }
+        Vector operator*(double scalar) const { return scale(scalar); }
 
-  Vector operator/(double scalar) const {
-    Vector ret;
-    for (int i = 0; i < N; i++)
-      ret.p_vec[i] = p_vec[i] / scalar;
-    return ret;
-  }
+        Vector operator/(double scalar) const {
+            Vector ret;
+            for (int i = 0; i < N; i++)
+                ret.p_vec[i] = p_vec[i] / scalar;
+            return ret;
+        }
 
-  void toDegrees() {
-    for (int i = 0; i < N; i++)
-      p_vec[i] *= 57.2957795131; // 180/pi
-  }
+        void toDegrees() {
+            for (int i = 0; i < N; i++)
+                p_vec[i] *= 57.2957795131; // 180/pi
+        }
 
-  void toRadians() {
-    for (int i = 0; i < N; i++)
-      p_vec[i] *= 0.01745329251; // pi/180
-  }
+        void toRadians() {
+            for (int i = 0; i < N; i++)
+                p_vec[i] *= 0.01745329251; // pi/180
+        }
 
-  double &x() { return p_vec[0]; }
-  double &y() { return p_vec[1]; }
-  double &z() { return p_vec[2]; }
-  double x() const { return p_vec[0]; }
-  double y() const { return p_vec[1]; }
-  double z() const { return p_vec[2]; }
+        double& x() { return p_vec[0]; }
+        double& y() { return p_vec[1]; }
+        double& z() { return p_vec[2]; }
+        double x() const { return p_vec[0]; }
+        double y() const { return p_vec[1]; }
+        double z() const { return p_vec[2]; }
 
-private:
-  double p_vec[N];
-};
+    private:
+        double p_vec[N];
+    };
 
-template <> inline Vector<3> Vector<3>::cross(const Vector &v) const {
-  return Vector(p_vec[1] * v.p_vec[2] - p_vec[2] * v.p_vec[1],
-                p_vec[2] * v.p_vec[0] - p_vec[0] * v.p_vec[2],
-                p_vec[0] * v.p_vec[1] - p_vec[1] * v.p_vec[0]);
-}
+    template <> inline Vector<3> Vector<3>::cross(const Vector& v) const {
+        return Vector(p_vec[1] * v.p_vec[2] - p_vec[2] * v.p_vec[1],
+            p_vec[2] * v.p_vec[0] - p_vec[0] * v.p_vec[2],
+            p_vec[0] * v.p_vec[1] - p_vec[1] * v.p_vec[0]);
+    }
 
 } // namespace imu

--- a/examples/ahrs_telemetry/imu_vector.h
+++ b/examples/ahrs_telemetry/imu_vector.h
@@ -1,0 +1,181 @@
+//  Inertial Measurement Unit Maths Library
+//
+//  Copyright 2013-2021 Sam Cowen <samuel.cowen@camelsoftware.com>
+//  Bug fixes and cleanups by Gé Vissers (gvissers@gmail.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//  DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace imu {
+
+template <uint8_t N> class Vector {
+public:
+  Vector() { memset(p_vec, 0, sizeof(double) * N); }
+
+  Vector(double a) {
+    memset(p_vec, 0, sizeof(double) * N);
+    p_vec[0] = a;
+  }
+
+  Vector(double a, double b) {
+    memset(p_vec, 0, sizeof(double) * N);
+    p_vec[0] = a;
+    p_vec[1] = b;
+  }
+
+  Vector(double a, double b, double c) {
+    memset(p_vec, 0, sizeof(double) * N);
+    p_vec[0] = a;
+    p_vec[1] = b;
+    p_vec[2] = c;
+  }
+
+  Vector(double a, double b, double c, double d) {
+    memset(p_vec, 0, sizeof(double) * N);
+    p_vec[0] = a;
+    p_vec[1] = b;
+    p_vec[2] = c;
+    p_vec[3] = d;
+  }
+
+  Vector(const Vector<N> &v) {
+    for (int x = 0; x < N; x++)
+      p_vec[x] = v.p_vec[x];
+  }
+
+  ~Vector() {}
+
+  uint8_t n() { return N; }
+
+  double magnitude() const {
+    double res = 0;
+    for (int i = 0; i < N; i++)
+      res += p_vec[i] * p_vec[i];
+
+    return sqrt(res);
+  }
+
+  void normalize() {
+    double mag = magnitude();
+    if (isnan(mag) || mag == 0.0)
+      return;
+
+    for (int i = 0; i < N; i++)
+      p_vec[i] /= mag;
+  }
+
+  double dot(const Vector &v) const {
+    double ret = 0;
+    for (int i = 0; i < N; i++)
+      ret += p_vec[i] * v.p_vec[i];
+
+    return ret;
+  }
+
+  // The cross product is only valid for vectors with 3 dimensions,
+  // with the exception of higher dimensional stuff that is beyond
+  // the intended scope of this library.
+  // Only a definition for N==3 is given below this class, using
+  // cross() with another value for N will result in a link error.
+  Vector cross(const Vector &v) const;
+
+  Vector scale(double scalar) const {
+    Vector ret;
+    for (int i = 0; i < N; i++)
+      ret.p_vec[i] = p_vec[i] * scalar;
+    return ret;
+  }
+
+  Vector invert() const {
+    Vector ret;
+    for (int i = 0; i < N; i++)
+      ret.p_vec[i] = -p_vec[i];
+    return ret;
+  }
+
+  Vector &operator=(const Vector &v) {
+    for (int x = 0; x < N; x++)
+      p_vec[x] = v.p_vec[x];
+    return *this;
+  }
+
+  double &operator[](int n) { return p_vec[n]; }
+
+  double operator[](int n) const { return p_vec[n]; }
+
+  double &operator()(int n) { return p_vec[n]; }
+
+  double operator()(int n) const { return p_vec[n]; }
+
+  Vector operator+(const Vector &v) const {
+    Vector ret;
+    for (int i = 0; i < N; i++)
+      ret.p_vec[i] = p_vec[i] + v.p_vec[i];
+    return ret;
+  }
+
+  Vector operator-(const Vector &v) const {
+    Vector ret;
+    for (int i = 0; i < N; i++)
+      ret.p_vec[i] = p_vec[i] - v.p_vec[i];
+    return ret;
+  }
+
+  Vector operator*(double scalar) const { return scale(scalar); }
+
+  Vector operator/(double scalar) const {
+    Vector ret;
+    for (int i = 0; i < N; i++)
+      ret.p_vec[i] = p_vec[i] / scalar;
+    return ret;
+  }
+
+  void toDegrees() {
+    for (int i = 0; i < N; i++)
+      p_vec[i] *= 57.2957795131; // 180/pi
+  }
+
+  void toRadians() {
+    for (int i = 0; i < N; i++)
+      p_vec[i] *= 0.01745329251; // pi/180
+  }
+
+  double &x() { return p_vec[0]; }
+  double &y() { return p_vec[1]; }
+  double &z() { return p_vec[2]; }
+  double x() const { return p_vec[0]; }
+  double y() const { return p_vec[1]; }
+  double z() const { return p_vec[2]; }
+
+private:
+  double p_vec[N];
+};
+
+template <> inline Vector<3> Vector<3>::cross(const Vector &v) const {
+  return Vector(p_vec[1] * v.p_vec[2] - p_vec[2] * v.p_vec[1],
+                p_vec[2] * v.p_vec[0] - p_vec[0] * v.p_vec[2],
+                p_vec[0] * v.p_vec[1] - p_vec[1] * v.p_vec[0]);
+}
+
+} // namespace imu

--- a/examples/ahrs_telemetry/unified_sensor.cpp
+++ b/examples/ahrs_telemetry/unified_sensor.cpp
@@ -10,88 +10,88 @@
  */
 #include "unified_sensor.h"
 
-/**************************************************************************/
-/*!
-    @brief  Prints sensor information to serial console
-*/
-/**************************************************************************/
+ /**************************************************************************/
+ /*!
+     @brief  Prints sensor information to serial console
+ */
+ /**************************************************************************/
 void Unified_Sensor::printSensorDetails(void) {
-  sensor_t sensor;
-  getSensor(&sensor);
-  Serial.println(F("------------------------------------"));
-  Serial.print(F("Sensor:       "));
-  Serial.println(sensor.name);
-  Serial.print(F("Type:         "));
-  switch ((sensors_type_t)sensor.type) {
-  case SENSOR_TYPE_ACCELEROMETER:
-    Serial.print(F("Acceleration (m/s2)"));
-    break;
-  case SENSOR_TYPE_MAGNETIC_FIELD:
-    Serial.print(F("Magnetic (uT)"));
-    break;
-  case SENSOR_TYPE_ORIENTATION:
-    Serial.print(F("Orientation (degrees)"));
-    break;
-  case SENSOR_TYPE_GYROSCOPE:
-    Serial.print(F("Gyroscopic (rad/s)"));
-    break;
-  case SENSOR_TYPE_LIGHT:
-    Serial.print(F("Light (lux)"));
-    break;
-  case SENSOR_TYPE_PRESSURE:
-    Serial.print(F("Pressure (hPa)"));
-    break;
-  case SENSOR_TYPE_PROXIMITY:
-    Serial.print(F("Distance (cm)"));
-    break;
-  case SENSOR_TYPE_GRAVITY:
-    Serial.print(F("Gravity (m/s2)"));
-    break;
-  case SENSOR_TYPE_LINEAR_ACCELERATION:
-    Serial.print(F("Linear Acceleration (m/s2)"));
-    break;
-  case SENSOR_TYPE_ROTATION_VECTOR:
-    Serial.print(F("Rotation vector"));
-    break;
-  case SENSOR_TYPE_RELATIVE_HUMIDITY:
-    Serial.print(F("Relative Humidity (%)"));
-    break;
-  case SENSOR_TYPE_AMBIENT_TEMPERATURE:
-    Serial.print(F("Ambient Temp (C)"));
-    break;
-  case SENSOR_TYPE_OBJECT_TEMPERATURE:
-    Serial.print(F("Object Temp (C)"));
-    break;
-  case SENSOR_TYPE_VOLTAGE:
-    Serial.print(F("Voltage (V)"));
-    break;
-  case SENSOR_TYPE_CURRENT:
-    Serial.print(F("Current (mA)"));
-    break;
-  case SENSOR_TYPE_COLOR:
-    Serial.print(F("Color (RGBA)"));
-    break;
-  case SENSOR_TYPE_TVOC:
-    Serial.print(F("Total Volatile Organic Compounds (ppb)"));
-    break;
-  case SENSOR_TYPE_VOC_INDEX:
-    Serial.print(F("Volatile Organic Compounds (Index)"));
-    break;
-  case SENSOR_TYPE_NOX_INDEX:
-    Serial.print(F("Nitrogen Oxides (Index)"));
-    break;
-  }
+    sensor_t sensor;
+    getSensor(&sensor);
+    Serial.println(F("------------------------------------"));
+    Serial.print(F("Sensor:       "));
+    Serial.println(sensor.name);
+    Serial.print(F("Type:         "));
+    switch ((sensors_type_t)sensor.type) {
+    case SENSOR_TYPE_ACCELEROMETER:
+        Serial.print(F("Acceleration (m/s2)"));
+        break;
+    case SENSOR_TYPE_MAGNETIC_FIELD:
+        Serial.print(F("Magnetic (uT)"));
+        break;
+    case SENSOR_TYPE_ORIENTATION:
+        Serial.print(F("Orientation (degrees)"));
+        break;
+    case SENSOR_TYPE_GYROSCOPE:
+        Serial.print(F("Gyroscopic (rad/s)"));
+        break;
+    case SENSOR_TYPE_LIGHT:
+        Serial.print(F("Light (lux)"));
+        break;
+    case SENSOR_TYPE_PRESSURE:
+        Serial.print(F("Pressure (hPa)"));
+        break;
+    case SENSOR_TYPE_PROXIMITY:
+        Serial.print(F("Distance (cm)"));
+        break;
+    case SENSOR_TYPE_GRAVITY:
+        Serial.print(F("Gravity (m/s2)"));
+        break;
+    case SENSOR_TYPE_LINEAR_ACCELERATION:
+        Serial.print(F("Linear Acceleration (m/s2)"));
+        break;
+    case SENSOR_TYPE_ROTATION_VECTOR:
+        Serial.print(F("Rotation vector"));
+        break;
+    case SENSOR_TYPE_RELATIVE_HUMIDITY:
+        Serial.print(F("Relative Humidity (%)"));
+        break;
+    case SENSOR_TYPE_AMBIENT_TEMPERATURE:
+        Serial.print(F("Ambient Temp (C)"));
+        break;
+    case SENSOR_TYPE_OBJECT_TEMPERATURE:
+        Serial.print(F("Object Temp (C)"));
+        break;
+    case SENSOR_TYPE_VOLTAGE:
+        Serial.print(F("Voltage (V)"));
+        break;
+    case SENSOR_TYPE_CURRENT:
+        Serial.print(F("Current (mA)"));
+        break;
+    case SENSOR_TYPE_COLOR:
+        Serial.print(F("Color (RGBA)"));
+        break;
+    case SENSOR_TYPE_TVOC:
+        Serial.print(F("Total Volatile Organic Compounds (ppb)"));
+        break;
+    case SENSOR_TYPE_VOC_INDEX:
+        Serial.print(F("Volatile Organic Compounds (Index)"));
+        break;
+    case SENSOR_TYPE_NOX_INDEX:
+        Serial.print(F("Nitrogen Oxides (Index)"));
+        break;
+    }
 
-  Serial.println();
-  Serial.print(F("Driver Ver:   "));
-  Serial.println(sensor.version);
-  Serial.print(F("Unique ID:    "));
-  Serial.println(sensor.sensor_id);
-  Serial.print(F("Min Value:    "));
-  Serial.println(sensor.min_value);
-  Serial.print(F("Max Value:    "));
-  Serial.println(sensor.max_value);
-  Serial.print(F("Resolution:   "));
-  Serial.println(sensor.resolution);
-  Serial.println(F("------------------------------------\n"));
+    Serial.println();
+    Serial.print(F("Driver Ver:   "));
+    Serial.println(sensor.version);
+    Serial.print(F("Unique ID:    "));
+    Serial.println(sensor.sensor_id);
+    Serial.print(F("Min Value:    "));
+    Serial.println(sensor.min_value);
+    Serial.print(F("Max Value:    "));
+    Serial.println(sensor.max_value);
+    Serial.print(F("Resolution:   "));
+    Serial.println(sensor.resolution);
+    Serial.println(F("------------------------------------\n"));
 }

--- a/examples/ahrs_telemetry/unified_sensor.cpp
+++ b/examples/ahrs_telemetry/unified_sensor.cpp
@@ -1,0 +1,97 @@
+/**
+ * @file unified_sensor.cpp
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief A generic unified sensor library, based on Adafruit's Unified Sensor library.
+ * @version 0.2.0
+ * @date 2023-02-08
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+#include "unified_sensor.h"
+
+/**************************************************************************/
+/*!
+    @brief  Prints sensor information to serial console
+*/
+/**************************************************************************/
+void Unified_Sensor::printSensorDetails(void) {
+  sensor_t sensor;
+  getSensor(&sensor);
+  Serial.println(F("------------------------------------"));
+  Serial.print(F("Sensor:       "));
+  Serial.println(sensor.name);
+  Serial.print(F("Type:         "));
+  switch ((sensors_type_t)sensor.type) {
+  case SENSOR_TYPE_ACCELEROMETER:
+    Serial.print(F("Acceleration (m/s2)"));
+    break;
+  case SENSOR_TYPE_MAGNETIC_FIELD:
+    Serial.print(F("Magnetic (uT)"));
+    break;
+  case SENSOR_TYPE_ORIENTATION:
+    Serial.print(F("Orientation (degrees)"));
+    break;
+  case SENSOR_TYPE_GYROSCOPE:
+    Serial.print(F("Gyroscopic (rad/s)"));
+    break;
+  case SENSOR_TYPE_LIGHT:
+    Serial.print(F("Light (lux)"));
+    break;
+  case SENSOR_TYPE_PRESSURE:
+    Serial.print(F("Pressure (hPa)"));
+    break;
+  case SENSOR_TYPE_PROXIMITY:
+    Serial.print(F("Distance (cm)"));
+    break;
+  case SENSOR_TYPE_GRAVITY:
+    Serial.print(F("Gravity (m/s2)"));
+    break;
+  case SENSOR_TYPE_LINEAR_ACCELERATION:
+    Serial.print(F("Linear Acceleration (m/s2)"));
+    break;
+  case SENSOR_TYPE_ROTATION_VECTOR:
+    Serial.print(F("Rotation vector"));
+    break;
+  case SENSOR_TYPE_RELATIVE_HUMIDITY:
+    Serial.print(F("Relative Humidity (%)"));
+    break;
+  case SENSOR_TYPE_AMBIENT_TEMPERATURE:
+    Serial.print(F("Ambient Temp (C)"));
+    break;
+  case SENSOR_TYPE_OBJECT_TEMPERATURE:
+    Serial.print(F("Object Temp (C)"));
+    break;
+  case SENSOR_TYPE_VOLTAGE:
+    Serial.print(F("Voltage (V)"));
+    break;
+  case SENSOR_TYPE_CURRENT:
+    Serial.print(F("Current (mA)"));
+    break;
+  case SENSOR_TYPE_COLOR:
+    Serial.print(F("Color (RGBA)"));
+    break;
+  case SENSOR_TYPE_TVOC:
+    Serial.print(F("Total Volatile Organic Compounds (ppb)"));
+    break;
+  case SENSOR_TYPE_VOC_INDEX:
+    Serial.print(F("Volatile Organic Compounds (Index)"));
+    break;
+  case SENSOR_TYPE_NOX_INDEX:
+    Serial.print(F("Nitrogen Oxides (Index)"));
+    break;
+  }
+
+  Serial.println();
+  Serial.print(F("Driver Ver:   "));
+  Serial.println(sensor.version);
+  Serial.print(F("Unique ID:    "));
+  Serial.println(sensor.sensor_id);
+  Serial.print(F("Min Value:    "));
+  Serial.println(sensor.min_value);
+  Serial.print(F("Max Value:    "));
+  Serial.println(sensor.max_value);
+  Serial.print(F("Resolution:   "));
+  Serial.println(sensor.resolution);
+  Serial.println(F("------------------------------------\n"));
+}

--- a/examples/ahrs_telemetry/unified_sensor.h
+++ b/examples/ahrs_telemetry/unified_sensor.h
@@ -1,0 +1,185 @@
+/**
+ * @file unified_sensor.h
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief A generic unified sensor library, based on Adafruit's Unified Sensor library.
+ * @version 0.2.0
+ * @date 2023-02-08
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ */
+
+#pragma once
+
+#ifndef ARDUINO
+#include <stdint.h>
+#elif ARDUINO >= 100
+#include "Arduino.h"
+#include "Print.h"
+#else
+#include "WProgram.h"
+#endif
+
+/* Constants */
+#define SENSORS_GRAVITY_EARTH (9.80665F) /**< Earth's gravity in m/s^2 */
+#define SENSORS_GRAVITY_MOON (1.6F)      /**< The moon's gravity in m/s^2 */
+#define SENSORS_GRAVITY_SUN (275.0F)     /**< The sun's gravity in m/s^2 */
+#define SENSORS_GRAVITY_STANDARD (SENSORS_GRAVITY_EARTH)
+#define SENSORS_MAGFIELD_EARTH_MAX                                             \
+  (60.0F) /**< Maximum magnetic field on Earth's surface */
+#define SENSORS_MAGFIELD_EARTH_MIN                                             \
+  (30.0F) /**< Minimum magnetic field on Earth's surface */
+#define SENSORS_PRESSURE_SEALEVELHPA                                           \
+  (1013.25F) /**< Average sea level pressure is 1013.25 hPa */
+#define SENSORS_DPS_TO_RADS                                                    \
+  (0.017453293F) /**< Degrees/s to rad/s multiplier                            \
+                  */
+#define SENSORS_RADS_TO_DPS                                                    \
+  (57.29577793F) /**< Rad/s to degrees/s  multiplier */
+#define SENSORS_GAUSS_TO_MICROTESLA                                            \
+  (100) /**< Gauss to micro-Tesla multiplier */
+
+/** Sensor types */
+typedef enum {
+  SENSOR_TYPE_ACCELEROMETER = (1), /**< Gravity + linear acceleration */
+  SENSOR_TYPE_MAGNETIC_FIELD = (2),
+  SENSOR_TYPE_ORIENTATION = (3),
+  SENSOR_TYPE_GYROSCOPE = (4),
+  SENSOR_TYPE_LIGHT = (5),
+  SENSOR_TYPE_PRESSURE = (6),
+  SENSOR_TYPE_PROXIMITY = (8),
+  SENSOR_TYPE_GRAVITY = (9),
+  SENSOR_TYPE_LINEAR_ACCELERATION =
+      (10), /**< Acceleration not including gravity */
+  SENSOR_TYPE_ROTATION_VECTOR = (11),
+  SENSOR_TYPE_RELATIVE_HUMIDITY = (12),
+  SENSOR_TYPE_AMBIENT_TEMPERATURE = (13),
+  SENSOR_TYPE_OBJECT_TEMPERATURE = (14),
+  SENSOR_TYPE_VOLTAGE = (15),
+  SENSOR_TYPE_CURRENT = (16),
+  SENSOR_TYPE_COLOR = (17),
+  SENSOR_TYPE_TVOC = (18),
+  SENSOR_TYPE_VOC_INDEX = (19),
+  SENSOR_TYPE_NOX_INDEX = (20)
+} sensors_type_t;
+
+/** struct sensors_vec_s is used to return a vector in a common format. */
+typedef struct {
+  union {
+    float v[3]; ///< 3D vector elements
+    struct {
+      float x; ///< X component of vector
+      float y; ///< Y component of vector
+      float z; ///< Z component of vector
+    };         ///< Struct for holding XYZ component
+    /* Orientation sensors */
+    struct {
+      float roll; /**< Rotation around the longitudinal axis (the plane body, 'X
+                     axis'). Roll is positive and increasing when moving
+                     downward. -90 degrees <= roll <= 90 degrees */
+      float pitch;   /**< Rotation around the lateral axis (the wing span, 'Y
+                        axis'). Pitch is positive and increasing when moving
+                        upwards. -180 degrees <= pitch <= 180 degrees) */
+      float heading; /**< Angle between the longitudinal axis (the plane body)
+                        and magnetic north, measured clockwise when viewing from
+                        the top of the device. 0-359 degrees */
+    };               ///< Struct for holding roll/pitch/heading
+  };                 ///< Union that can hold 3D vector array, XYZ components or
+                     ///< roll/pitch/heading
+  int8_t status;     ///< Status byte
+  uint8_t reserved[3]; ///< Reserved
+} sensors_vec_t;
+
+/** struct sensors_color_s is used to return color data in a common format. */
+typedef struct {
+  union {
+    float c[3]; ///< Raw 3-element data
+    /* RGB color space */
+    struct {
+      float r;   /**< Red component */
+      float g;   /**< Green component */
+      float b;   /**< Blue component */
+    };           ///< RGB data in floating point notation
+  };             ///< Union of various ways to describe RGB colorspace
+  uint32_t rgba; /**< 24-bit RGBA value */
+} sensors_color_t;
+
+/* Sensor event (36 bytes) */
+/** struct sensor_event_s is used to provide a single sensor event in a common
+ * format. */
+typedef struct {
+  int32_t version;   /**< must be sizeof(struct sensors_event_t) */
+  int32_t sensor_id; /**< unique sensor identifier */
+  int32_t type;      /**< sensor type */
+  int32_t reserved0; /**< reserved */
+  int32_t timestamp; /**< time is in milliseconds */
+  union {
+    float data[4];              ///< Raw data
+    sensors_vec_t acceleration; /**< acceleration values are in meter per second
+                                   per second (m/s^2) */
+    sensors_vec_t
+        magnetic; /**< magnetic vector values are in micro-Tesla (uT) */
+    sensors_vec_t orientation; /**< orientation values are in degrees */
+    sensors_vec_t gyro;        /**< gyroscope values are in rad/s */
+    float temperature; /**< temperature is in degrees centigrade (Celsius) */
+    float distance;    /**< distance in centimeters */
+    float light;       /**< light in SI lux units */
+    float pressure;    /**< pressure in hectopascal (hPa) */
+    float relative_humidity; /**< relative humidity in percent */
+    float current;           /**< current in milliamps (mA) */
+    float voltage;           /**< voltage in volts (V) */
+    float tvoc;              /**< Total Volatile Organic Compounds, in ppb */
+    float voc_index; /**< VOC (Volatile Organic Compound) index where 100 is
+                          normal (unitless) */
+    float nox_index; /**< NOx (Nitrogen Oxides) index where 100 is normal
+                          (unitless) */
+    sensors_color_t color; /**< color in RGB component values */
+  };                       ///< Union for the wide ranges of data we can carry
+} sensors_event_t;
+
+/* Sensor details (40 bytes) */
+/** struct sensor_s is used to describe basic information about a specific
+ * sensor. */
+typedef struct {
+  char name[12];     /**< sensor name */
+  int32_t version;   /**< version of the hardware + driver */
+  int32_t sensor_id; /**< unique sensor identifier */
+  int32_t type;      /**< this sensor's type (ex. SENSOR_TYPE_LIGHT) */
+  float max_value;   /**< maximum value of this sensor's value in SI units */
+  float min_value;   /**< minimum value of this sensor's value in SI units */
+  float resolution; /**< smallest difference between two values reported by this
+                       sensor */
+  int32_t min_delay; /**< min delay in microseconds between events. zero = not a
+                        constant rate */
+} sensor_t;
+
+/** @brief Common sensor interface to unify various sensors.
+ * Intentionally modeled after sensors.h in the Android API:
+ * https://github.com/android/platform_hardware_libhardware/blob/master/include/hardware/sensors.h
+ */
+class Unified_Sensor {
+public:
+  // Constructor(s)
+  Unified_Sensor() {}
+  virtual ~Unified_Sensor() {}
+
+  // These must be defined by the subclass
+
+  /*! @brief Whether we should automatically change the range (if possible) for
+     higher precision
+      @param enabled True if we will try to autorange */
+  virtual void enableAutoRange(bool enabled) {
+    (void)enabled; /* suppress unused warning */
+  };
+
+  /*! @brief Get the latest sensor event
+      @returns True if able to fetch an event */
+  virtual bool getEvent(sensors_event_t *) = 0;
+  /*! @brief Get info about the sensor itself */
+  virtual void getSensor(sensor_t *) = 0;
+
+  void printSensorDetails(void);
+
+private:
+  bool _autoRange;
+};

--- a/examples/ahrs_telemetry/unified_sensor.h
+++ b/examples/ahrs_telemetry/unified_sensor.h
@@ -20,7 +20,7 @@
 #include "WProgram.h"
 #endif
 
-/* Constants */
+ /* Constants */
 #define SENSORS_GRAVITY_EARTH (9.80665F) /**< Earth's gravity in m/s^2 */
 #define SENSORS_GRAVITY_MOON (1.6F)      /**< The moon's gravity in m/s^2 */
 #define SENSORS_GRAVITY_SUN (275.0F)     /**< The sun's gravity in m/s^2 */
@@ -41,116 +41,116 @@
 
 /** Sensor types */
 typedef enum {
-  SENSOR_TYPE_ACCELEROMETER = (1), /**< Gravity + linear acceleration */
-  SENSOR_TYPE_MAGNETIC_FIELD = (2),
-  SENSOR_TYPE_ORIENTATION = (3),
-  SENSOR_TYPE_GYROSCOPE = (4),
-  SENSOR_TYPE_LIGHT = (5),
-  SENSOR_TYPE_PRESSURE = (6),
-  SENSOR_TYPE_PROXIMITY = (8),
-  SENSOR_TYPE_GRAVITY = (9),
-  SENSOR_TYPE_LINEAR_ACCELERATION =
-      (10), /**< Acceleration not including gravity */
-  SENSOR_TYPE_ROTATION_VECTOR = (11),
-  SENSOR_TYPE_RELATIVE_HUMIDITY = (12),
-  SENSOR_TYPE_AMBIENT_TEMPERATURE = (13),
-  SENSOR_TYPE_OBJECT_TEMPERATURE = (14),
-  SENSOR_TYPE_VOLTAGE = (15),
-  SENSOR_TYPE_CURRENT = (16),
-  SENSOR_TYPE_COLOR = (17),
-  SENSOR_TYPE_TVOC = (18),
-  SENSOR_TYPE_VOC_INDEX = (19),
-  SENSOR_TYPE_NOX_INDEX = (20)
+    SENSOR_TYPE_ACCELEROMETER = (1), /**< Gravity + linear acceleration */
+    SENSOR_TYPE_MAGNETIC_FIELD = (2),
+    SENSOR_TYPE_ORIENTATION = (3),
+    SENSOR_TYPE_GYROSCOPE = (4),
+    SENSOR_TYPE_LIGHT = (5),
+    SENSOR_TYPE_PRESSURE = (6),
+    SENSOR_TYPE_PROXIMITY = (8),
+    SENSOR_TYPE_GRAVITY = (9),
+    SENSOR_TYPE_LINEAR_ACCELERATION =
+    (10), /**< Acceleration not including gravity */
+    SENSOR_TYPE_ROTATION_VECTOR = (11),
+    SENSOR_TYPE_RELATIVE_HUMIDITY = (12),
+    SENSOR_TYPE_AMBIENT_TEMPERATURE = (13),
+    SENSOR_TYPE_OBJECT_TEMPERATURE = (14),
+    SENSOR_TYPE_VOLTAGE = (15),
+    SENSOR_TYPE_CURRENT = (16),
+    SENSOR_TYPE_COLOR = (17),
+    SENSOR_TYPE_TVOC = (18),
+    SENSOR_TYPE_VOC_INDEX = (19),
+    SENSOR_TYPE_NOX_INDEX = (20)
 } sensors_type_t;
 
 /** struct sensors_vec_s is used to return a vector in a common format. */
 typedef struct {
-  union {
-    float v[3]; ///< 3D vector elements
-    struct {
-      float x; ///< X component of vector
-      float y; ///< Y component of vector
-      float z; ///< Z component of vector
-    };         ///< Struct for holding XYZ component
-    /* Orientation sensors */
-    struct {
-      float roll; /**< Rotation around the longitudinal axis (the plane body, 'X
-                     axis'). Roll is positive and increasing when moving
-                     downward. -90 degrees <= roll <= 90 degrees */
-      float pitch;   /**< Rotation around the lateral axis (the wing span, 'Y
-                        axis'). Pitch is positive and increasing when moving
-                        upwards. -180 degrees <= pitch <= 180 degrees) */
-      float heading; /**< Angle between the longitudinal axis (the plane body)
-                        and magnetic north, measured clockwise when viewing from
-                        the top of the device. 0-359 degrees */
-    };               ///< Struct for holding roll/pitch/heading
-  };                 ///< Union that can hold 3D vector array, XYZ components or
-                     ///< roll/pitch/heading
-  int8_t status;     ///< Status byte
-  uint8_t reserved[3]; ///< Reserved
+    union {
+        float v[3]; ///< 3D vector elements
+        struct {
+            float x; ///< X component of vector
+            float y; ///< Y component of vector
+            float z; ///< Z component of vector
+        };         ///< Struct for holding XYZ component
+        /* Orientation sensors */
+        struct {
+            float roll; /**< Rotation around the longitudinal axis (the plane body, 'X
+                           axis'). Roll is positive and increasing when moving
+                           downward. -90 degrees <= roll <= 90 degrees */
+            float pitch;   /**< Rotation around the lateral axis (the wing span, 'Y
+                              axis'). Pitch is positive and increasing when moving
+                              upwards. -180 degrees <= pitch <= 180 degrees) */
+            float heading; /**< Angle between the longitudinal axis (the plane body)
+                              and magnetic north, measured clockwise when viewing from
+                              the top of the device. 0-359 degrees */
+        };               ///< Struct for holding roll/pitch/heading
+    };                 ///< Union that can hold 3D vector array, XYZ components or
+    ///< roll/pitch/heading
+    int8_t status;     ///< Status byte
+    uint8_t reserved[3]; ///< Reserved
 } sensors_vec_t;
 
 /** struct sensors_color_s is used to return color data in a common format. */
 typedef struct {
-  union {
-    float c[3]; ///< Raw 3-element data
-    /* RGB color space */
-    struct {
-      float r;   /**< Red component */
-      float g;   /**< Green component */
-      float b;   /**< Blue component */
-    };           ///< RGB data in floating point notation
-  };             ///< Union of various ways to describe RGB colorspace
-  uint32_t rgba; /**< 24-bit RGBA value */
+    union {
+        float c[3]; ///< Raw 3-element data
+        /* RGB color space */
+        struct {
+            float r;   /**< Red component */
+            float g;   /**< Green component */
+            float b;   /**< Blue component */
+        };           ///< RGB data in floating point notation
+    };             ///< Union of various ways to describe RGB colorspace
+    uint32_t rgba; /**< 24-bit RGBA value */
 } sensors_color_t;
 
 /* Sensor event (36 bytes) */
 /** struct sensor_event_s is used to provide a single sensor event in a common
  * format. */
 typedef struct {
-  int32_t version;   /**< must be sizeof(struct sensors_event_t) */
-  int32_t sensor_id; /**< unique sensor identifier */
-  int32_t type;      /**< sensor type */
-  int32_t reserved0; /**< reserved */
-  int32_t timestamp; /**< time is in milliseconds */
-  union {
-    float data[4];              ///< Raw data
-    sensors_vec_t acceleration; /**< acceleration values are in meter per second
-                                   per second (m/s^2) */
-    sensors_vec_t
-        magnetic; /**< magnetic vector values are in micro-Tesla (uT) */
-    sensors_vec_t orientation; /**< orientation values are in degrees */
-    sensors_vec_t gyro;        /**< gyroscope values are in rad/s */
-    float temperature; /**< temperature is in degrees centigrade (Celsius) */
-    float distance;    /**< distance in centimeters */
-    float light;       /**< light in SI lux units */
-    float pressure;    /**< pressure in hectopascal (hPa) */
-    float relative_humidity; /**< relative humidity in percent */
-    float current;           /**< current in milliamps (mA) */
-    float voltage;           /**< voltage in volts (V) */
-    float tvoc;              /**< Total Volatile Organic Compounds, in ppb */
-    float voc_index; /**< VOC (Volatile Organic Compound) index where 100 is
-                          normal (unitless) */
-    float nox_index; /**< NOx (Nitrogen Oxides) index where 100 is normal
-                          (unitless) */
-    sensors_color_t color; /**< color in RGB component values */
-  };                       ///< Union for the wide ranges of data we can carry
+    int32_t version;   /**< must be sizeof(struct sensors_event_t) */
+    int32_t sensor_id; /**< unique sensor identifier */
+    int32_t type;      /**< sensor type */
+    int32_t reserved0; /**< reserved */
+    int32_t timestamp; /**< time is in milliseconds */
+    union {
+        float data[4];              ///< Raw data
+        sensors_vec_t acceleration; /**< acceleration values are in meter per second
+                                       per second (m/s^2) */
+        sensors_vec_t
+            magnetic; /**< magnetic vector values are in micro-Tesla (uT) */
+        sensors_vec_t orientation; /**< orientation values are in degrees */
+        sensors_vec_t gyro;        /**< gyroscope values are in rad/s */
+        float temperature; /**< temperature is in degrees centigrade (Celsius) */
+        float distance;    /**< distance in centimeters */
+        float light;       /**< light in SI lux units */
+        float pressure;    /**< pressure in hectopascal (hPa) */
+        float relative_humidity; /**< relative humidity in percent */
+        float current;           /**< current in milliamps (mA) */
+        float voltage;           /**< voltage in volts (V) */
+        float tvoc;              /**< Total Volatile Organic Compounds, in ppb */
+        float voc_index; /**< VOC (Volatile Organic Compound) index where 100 is
+                              normal (unitless) */
+        float nox_index; /**< NOx (Nitrogen Oxides) index where 100 is normal
+                              (unitless) */
+        sensors_color_t color; /**< color in RGB component values */
+    };                       ///< Union for the wide ranges of data we can carry
 } sensors_event_t;
 
 /* Sensor details (40 bytes) */
 /** struct sensor_s is used to describe basic information about a specific
  * sensor. */
 typedef struct {
-  char name[12];     /**< sensor name */
-  int32_t version;   /**< version of the hardware + driver */
-  int32_t sensor_id; /**< unique sensor identifier */
-  int32_t type;      /**< this sensor's type (ex. SENSOR_TYPE_LIGHT) */
-  float max_value;   /**< maximum value of this sensor's value in SI units */
-  float min_value;   /**< minimum value of this sensor's value in SI units */
-  float resolution; /**< smallest difference between two values reported by this
-                       sensor */
-  int32_t min_delay; /**< min delay in microseconds between events. zero = not a
-                        constant rate */
+    char name[12];     /**< sensor name */
+    int32_t version;   /**< version of the hardware + driver */
+    int32_t sensor_id; /**< unique sensor identifier */
+    int32_t type;      /**< this sensor's type (ex. SENSOR_TYPE_LIGHT) */
+    float max_value;   /**< maximum value of this sensor's value in SI units */
+    float min_value;   /**< minimum value of this sensor's value in SI units */
+    float resolution; /**< smallest difference between two values reported by this
+                         sensor */
+    int32_t min_delay; /**< min delay in microseconds between events. zero = not a
+                          constant rate */
 } sensor_t;
 
 /** @brief Common sensor interface to unify various sensors.
@@ -159,27 +159,27 @@ typedef struct {
  */
 class Unified_Sensor {
 public:
-  // Constructor(s)
-  Unified_Sensor() {}
-  virtual ~Unified_Sensor() {}
+    // Constructor(s)
+    Unified_Sensor() {}
+    virtual ~Unified_Sensor() {}
 
-  // These must be defined by the subclass
+    // These must be defined by the subclass
 
-  /*! @brief Whether we should automatically change the range (if possible) for
-     higher precision
-      @param enabled True if we will try to autorange */
-  virtual void enableAutoRange(bool enabled) {
-    (void)enabled; /* suppress unused warning */
-  };
+    /*! @brief Whether we should automatically change the range (if possible) for
+       higher precision
+        @param enabled True if we will try to autorange */
+    virtual void enableAutoRange(bool enabled) {
+        (void)enabled; /* suppress unused warning */
+    };
 
-  /*! @brief Get the latest sensor event
-      @returns True if able to fetch an event */
-  virtual bool getEvent(sensors_event_t *) = 0;
-  /*! @brief Get info about the sensor itself */
-  virtual void getSensor(sensor_t *) = 0;
+    /*! @brief Get the latest sensor event
+        @returns True if able to fetch an event */
+    virtual bool getEvent(sensors_event_t*) = 0;
+    /*! @brief Get info about the sensor itself */
+    virtual void getSensor(sensor_t*) = 0;
 
-  void printSensorDetails(void);
+    void printSensorDetails(void);
 
 private:
-  bool _autoRange;
+    bool _autoRange;
 };


### PR DESCRIPTION
## Overview

This Pull Request adds support for the [BNO055](https://www.bosch-sensortec.com/products/smart-sensors/bno055/) from Bosch Sensortec.

Adafruit produce a nice [Absolute Orientation IMU Breakout](https://www.adafruit.com/product/2472) development module with this sensor built-in.

Instead of introducing more dependencies on third-party libraries, I have elected to create my own versions of the necessary support libraries for this sensor. 99% of these libraries _are_ based on the ones made by Adafruit.

## What's new

- Example firmware: AHRS telemetry.
  - Aggregates ELRS, GPS, & IMU into one firmware, based on previous examples.
  - Currently a work-in-progress.
  - Currently, two compile options exst:  ```PRINT_IMU_DATA``` & ```TEST_IMU```.
    These may change in the future, as they are here only to aid in developing the necessary drivers for the IMU.
    ```TEST IMU``` must be set to ```1``` if you want to test the IMU in isolation -IE the comms with a GPS & connected ELRS receiver will not run. You also need to have ```PRINT_IMU_DATA``` set to ```1``` before flashing, otherwise you _will not_ be able to see the IMU's gyro output in the Serial Monitor.
- BNO055 driver.
  - Based on Adafruit's [BNO055 library](https://github.com/adafruit/Adafruit_BNO055) by K. Townsend.
  - Includes the original IMU maths utilities.
- Generic BusIO I2C abstraction layer.
  - Based on Adafruit's [BusIO](https://github.com/adafruit/Adafruit_BusIO) I2C & SPI abstraction layer.
- Generic I2C driver.
  - Based on Arduino's [TWI/I2C Libary for Arduino Zero.](https://www.arduino.cc/reference/en/language/functions/communication/wire/)
- Generic IMU driver & abstraction layer.
  - Entirely my own handiwork.
- Generic Unified Sensor library.
  - Based on Adafruit's [Unified Sensor Library.](https://github.com/adafruit/Adafruit_Sensor)