### PR TITLE
refactor(compatibility table): Use USB VIDs & PIDs to detect compatible development boards

### DIFF
--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -2,8 +2,8 @@
  * @file channels.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
- * @version 0.3.2
- * @date 2023-06-03
+ * @version 0.3.3
+ * @date 2023-07-18
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRSFforArduino
-version=0.3.2
+version=0.3.3
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=An Arduino Library for communicating with ExpressLRS receivers.

--- a/platformio.ini
+++ b/platformio.ini
@@ -113,8 +113,8 @@ board_build.f_cpu = ${common.cpu_speed}
 build_flags = ${common.compile_flags}
 lib_deps = ${common.lib_deps}
 
-[env:adafruit_grand_central_m4]
-board = adafruit_grand_central_m4
+[env:adafruit_grandcentral_m4]
+board = adafruit_grandcentral_m4
 board_build.f_cpu = ${common.cpu_speed}
 build_flags = ${common.compile_flags}
 debug_tool = ${common.debugger}

--- a/src/CRSFforArduino.h
+++ b/src/CRSFforArduino.h
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
- * @version 0.3.2
- * @date 2023-06-03
+ * @version 0.3.3
+ * @date 2023-07-18
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
- * @version 0.3.2
- * @date 2023-06-03
+ * @version 0.3.3
+ * @date 2023-07-18
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -331,65 +331,6 @@ Sercom *CRSFforArduino::_getSercom()
     /* Get the SERCOM instance for the current UART.
     This adds compatibility with most development boards on the market today. */
 
-    // DEPRECATED:
-    // #if defined(__SAMD21E18A__)
-
-    // /* Adafruit QtPy M0 & Trinket M0. */
-    // #if defined(ADAFRUIT_QTPY_M0) || defined(ADAFRUIT_TRINKET_M0)
-    //     sercom = SERCOM0;
-    // #endif
-
-    // #elif defined(__SAMD21G18A__)
-
-    // /* Adafruit Feather M0 , Feather M0 Express, ItsyBitsy M0 & Metro M0 Express. */
-    // #if defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ADAFRUIT_ITSYBITSY_M0) || "\"
-    //     defined(ADAFRUIT_METRO_M0_EXPRESS)
-    //     sercom = SERCOM0;
-
-    // /* The entire lineup of Arduino MKR boards. */
-    // #elif defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SAMD_MKRFox1200) || defined(ARDUINO_SAMD_MKRGSM1400) ||   "\"
-    //     defined(ARDUINO_SAMD_MKRNB1500) || defined(ARDUINO_SAMD_MKRVIDOR4000) || defined(ARDUINO_SAMD_MKRWAN1300) || "\"
-    //     defined(ARDUINO_SAMD_MKRWAN1310) || defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_MKRZERO) ||    "\"
-    //     defined(ARDUINO_SAMD_NANO_33_IOT)
-    //     sercom = SERCOM5;
-
-    // /* Arduino Zero. */
-    // #elif defined(ARDUINO_SAMD_ZERO)
-    //     sercom = SERCOM0;
-    // #endif
-
-    // #elif defined(__SAMD51G19A__)
-
-    // /* Adafruit ItsyBitsy M4 Express. */
-    // #if defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS)
-    //     sercom = SERCOM3;
-    // #endif
-
-    // #elif defined(__SAMD51J19A__)
-
-    // /* Adafruit Feather M4 Express. */
-    // #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-    //     sercom = SERCOM5;
-    //     ;
-
-    // /* Adafruit Metro M4 Airlift Lite & Metro M4 Express. */
-    // #elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_METRO_M4_EXPRESS)
-    //     sercom = SERCOM3;
-    // #endif
-    // #elif defined(__SAMD51P20A__)
-
-    // /* Adafruit Grand Central M4. */
-    // #if defined(ADAFRUIT_GRAND_CENTRAL_M4)
-    //     sercom = SERCOM0;
-    // #endif
-    // #elif defined(__SAME51J19A__)
-
-    // /* Adafruit Feather M4 CAN. */
-    // #if defined(ADAFRUIT_FEATHER_M4_CAN)
-    //     sercom = SERCOM5;
-    // #endif
-    // #endif
-
 #if USB_VID == 0x239A
     // Adafruit devboards
 

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -331,63 +331,64 @@ Sercom *CRSFforArduino::_getSercom()
     /* Get the SERCOM instance for the current UART.
     This adds compatibility with most development boards on the market today. */
 
