### PR TITLE
Manually point Arduino IDE to Compatibility Table location

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The example below demonstrates what your code should look like, using the instru
 
 /* 2. Declare a CRSFforArduino object.
 You can call it literally anything you want, as long as you tell CRSF for Arduino what serial port your receiver is connected to. */
-CRSFforArduino crsf = CRSFforArduino(&Serial1)
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 void setup()
 {

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
  * @version 0.4.0
- * @date 2023-05-31
+ * @date 2023-06-03
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.h
+++ b/src/CRSFforArduino.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
  * @version 0.4.0
- * @date 2023-05-31
+ * @date 2023-06-03
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -25,7 +25,11 @@
  */
 
 #include "CRSFforArduino.h"
+#if defined(ARDUINO) && defined(PLATFORMIO)
 #include "CompatibilityTable.h"
+#else
+#include "lib/CompatibilityTable/CompatibilityTable.h"
+#endif
 
 CompatibilityTable CT = CompatibilityTable();
 

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 0.4.0
- * @date 2023-05-31
+ * @date 2023-06-03
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/CRSFforArduino.h
+++ b/src/lib/CRSFforArduino/CRSFforArduino.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 0.4.0
- * @date 2023-05-31
+ * @date 2023-06-03
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -1,3 +1,29 @@
+/**
+ * @file CompatibilityTable.cpp
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief Compatibility Table is used to determine if the current device is compatible with CRSF for Arduino.
+ * @version 0.4.0
+ * @date 2023-06-03
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ * @section License GNU General Public License v3.0
+ * This source file is a part of the CRSF for Arduino library.
+ * CRSF for Arduino is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CRSF for Arduino is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CRSF for Arduino.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "CompatibilityTable.h"
 
 CompatibilityTable::CompatibilityTable()

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -53,6 +53,9 @@ CompatibilityTable::CompatibilityTable()
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif // ADAFRUIT_FEATHER_M0 etc
+#else
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#warning "Devboard not supported. Please check the compatibility table."
 #endif // ARDUINO_ARCH_SAMD
 }
 

--- a/src/lib/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CompatibilityTable/CompatibilityTable.h
@@ -1,3 +1,29 @@
+/**
+ * @file CompatibilityTable.h
+ * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
+ * @brief Compatibility Table is used to determine if the current device is compatible with CRSF for Arduino.
+ * @version 0.4.0
+ * @date 2023-06-03
+ *
+ * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
+ *
+ * @section License GNU General Public License v3.0
+ * This header file is a part of the CRSF for Arduino library.
+ * CRSF for Arduino is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CRSF for Arduino is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CRSF for Arduino.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 #pragma once
 
 #include "Arduino.h"

--- a/src/src/main_rc.cpp
+++ b/src/src/main_rc.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
  * @version 0.4.0
- * @date 2023-05-31
+ * @date 2023-06-03
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
## Overview

This Pull Request fixes #20 (as discussed in #19).

## What's changed

I had to add in some preprocessor statements to  differentiate between how PlatformIO sees files & how the Arduino IDE sees files. This results in two seperate includes for the Compatibility Table, based on what is being used to build a project that uses CRSF for Arduino.
This is completely transparent to the developer.

## Additional

I also added in two more preprocessor statements to provide appropriate warnings in the compiler, when CRSF for Arduino is being compiled for incompatible hardware.

This warning will not flag as a compilation error.