### PR TITLE
refactor(rc channels): Use packed RC channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,11 @@ While CRSF for Arduino is primarily developed on the Adafruit Metro M4 Express, 
 
 Compatibility with other microcontroller boards may be added in future, if there is demand for it. Keep in mind that this will be subject to hardware limitations of the host microcontroller itself.
 
-Generally speaking, if the host microcontroller's UART peripheral supports 420k bauds (or higher), it is a likely candidate for CRSF for Arduino. Bonus points if the microcontroller has DMA (Direct Memory Access), because this helps immensely to capture RC data & send out telemetry data.
+In order for CRSF for Arduino to run, the host microcontroller _must_ meet these minimum requirements:
+
+- Core Clock Speed: 48 MHz or higher.
+- CPU: ARM Cortex M0+ or later.
+- UART Baud Rate: 420 KB/s.
 
 I am now aware that Arduino are making an R4 of their UNO & Adafruit are making a Metro M7. This is exciting news for me, because I would like to make these development boards fully compatible with CRSF for Arduino as & when their respective underlying code & toolchain support is added.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ In order for CRSF for Arduino to run, the host microcontroller _must_ meet these
 
 I am now aware that Arduino are making an R4 of their UNO & Adafruit are making a Metro M7. This is exciting news for me, because I would like to make these development boards fully compatible with CRSF for Arduino as & when their respective underlying code & toolchain support is added.
 