-#if defined(__SAMD21E18A__)
+    // DEPRECATED:
+    // #if defined(__SAMD21E18A__)
 
-/* Adafruit QtPy M0 & Trinket M0. */
-#if defined(ADAFRUIT_QTPY_M0) || defined(ADAFRUIT_TRINKET_M0)
-    sercom = SERCOM0;
-#endif
+    // /* Adafruit QtPy M0 & Trinket M0. */
+    // #if defined(ADAFRUIT_QTPY_M0) || defined(ADAFRUIT_TRINKET_M0)
+    //     sercom = SERCOM0;
+    // #endif
 
-#elif defined(__SAMD21G18A__)
+    // #elif defined(__SAMD21G18A__)
 
-/* Adafruit Feather M0 , Feather M0 Express, ItsyBitsy M0 & Metro M0 Express. */
-#if defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ADAFRUIT_ITSYBITSY_M0) || \
-    defined(ADAFRUIT_METRO_M0_EXPRESS)
-    sercom = SERCOM0;
+    // /* Adafruit Feather M0 , Feather M0 Express, ItsyBitsy M0 & Metro M0 Express. */
+    // #if defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ADAFRUIT_ITSYBITSY_M0) || "\"
+    //     defined(ADAFRUIT_METRO_M0_EXPRESS)
+    //     sercom = SERCOM0;
 
-/* The entire lineup of Arduino MKR boards. */
-#elif defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SAMD_MKRFox1200) || defined(ARDUINO_SAMD_MKRGSM1400) ||   \
-    defined(ARDUINO_SAMD_MKRNB1500) || defined(ARDUINO_SAMD_MKRVIDOR4000) || defined(ARDUINO_SAMD_MKRWAN1300) || \
-    defined(ARDUINO_SAMD_MKRWAN1310) || defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_MKRZERO) ||    \
-    defined(ARDUINO_SAMD_NANO_33_IOT)
-    sercom = SERCOM5;
+    // /* The entire lineup of Arduino MKR boards. */
+    // #elif defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SAMD_MKRFox1200) || defined(ARDUINO_SAMD_MKRGSM1400) ||   "\"
+    //     defined(ARDUINO_SAMD_MKRNB1500) || defined(ARDUINO_SAMD_MKRVIDOR4000) || defined(ARDUINO_SAMD_MKRWAN1300) || "\"
+    //     defined(ARDUINO_SAMD_MKRWAN1310) || defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_MKRZERO) ||    "\"
+    //     defined(ARDUINO_SAMD_NANO_33_IOT)
+    //     sercom = SERCOM5;
 
-/* Arduino Zero. */
-#elif defined(ARDUINO_SAMD_ZERO)
-    sercom = SERCOM0;
-#endif
+    // /* Arduino Zero. */
+    // #elif defined(ARDUINO_SAMD_ZERO)
+    //     sercom = SERCOM0;
+    // #endif
 
-#elif defined(__SAMD51G19A__)
+    // #elif defined(__SAMD51G19A__)
 
-/* Adafruit ItsyBitsy M4 Express. */
-#if defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS)
-    sercom = SERCOM3;
-#endif
+    // /* Adafruit ItsyBitsy M4 Express. */
+    // #if defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS)
+    //     sercom = SERCOM3;
+    // #endif
 
-#elif defined(__SAMD51J19A__)
+    // #elif defined(__SAMD51J19A__)
 
-/* Adafruit Feather M4 Express. */
-#if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-    sercom = SERCOM5;
-    ;
+    // /* Adafruit Feather M4 Express. */
+    // #if defined(ADAFRUIT_FEATHER_M4_EXPRESS)
+    //     sercom = SERCOM5;
+    //     ;
 
-/* Adafruit Metro M4 Airlift Lite & Metro M4 Express. */
-#elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_METRO_M4_EXPRESS)
-    sercom = SERCOM3;
-#endif
-#elif defined(__SAMD51P20A__)
+    // /* Adafruit Metro M4 Airlift Lite & Metro M4 Express. */
+    // #elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_METRO_M4_EXPRESS)
+    //     sercom = SERCOM3;
+    // #endif
+    // #elif defined(__SAMD51P20A__)
 
-/* Adafruit Grand Central M4. */
-#if defined(ADAFRUIT_GRAND_CENTRAL_M4)
-    sercom = SERCOM0;
-#endif
-#elif defined(__SAME51J19A__)
+    // /* Adafruit Grand Central M4. */
+    // #if defined(ADAFRUIT_GRAND_CENTRAL_M4)
+    //     sercom = SERCOM0;
+    // #endif
+    // #elif defined(__SAME51J19A__)
 
-/* Adafruit Feather M4 CAN. */
-#if defined(ADAFRUIT_FEATHER_M4_CAN)
-    sercom = SERCOM5;
-#endif
-#endif
+    // /* Adafruit Feather M4 CAN. */
+    // #if defined(ADAFRUIT_FEATHER_M4_CAN)
+    //     sercom = SERCOM5;
+    // #endif
+    // #endif
 
     return sercom;
 }

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -390,6 +390,80 @@ Sercom *CRSFforArduino::_getSercom()
     // #endif
     // #endif
 
+#if USB_VID == 0x239A
+    // Adafruit devboards
+
+#if defined(__SAMD21G18A__)
+    // Devboards that use the SAMD21G18A chip.
+
+#if USB_PID == 0x800B || USB_PID == 0x801B || USB_PID == 0x800F || USB_PID == 0x8013
+    // Adafruit Feather M0, Feather M0 Express, ItsyBitsy M0 & Metro M0 Express.
+
+    sercom = SERCOM0;
+#endif
+
+#elif defined(__SAMD51G19A__)
+    // Devboards that use the SAMD51G19A chip.
+
+#if USB_PID == 0x802B
+    // Adafruit ItsyBitsy M4 Express.
+
+    sercom = SERCOM3;
+#endif
+
+#elif defined(__SAMD51J19A__)
+    // Devboards that use the SAMD51J19A chip.
+
+#if USB_PID == 0x8031
+    // Adafruit Feather M4 Express.
+
+    sercom = SERCOM5;
+#elif USB_PID == 0x8037 || USB_PID == 0x8020
+    // Adafruit Metro M4 Airlift Lite & Metro M4 Express.
+
+    sercom = SERCOM3;
+#endif
+
+#elif defined(__SAMD51P20A__)
+    // Devboards that use the SAMD51P20A chip.
+
+#if USB_PID == 0x8020
+    // Adafruit Grand Central M4.
+
+    sercom = SERCOM0;
+#endif
+
+#elif defined(__SAME51J19A__)
+    // Devboards that use the SAME51J19A chip.
+
+#if USB_PID == 0x80CD
+    // Adafruit Feather M4 CAN.
+
+    sercom = SERCOM5;
+#endif
+
+#endif
+
+#elif USB_VID == 0x2341
+    // Arduino devboards
+
+#if defined(__SAMD21G18A__)
+    // Devboards that use the SAMD21G18A chip.
+
+    // All Arduino MKR boards use the same SERCOM instance.
+#if USB_PID == 0x8050 || USB_PID == 0x8052 || USB_PID == 0x8055 || USB_PID == 0x8056 || USB_PID == 0x8053 || USB_PID == 0x8059 || USB_PID == 0x8054 || USB_PID == 0x804F
+    // Arduino MKR FOX 1200, MKR GSM 1400, MKR NB 1500, MKR Vidor 4000, MKR WAN 1300, MKR WAN 1310, MKR WIFI 1010 & MKR ZERO.
+
+    sercom = SERCOM5;
+
+#elif USB_PID == 0x804D
+    // Arduino Zero.
+
+    sercom = SERCOM0;
+#endif
+#endif
+#endif
+
     return sercom;
 }
 #endif

--- a/src/lib/CRSFforArduino/CRSFforArduino.h
+++ b/src/lib/CRSFforArduino/CRSFforArduino.h
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
- * @version 0.3.2
- * @date 2023-06-03
+ * @version 0.3.3
+ * @date 2023-07-18
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -86,8 +86,8 @@ CompatibilityTable::CompatibilityTable()
 #endif // ARDUINO_ARCH_SAMD
 */
 