+As for other development boards (& their host microcontrollers), if they meet the minimum requirements & you are still having compatibility issues, it is likely that I have not yet added your board to the Compatibility Table. Consider opening up an [Issue](https://github.com/ZZ-Cat/CRSFforArduino/issues/new/choose) & we can go from there.
+
 ## AVR based microcontrollers are not compatible
 
 Development boards of yesteryear that were built around ATmega AVR microcontrollers such as the 328, 32u4, 2560 & 4809 are incompatible with CRSF for Arduino.

--- a/README.md
+++ b/README.md
@@ -221,8 +221,6 @@ Compatibility with other microcontroller boards may be added in future, if there
 
 Generally speaking, if the host microcontroller's UART peripheral supports 420k bauds (or higher), it is a likely candidate for CRSF for Arduino. Bonus points if the microcontroller has DMA (Direct Memory Access), because this helps immensely to capture RC data & send out telemetry data.
 
-The only limitation so far is the microcontroller's ability to change the UART's data order. CRSF requires data to be transmitted & received in MSB (Most Significant Bit) First. Traditionally, UART is transmitted & received in LSB (Least Significant Bit) First. ATSAMD21 & ATSAMD51 microcontrollers are the only two Arduino-compatible microcontrollers (that I am aware of) that have the ability to select what data order the UART is sent & received as.
-
 I am now aware that Arduino are making an R4 of their UNO & Adafruit are making a Metro M7. This is exciting news for me, because I would like to make these development boards fully compatible with CRSF for Arduino as & when their respective underlying code & toolchain support is added.
 
 ## AVR based microcontrollers are not compatible

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -2,8 +2,8 @@
  * @file channels.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
- * @version 0.3.3
- * @date 2023-07-18
+ * @version 0.3.4
+ * @date 2023-07-21
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRSFforArduino
-version=0.3.3
+version=0.3.4
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=An Arduino Library for communicating with ExpressLRS receivers.

--- a/src/CRSFforArduino.h
+++ b/src/CRSFforArduino.h
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
- * @version 0.3.3
- * @date 2023-07-18
+ * @version 0.3.4
+ * @date 2023-07-21
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -115,18 +115,6 @@ bool CRSFforArduino::begin()
 
 #if defined(ARDUINO_ARCH_SAMD)
     Sercom *_sercom = _getSercom();
-
-    /* Change the data order to MSB First.
-    The CTRLA Register is enable protected, so it needs to be disabled before writing to it.
-    The Enable Bit is write syncronised. Therefore, a wait for sync is necessary.
-    Then re-enable the peripheral again. */
-    _sercom->USART.CTRLA.bit.ENABLE = 0;
-    while (_sercom->USART.SYNCBUSY.bit.ENABLE)
-        ;
-    _sercom->USART.CTRLA.bit.DORD = 1;
-    _sercom->USART.CTRLA.bit.ENABLE = 1;
-    while (_sercom->USART.SYNCBUSY.bit.ENABLE)
-        ;
 #endif
 
     _packetReceived = false;

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -218,22 +218,22 @@ bool CRSFforArduino::update()
                 {
                     // Read the RC channels.
                     // 11 bits per channel, 16 channels = 176 bits = 22 bytes.
-                    _channels[0] = (uint16_t)((_crsfFrame.frame.payload[0] | _crsfFrame.frame.payload[1] << 8) & 0x07FF);
-                    _channels[1] = (uint16_t)((_crsfFrame.frame.payload[1] >> 3 | _crsfFrame.frame.payload[2] << 5) & 0x07FF);
-                    _channels[2] = (uint16_t)((_crsfFrame.frame.payload[2] >> 6 | _crsfFrame.frame.payload[3] << 2 | _crsfFrame.frame.payload[4] << 10) & 0x07FF);
-                    _channels[3] = (uint16_t)((_crsfFrame.frame.payload[4] >> 1 | _crsfFrame.frame.payload[5] << 7) & 0x07FF);
-                    _channels[4] = (uint16_t)((_crsfFrame.frame.payload[5] >> 4 | _crsfFrame.frame.payload[6] << 4) & 0x07FF);
-                    _channels[5] = (uint16_t)((_crsfFrame.frame.payload[6] >> 7 | _crsfFrame.frame.payload[7] << 1 | _crsfFrame.frame.payload[8] << 9) & 0x07FF);
-                    _channels[6] = (uint16_t)((_crsfFrame.frame.payload[8] >> 2 | _crsfFrame.frame.payload[9] << 6) & 0x07FF);
-                    _channels[7] = (uint16_t)((_crsfFrame.frame.payload[9] >> 5 | _crsfFrame.frame.payload[10] << 3) & 0x07FF);
-                    _channels[8] = (uint16_t)((_crsfFrame.frame.payload[11] | _crsfFrame.frame.payload[12] << 8) & 0x07FF);
-                    _channels[9] = (uint16_t)((_crsfFrame.frame.payload[12] >> 3 | _crsfFrame.frame.payload[13] << 5) & 0x07FF);
-                    _channels[10] = (uint16_t)((_crsfFrame.frame.payload[13] >> 6 | _crsfFrame.frame.payload[14] << 2 | _crsfFrame.frame.payload[15] << 10) & 0x07FF);
-                    _channels[11] = (uint16_t)((_crsfFrame.frame.payload[15] >> 1 | _crsfFrame.frame.payload[16] << 7) & 0x07FF);
-                    _channels[12] = (uint16_t)((_crsfFrame.frame.payload[16] >> 4 | _crsfFrame.frame.payload[17] << 4) & 0x07FF);
-                    _channels[13] = (uint16_t)((_crsfFrame.frame.payload[17] >> 7 | _crsfFrame.frame.payload[18] << 1 | _crsfFrame.frame.payload[19] << 9) & 0x07FF);
-                    _channels[14] = (uint16_t)((_crsfFrame.frame.payload[19] >> 2 | _crsfFrame.frame.payload[20] << 6) & 0x07FF);
-                    _channels[15] = (uint16_t)((_crsfFrame.frame.payload[20] >> 5 | _crsfFrame.frame.payload[21] << 3) & 0x07FF);
+                    // _channels[0] = (uint16_t)((_crsfFrame.frame.payload[0] | _crsfFrame.frame.payload[1] << 8) & 0x07FF);
+                    // _channels[1] = (uint16_t)((_crsfFrame.frame.payload[1] >> 3 | _crsfFrame.frame.payload[2] << 5) & 0x07FF);
+                    // _channels[2] = (uint16_t)((_crsfFrame.frame.payload[2] >> 6 | _crsfFrame.frame.payload[3] << 2 | _crsfFrame.frame.payload[4] << 10) & 0x07FF);
+                    // _channels[3] = (uint16_t)((_crsfFrame.frame.payload[4] >> 1 | _crsfFrame.frame.payload[5] << 7) & 0x07FF);
+                    // _channels[4] = (uint16_t)((_crsfFrame.frame.payload[5] >> 4 | _crsfFrame.frame.payload[6] << 4) & 0x07FF);
+                    // _channels[5] = (uint16_t)((_crsfFrame.frame.payload[6] >> 7 | _crsfFrame.frame.payload[7] << 1 | _crsfFrame.frame.payload[8] << 9) & 0x07FF);
+                    // _channels[6] = (uint16_t)((_crsfFrame.frame.payload[8] >> 2 | _crsfFrame.frame.payload[9] << 6) & 0x07FF);
+                    // _channels[7] = (uint16_t)((_crsfFrame.frame.payload[9] >> 5 | _crsfFrame.frame.payload[10] << 3) & 0x07FF);
+                    // _channels[8] = (uint16_t)((_crsfFrame.frame.payload[11] | _crsfFrame.frame.payload[12] << 8) & 0x07FF);
+                    // _channels[9] = (uint16_t)((_crsfFrame.frame.payload[12] >> 3 | _crsfFrame.frame.payload[13] << 5) & 0x07FF);
+                    // _channels[10] = (uint16_t)((_crsfFrame.frame.payload[13] >> 6 | _crsfFrame.frame.payload[14] << 2 | _crsfFrame.frame.payload[15] << 10) & 0x07FF);
+                    // _channels[11] = (uint16_t)((_crsfFrame.frame.payload[15] >> 1 | _crsfFrame.frame.payload[16] << 7) & 0x07FF);
+                    // _channels[12] = (uint16_t)((_crsfFrame.frame.payload[16] >> 4 | _crsfFrame.frame.payload[17] << 4) & 0x07FF);
+                    // _channels[13] = (uint16_t)((_crsfFrame.frame.payload[17] >> 7 | _crsfFrame.frame.payload[18] << 1 | _crsfFrame.frame.payload[19] << 9) & 0x07FF);
+                    // _channels[14] = (uint16_t)((_crsfFrame.frame.payload[19] >> 2 | _crsfFrame.frame.payload[20] << 6) & 0x07FF);
+                    // _channels[15] = (uint16_t)((_crsfFrame.frame.payload[20] >> 5 | _crsfFrame.frame.payload[21] << 3) & 0x07FF);
 
                     // Set the packet received flag.
                     _packetReceived = true;

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -212,30 +212,10 @@ bool CRSFforArduino::update()
             // Check if the packet is a CRSF frame.
             if (_crsfFrame.frame.deviceAddress == CRSF_ADDRESS_FLIGHT_CONTROLLER)
             {
-                // uint8_t payloadSize = _crsfFrame.frame.frameLength - 2;
 
                 // Check if the packet is a CRSF RC frame.
                 if (_crsfFrame.frame.type == CRSF_FRAMETYPE_RC_CHANNELS_PACKED)
                 {
-                    // Read the RC channels.
-                    // 11 bits per channel, 16 channels = 176 bits = 22 bytes.
-                    // _channels[0] = (uint16_t)((_crsfFrame.frame.payload[0] | _crsfFrame.frame.payload[1] << 8) & 0x07FF);
-                    // _channels[1] = (uint16_t)((_crsfFrame.frame.payload[1] >> 3 | _crsfFrame.frame.payload[2] << 5) & 0x07FF);
-                    // _channels[2] = (uint16_t)((_crsfFrame.frame.payload[2] >> 6 | _crsfFrame.frame.payload[3] << 2 | _crsfFrame.frame.payload[4] << 10) & 0x07FF);
-                    // _channels[3] = (uint16_t)((_crsfFrame.frame.payload[4] >> 1 | _crsfFrame.frame.payload[5] << 7) & 0x07FF);
-                    // _channels[4] = (uint16_t)((_crsfFrame.frame.payload[5] >> 4 | _crsfFrame.frame.payload[6] << 4) & 0x07FF);
-                    // _channels[5] = (uint16_t)((_crsfFrame.frame.payload[6] >> 7 | _crsfFrame.frame.payload[7] << 1 | _crsfFrame.frame.payload[8] << 9) & 0x07FF);
-                    // _channels[6] = (uint16_t)((_crsfFrame.frame.payload[8] >> 2 | _crsfFrame.frame.payload[9] << 6) & 0x07FF);
-                    // _channels[7] = (uint16_t)((_crsfFrame.frame.payload[9] >> 5 | _crsfFrame.frame.payload[10] << 3) & 0x07FF);
-                    // _channels[8] = (uint16_t)((_crsfFrame.frame.payload[11] | _crsfFrame.frame.payload[12] << 8) & 0x07FF);
-                    // _channels[9] = (uint16_t)((_crsfFrame.frame.payload[12] >> 3 | _crsfFrame.frame.payload[13] << 5) & 0x07FF);
-                    // _channels[10] = (uint16_t)((_crsfFrame.frame.payload[13] >> 6 | _crsfFrame.frame.payload[14] << 2 | _crsfFrame.frame.payload[15] << 10) & 0x07FF);
-                    // _channels[11] = (uint16_t)((_crsfFrame.frame.payload[15] >> 1 | _crsfFrame.frame.payload[16] << 7) & 0x07FF);
-                    // _channels[12] = (uint16_t)((_crsfFrame.frame.payload[16] >> 4 | _crsfFrame.frame.payload[17] << 4) & 0x07FF);
-                    // _channels[13] = (uint16_t)((_crsfFrame.frame.payload[17] >> 7 | _crsfFrame.frame.payload[18] << 1 | _crsfFrame.frame.payload[19] << 9) & 0x07FF);
-                    // _channels[14] = (uint16_t)((_crsfFrame.frame.payload[19] >> 2 | _crsfFrame.frame.payload[20] << 6) & 0x07FF);
-                    // _channels[15] = (uint16_t)((_crsfFrame.frame.payload[20] >> 5 | _crsfFrame.frame.payload[21] << 3) & 0x07FF);
-
                     // Read the RC channels.
                     memcpy(&_crsfRcChannelsPackedFrame, &_crsfFrame, CRSF_FRAME_SIZE_MAX);
 

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -113,10 +113,6 @@ bool CRSFforArduino::begin()
     _serial->begin(420000, SERIAL_8N1);
     _serial->setTimeout(10);
 
-#if defined(ARDUINO_ARCH_SAMD)
-    Sercom *_sercom = _getSercom();
-#endif
-
     _packetReceived = false;
 
     memset(_crsfFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
@@ -124,6 +120,10 @@ bool CRSFforArduino::begin()
     memset(_channels, 0, sizeof(_channels));
 
 #ifdef USE_DMA
+#if defined(ARDUINO_ARCH_SAMD)
+    Sercom *_sercom = _getSercom();
+#endif
+
     /* Configure the DMA. */
     _dmaSerialRx.setTrigger(SERCOM3_DMAC_ID_RX);
     _dmaSerialRx.setAction(DMA_TRIGGER_ACTON_BEAT);

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
- * @version 0.3.3
- * @date 2023-07-18
+ * @version 0.3.4
+ * @date 2023-07-21
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/CRSFforArduino.cpp
@@ -132,6 +132,7 @@ bool CRSFforArduino::begin()
     _packetReceived = false;
 
     memset(_crsfFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
+    memset(_crsfRcChannelsPackedFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
     memset(_channels, 0, sizeof(_channels));
 
 #ifdef USE_DMA
@@ -235,6 +236,9 @@ bool CRSFforArduino::update()
                     // _channels[14] = (uint16_t)((_crsfFrame.frame.payload[19] >> 2 | _crsfFrame.frame.payload[20] << 6) & 0x07FF);
                     // _channels[15] = (uint16_t)((_crsfFrame.frame.payload[20] >> 5 | _crsfFrame.frame.payload[21] << 3) & 0x07FF);
 
+                    // Read the RC channels.
+                    memcpy(&_crsfRcChannelsPackedFrame, &_crsfFrame, CRSF_FRAME_SIZE_MAX);
+
                     // Set the packet received flag.
                     _packetReceived = true;
                 }
@@ -278,6 +282,27 @@ bool CRSFforArduino::packetReceived()
 
 uint16_t CRSFforArduino::getChannel(uint8_t channel)
 {
+    const __crsf_rcChannelsPacked_t *rcChannelsPacked = (__crsf_rcChannelsPacked_t *)&_crsfRcChannelsPackedFrame.frame.payload;
+
+    // Unpack the RC channels.
+    _channels[RC_CHANNEL_ROLL] = rcChannelsPacked->channel0;
+    _channels[RC_CHANNEL_PITCH] = rcChannelsPacked->channel1;
+    _channels[RC_CHANNEL_THROTTLE] = rcChannelsPacked->channel2;
+    _channels[RC_CHANNEL_YAW] = rcChannelsPacked->channel3;
+    _channels[RC_CHANNEL_AUX1] = rcChannelsPacked->channel4;
+    _channels[RC_CHANNEL_AUX2] = rcChannelsPacked->channel5;
+    _channels[RC_CHANNEL_AUX3] = rcChannelsPacked->channel6;
+    _channels[RC_CHANNEL_AUX4] = rcChannelsPacked->channel7;
+    _channels[RC_CHANNEL_AUX5] = rcChannelsPacked->channel8;
+    _channels[RC_CHANNEL_AUX6] = rcChannelsPacked->channel9;
+    _channels[RC_CHANNEL_AUX7] = rcChannelsPacked->channel10;
+    _channels[RC_CHANNEL_AUX8] = rcChannelsPacked->channel11;
+    _channels[RC_CHANNEL_AUX9] = rcChannelsPacked->channel12;
+    _channels[RC_CHANNEL_AUX10] = rcChannelsPacked->channel13;
+    _channels[RC_CHANNEL_AUX11] = rcChannelsPacked->channel14;
+    _channels[RC_CHANNEL_AUX12] = rcChannelsPacked->channel15;
+
+    // Return the requested channel.
     return _channels[(channel - 1) % RC_CHANNEL_COUNT];
 }
 

--- a/src/lib/CRSFforArduino/CRSFforArduino.h
+++ b/src/lib/CRSFforArduino/CRSFforArduino.h
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
- * @version 0.3.3
- * @date 2023-07-18
+ * @version 0.3.4
+ * @date 2023-07-21
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/CRSFforArduino.h
+++ b/src/lib/CRSFforArduino/CRSFforArduino.h
@@ -136,6 +136,29 @@ typedef enum __crsf_address_e
     CRSF_ADDRESS_CRSF_TRANSMITTER = 0xEE
 } __crsf_address_t;
 
+// RC Channels Packed. 22 bytes (11 bits per channel, 16 channels) total.
+struct __crsf_rcChannelsPacked_s
+{
+    uint16_t channel0 : 11;
+    uint16_t channel1 : 11;
+    uint16_t channel2 : 11;
+    uint16_t channel3 : 11;
+    uint16_t channel4 : 11;
+    uint16_t channel5 : 11;
+    uint16_t channel6 : 11;
+    uint16_t channel7 : 11;
+    uint16_t channel8 : 11;
+    uint16_t channel9 : 11;
+    uint16_t channel10 : 11;
+    uint16_t channel11 : 11;
+    uint16_t channel12 : 11;
+    uint16_t channel13 : 11;
+    uint16_t channel14 : 11;
+    uint16_t channel15 : 11;
+} __attribute__((packed));
+
+typedef struct __crsf_rcChannelsPacked_s __crsf_rcChannelsPacked_t;
+
 typedef struct __crsf_frameDefinition_s
 {
     uint8_t deviceAddress;                                          // Frame address.
@@ -168,6 +191,7 @@ class CRSFforArduino
     HardwareSerial *_serial;
     uint16_t _channels[RC_CHANNEL_COUNT];
     __crsf_frame_t _crsfFrame;
+    __crsf_frame_t _crsfRcChannelsPackedFrame;
 
     /* CRC */
     uint8_t _crc8_dvb_s2(uint8_t crc, uint8_t a);

--- a/src/lib/CRSFforArduino/CRSFforArduino.h
+++ b/src/lib/CRSFforArduino/CRSFforArduino.h
@@ -139,16 +139,16 @@ typedef enum __crsf_address_e
 // RC Channels Packed. 22 bytes (11 bits per channel, 16 channels) total.
 struct __crsf_rcChannelsPacked_s
 {
-    uint16_t channel0 : 11;
-    uint16_t channel1 : 11;
-    uint16_t channel2 : 11;
-    uint16_t channel3 : 11;
-    uint16_t channel4 : 11;
-    uint16_t channel5 : 11;
-    uint16_t channel6 : 11;
-    uint16_t channel7 : 11;
-    uint16_t channel8 : 11;
-    uint16_t channel9 : 11;
+    uint16_t channel0  : 11;
+    uint16_t channel1  : 11;
+    uint16_t channel2  : 11;
+    uint16_t channel3  : 11;
+    uint16_t channel4  : 11;
+    uint16_t channel5  : 11;
+    uint16_t channel6  : 11;
+    uint16_t channel7  : 11;
+    uint16_t channel8  : 11;
+    uint16_t channel9  : 11;
     uint16_t channel10 : 11;
     uint16_t channel11 : 11;
     uint16_t channel12 : 11;

--- a/src/lib/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CompatibilityTable/CompatibilityTable.cpp
@@ -2,8 +2,8 @@
  * @file CompatibilityTable.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Compatibility Table is used to determine if the current device is compatible with CRSF for Arduino.
- * @version 0.3.3
- * @date 2023-07-18
+ * @version 0.3.4
+ * @date 2023-07-21
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CompatibilityTable/CompatibilityTable.h
@@ -2,8 +2,8 @@
  * @file CompatibilityTable.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Compatibility Table is used to determine if the current device is compatible with CRSF for Arduino.
- * @version 0.3.3
- * @date 2023-07-18
+ * @version 0.3.4
+ * @date 2023-07-21
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/library.json
+++ b/src/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "CRSFforArduino",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "Arduino library for Crossfire protocol",
     "keywords": [
         "adafruit",

--- a/src/src/main_rc.cpp
+++ b/src/src/main_rc.cpp
@@ -2,8 +2,8 @@
  * @file main_rc.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
- * @version 0.3.3
- * @date 2023-07-18
+ * @version 0.3.4
+ * @date 2023-07-21
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
## Overview

This Pull Request re-factors the way RC channels data is handled.

## What's changed

### The Old Way

In the `CRSFforArduino::update()` function, this is how I used to unpack RC channels data...

```c++
// Read the RC channels.
// 11 bits per channel, 16 channels = 176 bits = 22 bytes.
_channels[0] = (uint16_t)((_crsfFrame.frame.payload[0] | _crsfFrame.frame.payload[1] << 8) & 0x07FF);
_channels[1] = (uint16_t)((_crsfFrame.frame.payload[1] >> 3 | _crsfFrame.frame.payload[2] << 5) & 0x07FF);
_channels[2] = (uint16_t)((_crsfFrame.frame.payload[2] >> 6 | _crsfFrame.frame.payload[3] << 2 | _crsfFrame.frame.payload[4] << 10) & 0x07FF);
_channels[3] = (uint16_t)((_crsfFrame.frame.payload[4] >> 1 | _crsfFrame.frame.payload[5] << 7) & 0x07FF);
_channels[4] = (uint16_t)((_crsfFrame.frame.payload[5] >> 4 | _crsfFrame.frame.payload[6] << 4) & 0x07FF);
_channels[5] = (uint16_t)((_crsfFrame.frame.payload[6] >> 7 | _crsfFrame.frame.payload[7] << 1 | _crsfFrame.frame.payload[8] << 9) & 0x07FF);
_channels[6] = (uint16_t)((_crsfFrame.frame.payload[8] >> 2 | _crsfFrame.frame.payload[9] << 6) & 0x07FF);
_channels[7] = (uint16_t)((_crsfFrame.frame.payload[9] >> 5 | _crsfFrame.frame.payload[10] << 3) & 0x07FF);
_channels[8] = (uint16_t)((_crsfFrame.frame.payload[11] | _crsfFrame.frame.payload[12] << 8) & 0x07FF);
_channels[9] = (uint16_t)((_crsfFrame.frame.payload[12] >> 3 | _crsfFrame.frame.payload[13] << 5) & 0x07FF);
_channels[10] = (uint16_t)((_crsfFrame.frame.payload[13] >> 6 | _crsfFrame.frame.payload[14] << 2 | _crsfFrame.frame.payload[15] << 10) & 0x07FF);
_channels[11] = (uint16_t)((_crsfFrame.frame.payload[15] >> 1 | _crsfFrame.frame.payload[16] << 7) & 0x07FF);
_channels[12] = (uint16_t)((_crsfFrame.frame.payload[16] >> 4 | _crsfFrame.frame.payload[17] << 4) & 0x07FF);
_channels[13] = (uint16_t)((_crsfFrame.frame.payload[17] >> 7 | _crsfFrame.frame.payload[18] << 1 | _crsfFrame.frame.payload[19] << 9) & 0x07FF);
_channels[14] = (uint16_t)((_crsfFrame.frame.payload[19] >> 2 | _crsfFrame.frame.payload[20] << 6) & 0x07FF);
_channels[15] = (uint16_t)((_crsfFrame.frame.payload[20] >> 5 | _crsfFrame.frame.payload[21] << 3) & 0x07FF);
```

This is a very inefficient way of doing it, plus visually speaking, it looks confusing af.

### The New Way

In the `CRSFforArduino::update()` function, this is how I roll, now...

```c++
// Read the RC channels.
memcpy(&_crsfRcChannelsPackedFrame, &_crsfFrame, CRSF_FRAME_SIZE_MAX);
```

Notice how it's much more concise?
Programmatically, it is more efficient because all I am doing here is double-buffering the incoming RC channel data.
I have also moved the RC channel data unpacking out of the `CRSFforArduino::update()` function & put it into the `CRSFforArduino::getChannel()` function.

```c++
const __crsf_rcChannelsPacked_t *rcChannelsPacked = (__crsf_rcChannelsPacked_t *)&_crsfRcChannelsPackedFrame.frame.payload;

// Unpack the RC channels.
_channels[RC_CHANNEL_ROLL] = rcChannelsPacked->channel0;
_channels[RC_CHANNEL_PITCH] = rcChannelsPacked->channel1;
_channels[RC_CHANNEL_THROTTLE] = rcChannelsPacked->channel2;
_channels[RC_CHANNEL_YAW] = rcChannelsPacked->channel3;
_channels[RC_CHANNEL_AUX1] = rcChannelsPacked->channel4;
_channels[RC_CHANNEL_AUX2] = rcChannelsPacked->channel5;
_channels[RC_CHANNEL_AUX3] = rcChannelsPacked->channel6;
_channels[RC_CHANNEL_AUX4] = rcChannelsPacked->channel7;
_channels[RC_CHANNEL_AUX5] = rcChannelsPacked->channel8;
_channels[RC_CHANNEL_AUX6] = rcChannelsPacked->channel9;
_channels[RC_CHANNEL_AUX7] = rcChannelsPacked->channel10;
_channels[RC_CHANNEL_AUX8] = rcChannelsPacked->channel11;
_channels[RC_CHANNEL_AUX9] = rcChannelsPacked->channel12;
_channels[RC_CHANNEL_AUX10] = rcChannelsPacked->channel13;
_channels[RC_CHANNEL_AUX11] = rcChannelsPacked->channel14;
_channels[RC_CHANNEL_AUX12] = rcChannelsPacked->channel15;
```

Here you can see how straightforward this looks. I know what RC channel is going where.

## Additional

I have removed the caveat regarding the SERCOM UART data order.
Since using packed RC channels, there is no need for me to the low-level hardware UART driver to set its data order to Most Significant Bit First.
This opens up the door for more hardware compatibility.

In the [readme](https://github.com/ZZ-Cat/CRSFforArduino/blob/testing-packedRCchannels/README.md) I have also clarified what CRSF for Arduino's minimum requirements are, & what you _can_ do if your devboard meets the minimum requirements & yet, you're still having compatibility issues.