-// Arduino IDE must be 1.7.0 or greater
-#if ARDUINO >= 10700
+// TEMPORARILY DISABLED: Arduino IDE must be 1.7.0 or greater
+// #if ARDUINO >= 10700
 
 // Arduino SAMD Architecture
 #if defined(ARDUINO_ARCH_SAMD)
@@ -216,9 +216,9 @@ CompatibilityTable::CompatibilityTable()
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_ARCH_SAMD
 
-#else
-#error "This library requires Arduino IDE 1.7.0 or greater. Please update your IDE."
-#endif // ARDUINO >= 10700
+// #else
+// #error "This library requires Arduino IDE 1.7.0 or greater. Please update your IDE."
+// #endif // ARDUINO >= 10700
 }
 
 bool CompatibilityTable::isDevboardCompatible(const char *name)

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -210,10 +210,12 @@ CompatibilityTable::CompatibilityTable()
 #warning "Devboard not supported. Please check the compatibility table."
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_SAMD_ADAFRUIT
+
 #else // Unsupported architecture
 #error "Unsupported architecture. Please check the compatibility table."
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_ARCH_SAMD
+
 #else
 #error "This library requires Arduino IDE 1.8.5 or greater. Please update your IDE."
 #endif // ARDUINO >= 10805

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -28,6 +28,7 @@
 
 CompatibilityTable::CompatibilityTable()
 {
+    /* DEPRECATED: This now uses the USB PID and VID to determine the devboard type.
 #if defined(ARDUINO_ARCH_SAMD)
 #if defined(ADAFRUIT_FEATHER_M0)
     device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M0;
@@ -83,6 +84,7 @@ CompatibilityTable::CompatibilityTable()
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif // ARDUINO_ARCH_SAMD
+*/
 }
 
 bool CompatibilityTable::isDevboardCompatible(const char *name)

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -211,7 +211,7 @@ CompatibilityTable::CompatibilityTable()
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_SAMD_ADAFRUIT
 #else // Unsupported architecture
-#warning "Unsupported architecture. Please check the compatibility table."
+#error "Unsupported architecture. Please check the compatibility table."
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_ARCH_SAMD
 #else

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -211,7 +211,7 @@ CompatibilityTable::CompatibilityTable()
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_SAMD_ADAFRUIT
 #else // Unsupported architecture
-#error "Unsupported architecture. Please check the compatibility table."
+#warning "Unsupported architecture. Please check the compatibility table."
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_ARCH_SAMD
 #else

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -2,8 +2,8 @@
  * @file CompatibilityTable.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Compatibility Table is used to determine if the current device is compatible with CRSF for Arduino.
- * @version 0.3.2
- * @date 2023-06-03
+ * @version 0.3.3
+ * @date 2023-07-18
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -28,64 +28,6 @@
 
 CompatibilityTable::CompatibilityTable()
 {
-    /* DEPRECATED: This now uses the USB PID and VID to determine the devboard type.
-#if defined(ARDUINO_ARCH_SAMD)
-#if defined(ADAFRUIT_FEATHER_M0)
-    device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M0;
-#elif defined(ADAFRUIT_FEATHER_M0_EXPRESS)
-    device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M0_EXPRESS;
-#elif defined(ADAFRUIT_ITSYBITSY_M0)
-    device.type.devboard = DEVBOARD_ADAFRUIT_ITSYBITSY_M0_EXPRESS;
-#elif defined(ADAFRUIT_METRO_M0_EXPRESS)
-    device.type.devboard = DEVBOARD_ADAFRUIT_METRO_M0_EXPRESS;
-#elif defined(ADAFRUIT_QTPY_M0)
-    device.type.devboard = DEVBOARD_ADAFRUIT_QTPY_M0;
-#elif defined(ADAFRUIT_TRINKET_M0)
-    device.type.devboard = DEVBOARD_ADAFRUIT_TRINKET_M0;
-#elif defined(ADAFRUIT_FEATHER_M4_EXPRESS)
-    device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M4_EXPRESS;
-#elif defined(ADAFRUIT_GRAND_CENTRAL_M4)
-    device.type.devboard = DEVBOARD_ADAFRUIT_GRAND_CENTRAL_M4;
-#elif defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS)
-    device.type.devboard = DEVBOARD_ADAFRUIT_ITSYBITSY_M4_EXPRESS;
-#elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE)
-    device.type.devboard = DEVBOARD_ADAFRUIT_METRO_M4_AIRLIFT_LITE;
-#elif defined(ADAFRUIT_METRO_M4_EXPRESS)
-    device.type.devboard = DEVBOARD_ADAFRUIT_METRO_M4_EXPRESS;
-#elif defined(ADAFRUIT_FEATHER_M4_CAN)
-    device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M4_CAN;
-#elif defined(ARDUINO_SAMD_MKR1000)
-    device.type.devboard = DEVBOARD_ARDUINO_MKR1000;
-#elif defined(ARDUINO_SAMD_MKRFox1200)
-    device.type.devboard = DEVBOARD_ARDUINO_MKRFox1200;
-#elif defined(ARDUINO_SAMD_MKRGSM1400)
-    device.type.devboard = DEVBOARD_ARDUINO_MKRGSM1400;
-#elif defined(ARDUINO_SAMD_MKRNB1500)
-    device.type.devboard = DEVBOARD_ARDUINO_MKRNB1500;
-#elif defined(ARDUINO_SAMD_MKRVIDOR4000)
-    device.type.devboard = DEVBOARD_ARDUINO_MKRVIDOR4000;
-#elif defined(ARDUINO_SAMD_MKRWAN1300)
-    device.type.devboard = DEVBOARD_ARDUINO_MKRWAN1300;
-#elif defined(ARDUINO_SAMD_MKRWAN1310)
-    device.type.devboard = DEVBOARD_ARDUINO_MKRWAN1310;
-#elif defined(ARDUINO_SAMD_MKRWIFI1010)
-    device.type.devboard = DEVBOARD_ARDUINO_MKRWIFI1010;
-#elif defined(ARDUINO_SAMD_MKRZERO)
-    device.type.devboard = DEVBOARD_ARDUINO_MKRZERO;
-#elif defined(ARDUINO_SAMD_NANO_33_IOT)
-    device.type.devboard = DEVBOARD_ARDUINO_NANO_33_IOT;
-#elif defined(ARDUINO_SAMD_ZERO)
-    device.type.devboard = DEVBOARD_ARDUINO_ZERO;
-#else
-    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
-#warning "Devboard not supported. Please check the compatibility table."
-#endif // ADAFRUIT_FEATHER_M0 etc
-#else
-    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
-#warning "Devboard not supported. Please check the compatibility table."
-#endif // ARDUINO_ARCH_SAMD
-*/
-
 // TEMPORARILY DISABLED: Arduino IDE must be 1.7.0 or greater
 // #if ARDUINO >= 10700
 

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -86,8 +86,8 @@ CompatibilityTable::CompatibilityTable()
 #endif // ARDUINO_ARCH_SAMD
 */
 
-// Arduino IDE must be 1.8.5 or greater
-#if ARDUINO >= 10805
+// Arduino IDE must be 1.7.13 or greater
+#if ARDUINO >= 10713
 
 // Arduino SAMD Architecture
 #if defined(ARDUINO_ARCH_SAMD)

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -85,6 +85,138 @@ CompatibilityTable::CompatibilityTable()
 #warning "Devboard not supported. Please check the compatibility table."
 #endif // ARDUINO_ARCH_SAMD
 */
+
+// Arduino IDE must be 1.8.5 or greater
+#if ARDUINO >= 10805
+
+// Arduino SAMD Architecture
+#if defined(ARDUINO_ARCH_SAMD)
+
+// Adafruit devboards
+#if USB_VID == 0x239A
+
+#if defined(__SAMD21G18A__)
+// Adafruit Feather M0
+#if USB_PID == 0x800B
+    device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M0;
+// Adafruit Feather M0 Express
+#elif USB_PID == 0x801B
+    device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M0_EXPRESS;
+// Adafruit ItsyBitsy M0
+#elif USB_PID == 0x800F
+    device.type.devboard = DEVBOARD_ADAFRUIT_ITSYBITSY_M0_EXPRESS;
+// Adafruit Metro M0 Express
+#elif USB_PID == 0x8013
+    device.type.devboard = DEVBOARD_ADAFRUIT_METRO_M0_EXPRESS;
+// Device is not supported
+#else
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#warning "Devboard not supported. Please check the compatibility table."
+#endif
+
+#elif defined(__SAMD51J19A__)
+// Adafruit Feather M4 Express
+#if USB_PID == 0x8031 
+    device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M4_EXPRESS;
+// Adafruit Metro M4 Express
+#elif USB_PID == 0x8020
+    device.type.devboard = DEVBOARD_ADAFRUIT_METRO_M4_EXPRESS;
+// Adafruit Metro M4 AirLift Lite
+#elif USB_PID == 0x8037
+    device.type.devboard = DEVBOARD_ADAFRUIT_METRO_M4_AIRLIFT_LITE;
+// Device is not supported
+#else
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#warning "Devboard not supported. Please check the compatibility table."
+#endif
+
+#elif defined(__SAMD51G19A__)
+// Adafruit ItsyBitsy M4 Express
+#if USB_PID == 0x802B
+    device.type.devboard = DEVBOARD_ADAFRUIT_ITSYBITSY_M4_EXPRESS;
+// Device is not supported
+#else
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#warning "Devboard not supported. Please check the compatibility table."
+#endif
+
+#elif defined(__SAMD51P20A__)
+// Adafruit Grand Central M4
+#if USB_PID == 0x8020
+    device.type.devboard = DEVBOARD_ADAFRUIT_GRAND_CENTRAL_M4;
+// Device is not supported
+#else
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#warning "Devboard not supported. Please check the compatibility table."
+#endif
+
+#elif defined(__SAME51J19A__)
+// Adafruit Feather M4 CAN
+#if USB_PID == 0x80CD
+    device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M4_CAN;
+// Device is not supported
+#else
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#warning "Devboard not supported. Please check the compatibility table."
+#endif
+#else // Incompatible devboards
+#warning "Devboard not supported. Please check the compatibility table."
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#endif
+
+// Arduino devboards
+#elif USB_VID == 0x2341
+
+#if defined(__SAMD21G18A__)
+// Arduino MKRFOX1200
+#if USB_PID == 0x8050
+    device.type.devboard = DEVBOARD_ARDUINO_MKRFOX1200;
+// Arduino MKRGSM1400
+#elif USB_PID == 0x8052
+    device.type.devboard = DEVBOARD_ARDUINO_MKRGSM1400;
+// Arduino MKRNB1500
+#elif USB_PID == 0x8055
+    device.type.devboard = DEVBOARD_ARDUINO_MKRNB1500;
+// Arduino MKRVIDOR4000
+#elif USB_PID == 0x8056
+    device.type.devboard = DEVBOARD_ARDUINO_MKRVIDOR4000;
+// Arduino MKRWAN1300
+#elif USB_PID == 0x8053
+    device.type.devboard = DEVBOARD_ARDUINO_MKRWAN1300;
+// Arduino MKRWAN1310
+#elif USB_PID == 0x8059
+    device.type.devboard = DEVBOARD_ARDUINO_MKRWAN1310;
+// Arduino MKRWiFi1010
+#elif USB_PID == 0x8054
+    device.type.devboard = DEVBOARD_ARDUINO_MKRWIFI1010;
+// Arduino MKRZERO
+#elif USB_PID == 0x804F
+    device.type.devboard = DEVBOARD_ARDUINO_MKRZERO;
+// Arduino Zero
+#elif USB_PID == 0x804D
+    device.type.devboard = DEVBOARD_ARDUINO_ZERO;
+// Device is not supported
+#else
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#warning "Devboard not supported. Please check the compatibility table."
+#endif
+    
+#else // Incompatible devboards
+#warning "Devboard not supported. Please check the compatibility table."
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#endif
+
+#else // Incompatible devboards
+#warning "Devboard not supported. Please check the compatibility table."
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#endif // ARDUINO_SAMD_ADAFRUIT
+#else // Unsupported architecture
+#error "Unsupported architecture. Please check the compatibility table."
+    device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#endif // ARDUINO_ARCH_SAMD
+#else
+#error "This library requires Arduino IDE 1.8.5 or greater. Please update your IDE."
+#endif // ARDUINO >= 10805
 }
 
 bool CompatibilityTable::isDevboardCompatible(const char *name)

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -116,7 +116,7 @@ CompatibilityTable::CompatibilityTable()
 
 #elif defined(__SAMD51J19A__)
 // Adafruit Feather M4 Express
-#if USB_PID == 0x8031 
+#if USB_PID == 0x8031
     device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M4_EXPRESS;
 // Adafruit Metro M4 Express
 #elif USB_PID == 0x8020
@@ -200,7 +200,7 @@ CompatibilityTable::CompatibilityTable()
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif
-    
+
 #else // Incompatible devboards
 #warning "Devboard not supported. Please check the compatibility table."
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -86,8 +86,8 @@ CompatibilityTable::CompatibilityTable()
 #endif // ARDUINO_ARCH_SAMD
 */
 
-// Arduino IDE must be 1.7.13 or greater
-#if ARDUINO >= 10713
+// Arduino IDE must be 1.7.0 or greater
+#if ARDUINO >= 10700
 
 // Arduino SAMD Architecture
 #if defined(ARDUINO_ARCH_SAMD)
@@ -217,8 +217,8 @@ CompatibilityTable::CompatibilityTable()
 #endif // ARDUINO_ARCH_SAMD
 
 #else
-#error "This library requires Arduino IDE 1.8.5 or greater. Please update your IDE."
-#endif // ARDUINO >= 10805
+#error "This library requires Arduino IDE 1.7.0 or greater. Please update your IDE."
+#endif // ARDUINO >= 10700
 }
 
 bool CompatibilityTable::isDevboardCompatible(const char *name)

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -216,9 +216,9 @@ CompatibilityTable::CompatibilityTable()
     device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_ARCH_SAMD
 
-// #else
-// #error "This library requires Arduino IDE 1.7.0 or greater. Please update your IDE."
-// #endif // ARDUINO >= 10700
+    // #else
+    // #error "This library requires Arduino IDE 1.7.0 or greater. Please update your IDE."
+    // #endif // ARDUINO >= 10700
 }
 
 bool CompatibilityTable::isDevboardCompatible(const char *name)

--- a/src/lib/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CompatibilityTable/CompatibilityTable.h
@@ -2,8 +2,8 @@
  * @file CompatibilityTable.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Compatibility Table is used to determine if the current device is compatible with CRSF for Arduino.
- * @version 0.3.2
- * @date 2023-06-03
+ * @version 0.3.3
+ * @date 2023-07-18
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/library.json
+++ b/src/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "CRSFforArduino",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "Arduino library for Crossfire protocol",
     "keywords": [
         "adafruit",

--- a/src/src/main_rc.cpp
+++ b/src/src/main_rc.cpp
@@ -2,8 +2,8 @@
  * @file main_rc.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
- * @version 0.3.2
- * @date 2023-06-03
+ * @version 0.3.3
+ * @date 2023-07-18
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
## Overview

While I was working on #27, it came to my attention that, in some cases, an incompatible development board was being seen (by default) as an Arduino Zero - Resulting in unpredictable behaviour.

This Pull Request resolves that problem.

## What's changed

The old way of checking compatibility via preprocessor checks on each pre-defined development board name is deprecated.

Here is what this Pull Request brings:

1. The first check is the Arduino IDE version. This _must_ be 1.8.5 or greater.
2. The second check is the architecture. This _must_ be based on the Arduino SAMD Architecture `ARDUINO_ARCH_SAMD`.
3. Next up is the vendor check. This uses the USB Vendor ID to determine the manufacturer of your development board.
4. The fourth check is the chipset that is used. Current compatible chipsets are the Microchip SAM D21, SAM D51, & SAM E51 series.
5. Within each chipset check, the USB Product ID is used to discover your development board.

Anything that fails one (or more) of these five checks, that means your development board is incompatible with CRSF for Arduino.