### PR TITLE
feat(devboard): Add support for Teensy 3.x and 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ While CRSF for Arduino is primarily developed on the Adafruit Metro M4 Express, 
   - Adafruit Metro M4 Express AirLift Lite
 - SAME51 based boards:
   - Adafruit Feather M4 CAN Express
+- Teensy 3.x
+  **NB:** The entire Teensy 3.x line is discontinued by the manufacturer, and is _not_ recommended for new projects.
+- Teensy 4.x
 
 Compatibility with other microcontroller boards may be added in future, if there is demand for it. Keep in mind that this will be subject to hardware limitations of the host microcontroller itself.
 

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -2,8 +2,8 @@
  * @file channels.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
- * @version 0.4.0
- * @date 2023-08-01
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -2,8 +2,8 @@
  * @file gps_telemetry.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch demonstrates how to pass data from a GPS module into CRSF for Arduino & transmit it as telemetry.
- * @version 0.4.0
- * @date 2023-08-01
+ * @version 0.5.0
+ * @date 2023-09-17
  * 
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRSFforArduino
-version=0.4.0
+version=0.5.0
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=An Arduino Library for communicating with ExpressLRS receivers.

--- a/platformio.ini
+++ b/platformio.ini
@@ -273,6 +273,13 @@ build_flags =
     -DUSE_ABSTRACTION_LAYER
     -DCRC_OPTIMISATION_LEVEL=0
 
+[env:teensy_36]
+platform = teensy
+board = teensy36
+build_flags =
+    -DUSE_ABSTRACTION_LAYER
+    -DCRC_OPTIMISATION_LEVEL=0
+
 [platformio]
 default_envs = adafruit_metro_m0
 include_dir = src/include

--- a/platformio.ini
+++ b/platformio.ini
@@ -251,6 +251,14 @@ debug_tool = ${common_samd51.debugger}
 lib_deps = ${common_samd51.lib_deps}
 upload_protocol = ${common_samd51.sketch_upload_protocol}
 
+; Teensy Boards
+[env:teensy_35]
+platform = teensy
+board = teensy35
+build_flags =
+    -DUSE_ABSTRACTION_LAYER
+    -DCRC_OPTIMISATION_LEVEL=0
+
 [platformio]
 default_envs = adafruit_metro_m0
 include_dir = src/include

--- a/platformio.ini
+++ b/platformio.ini
@@ -252,6 +252,13 @@ lib_deps = ${common_samd51.lib_deps}
 upload_protocol = ${common_samd51.sketch_upload_protocol}
 
 ; Teensy Boards
+[env:teensy_30]
+platform = teensy
+board = teensy30
+build_flags =
+    -DUSE_ABSTRACTION_LAYER
+    -DCRC_OPTIMISATION_LEVEL=0
+
 [env:teensy_35]
 platform = teensy
 board = teensy35

--- a/platformio.ini
+++ b/platformio.ini
@@ -266,6 +266,17 @@ build_flags =
     -DUSE_ABSTRACTION_LAYER
     -DCRC_OPTIMISATION_LEVEL=0
 
+[env:teensy_32]
+# I am pretty much having to fake Teensy 3.2 support here,
+# because PlatformIO lumps Teensy 3.1 and Teensy 3.2 together as one board.
+# Yet, the Arduino IDE sees Teensy 3.1 and Teensy 3.2 as two separate boards.
+# This can cause a "false negative" in the Compatibility Table with Teensy 3.2.
+platform = teensy
+board = teensy31
+build_flags =
+    -DUSE_ABSTRACTION_LAYER
+    -DCRC_OPTIMISATION_LEVEL=0
+
 [env:teensy_35]
 platform = teensy
 board = teensy35

--- a/platformio.ini
+++ b/platformio.ini
@@ -280,6 +280,20 @@ build_flags =
     -DUSE_ABSTRACTION_LAYER
     -DCRC_OPTIMISATION_LEVEL=0
 
+[env:teensy_40]
+platform = teensy
+board = teensy40
+build_flags =
+    -DUSE_ABSTRACTION_LAYER
+    -DCRC_OPTIMISATION_LEVEL=0
+
+[env:teensy_41]
+platform = teensy
+board = teensy41
+build_flags =
+    -DUSE_ABSTRACTION_LAYER
+    -DCRC_OPTIMISATION_LEVEL=0
+
 [platformio]
 default_envs = adafruit_metro_m0
 include_dir = src/include

--- a/platformio.ini
+++ b/platformio.ini
@@ -259,6 +259,13 @@ build_flags =
     -DUSE_ABSTRACTION_LAYER
     -DCRC_OPTIMISATION_LEVEL=0
 
+[env:teensy_31]
+platform = teensy
+board = teensy31
+build_flags =
+    -DUSE_ABSTRACTION_LAYER
+    -DCRC_OPTIMISATION_LEVEL=0
+
 [env:teensy_35]
 platform = teensy
 board = teensy35

--- a/src/CRSFforArduino.h
+++ b/src/CRSFforArduino.h
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/src/CRSFforArduino.cpp
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/CRSFforArduino.h
+++ b/src/lib/CRSFforArduino/src/CRSFforArduino.h
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -202,6 +202,12 @@ namespace hal
         device.type.devboard = DEVBOARD_TEENSY_36;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #endif
+#elif defined (__IMXRT1062__)
+#if defined(ARDUINO_TEENSY40)
+        device.type.devboard = DEVBOARD_TEENSY_40;
+#elif defined(ARDUINO_TEENSY41)
+        device.type.devboard = DEVBOARD_TEENSY_41;
+#endif
 #else // Incompatible devboards
 #warning "Devboard not supported. Please check the compatibility table."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -197,6 +197,11 @@ namespace hal
 #warning "Devboard not supported. Please check the compatibility table."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif
+#elif defined(__MK66FX1M0__)
+#if defined(ARDUINO_TEENSY36)
+        device.type.devboard = DEVBOARD_TEENSY_36;
+#pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
+#endif
 #else // Incompatible devboards
 #warning "Devboard not supported. Please check the compatibility table."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -176,9 +176,18 @@ namespace hal
 #endif // ARDUINO_SAMD_ADAFRUIT
 
 #elif defined(CORE_TEENSY)
-#if defined(__MK64FX512__)
+#if defined(__MK20DX128__)
+#if defined(ARDUINO_TEENSY30)
+        device.type.devboard = DEVBOARD_TEENSY_30;
+#pragma message "Teensy 3.0 is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
+#else
+#warning "Devboard not supported. Please check the compatibility table."
+        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#endif
+#elif defined(__MK64FX512__)
 #if defined(ARDUINO_TEENSY35)
         device.type.devboard = DEVBOARD_TEENSY_35;
+#pragma message "Teensy 3.5 is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else // Incompatible devboards
 #warning "Devboard not supported. Please check the compatibility table."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -179,15 +179,20 @@ namespace hal
 #if defined(__MK20DX128__)
 #if defined(ARDUINO_TEENSY30)
         device.type.devboard = DEVBOARD_TEENSY_30;
-#pragma message "Teensy 3.0 is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
+#pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else
 #warning "Devboard not supported. Please check the compatibility table."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif
+#elif defined(__MK20DX256__)
+#if defined(ARDUINO_TEENSY31)
+        device.type.devboard = DEVBOARD_TEENSY_31;
+#pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
+#endif
 #elif defined(__MK64FX512__)
 #if defined(ARDUINO_TEENSY35)
         device.type.devboard = DEVBOARD_TEENSY_35;
-#pragma message "Teensy 3.5 is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
+#pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else // Incompatible devboards
 #warning "Devboard not supported. Please check the compatibility table."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -202,7 +202,7 @@ namespace hal
         device.type.devboard = DEVBOARD_TEENSY_36;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #endif
-#elif defined (__IMXRT1062__)
+#elif defined(__IMXRT1062__)
 #if defined(ARDUINO_TEENSY40)
         device.type.devboard = DEVBOARD_TEENSY_40;
 #elif defined(ARDUINO_TEENSY41)

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -3,8 +3,8 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the implementation of the Compatibility Table.
  * It is used to determine if the target development board is compatible with CRSF for Arduino.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -185,8 +185,10 @@ namespace hal
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif
 #elif defined(__MK20DX256__)
-#if defined(ARDUINO_TEENSY31)
-        device.type.devboard = DEVBOARD_TEENSY_31;
+/* PlatformIO treats Teensy 3.1 and Teensy 3.2 as the same board, but the Arduino IDE treats them
+as two separate boards. To prevent a false negative, check for both boards. */
+#if defined(ARDUINO_TEENSY31) || defined(ARDUINO_TEENSY32)
+        device.type.devboard = DEVBOARD_TEENSY_31_32;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else // Incompatible devboards
 #warning "Devboard not supported. Please check the compatibility table."

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -188,6 +188,9 @@ namespace hal
 #if defined(ARDUINO_TEENSY31)
         device.type.devboard = DEVBOARD_TEENSY_31;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
+#else // Incompatible devboards
+#warning "Devboard not supported. Please check the compatibility table."
+        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif
 #elif defined(__MK64FX512__)
 #if defined(ARDUINO_TEENSY35)
@@ -201,12 +204,18 @@ namespace hal
 #if defined(ARDUINO_TEENSY36)
         device.type.devboard = DEVBOARD_TEENSY_36;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
+#else // Incompatible devboards
+#warning "Devboard not supported. Please check the compatibility table."
+        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif
 #elif defined(__IMXRT1062__)
 #if defined(ARDUINO_TEENSY40)
         device.type.devboard = DEVBOARD_TEENSY_40;
 #elif defined(ARDUINO_TEENSY41)
         device.type.devboard = DEVBOARD_TEENSY_41;
+#else // Incompatible devboards
+#warning "Devboard not supported. Please check the compatibility table."
+        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif
 #else // Incompatible devboards
 #warning "Devboard not supported. Please check the compatibility table."

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -175,6 +175,19 @@ namespace hal
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_SAMD_ADAFRUIT
 
+#elif defined(CORE_TEENSY)
+#if defined(__MK64FX512__)
+#if defined(ARDUINO_TEENSY35)
+        device.type.devboard = DEVBOARD_TEENSY_35;
+#else // Incompatible devboards
+#warning "Devboard not supported. Please check the compatibility table."
+        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#endif
+#else // Incompatible devboards
+#warning "Devboard not supported. Please check the compatibility table."
+        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+#endif
+
 #else // Unsupported architecture
 #error "Unsupported architecture. Please check the compatibility table."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -244,7 +244,26 @@ namespace hal
      */
     bool CompatibilityTable::isDevboardCompatible(const char *name)
     {
-        return strcmp(name, deviceNames[DEVBOARD_IS_INCOMPATIBLE]) != 0 ? true : false;
+        // Debug.
+        Serial.print("[Compatibility Table | DEBUG]: Board is ");
+
+        if (strcmp(name, deviceNames[DEVBOARD_IS_INCOMPATIBLE]) == 0)
+        {
+            // Debug.
+            Serial.println("incompatible.");
+
+            return false;
+        }
+
+        else
+        {
+            // Debug.
+            Serial.println("compatible.");
+
+            return true;
+        }
+
+        // return strcmp(name, deviceNames[DEVBOARD_IS_INCOMPATIBLE]) != 0 ? true : false;
     }
 
     /**
@@ -254,10 +273,17 @@ namespace hal
      */
     const char *CompatibilityTable::getDevboardName()
     {
-        if (device.type.devboard > DEVBOARD_COUNT)
+        if (device.type.devboard >= DEVBOARD_COUNT)
         {
+            // Debug.
+            Serial.println("\r\n[Compatibility Table | FATAL ERROR]: Board index is out of bounds.");
+
             return deviceNames[DEVBOARD_IS_INCOMPATIBLE];
         }
+
+        // Debug.
+        Serial.print("\r\n[Compatibility Table | DEBUG]: Board is ");
+        Serial.println(deviceNames[device.type.devboard]);
 
         return deviceNames[device.type.devboard];
     }

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -79,6 +79,9 @@ namespace hal
             // Seeed Studio boards.
             DEVBOARD_SEEEDSTUDIO_XIAO_M0,
 
+            // Teensy boards.
+            DEVBOARD_TEENSY_35,
+
             DEVBOARD_COUNT
         } ct_devboards_t;
 
@@ -119,6 +122,7 @@ namespace hal
             "Arduino MKRZERO",
             "Arduino Nano 33 IoT",
             "Arduino Zero",
-            "Seeed Studio Xiao SAMD21"};
+            "Seeed Studio Xiao SAMD21",
+            "Teensy 3.5"};
     };
 } // namespace hal

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -81,6 +81,7 @@ namespace hal
 
             // Teensy boards.
             DEVBOARD_TEENSY_30,
+            DEVBOARD_TEENSY_31,
             DEVBOARD_TEENSY_35,
 
             DEVBOARD_COUNT
@@ -125,6 +126,7 @@ namespace hal
             "Arduino Zero",
             "Seeed Studio Xiao SAMD21",
             "Teensy 3.0",
+            "Teensy 3.1/3.2",
             "Teensy 3.5"};
     };
 } // namespace hal

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -81,7 +81,7 @@ namespace hal
 
             // Teensy boards.
             DEVBOARD_TEENSY_30,
-            DEVBOARD_TEENSY_31,
+            DEVBOARD_TEENSY_31_32,
             DEVBOARD_TEENSY_35,
             DEVBOARD_TEENSY_36,
             DEVBOARD_TEENSY_40,

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -83,6 +83,7 @@ namespace hal
             DEVBOARD_TEENSY_30,
             DEVBOARD_TEENSY_31,
             DEVBOARD_TEENSY_35,
+            DEVBOARD_TEENSY_36,
 
             DEVBOARD_COUNT
         } ct_devboards_t;
@@ -127,6 +128,7 @@ namespace hal
             "Seeed Studio Xiao SAMD21",
             "Teensy 3.0",
             "Teensy 3.1/3.2",
-            "Teensy 3.5"};
+            "Teensy 3.5",
+            "Teensy 3.6"};
     };
 } // namespace hal

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -2,8 +2,8 @@
  * @file CompatibilityTable.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the Compatibility Table header file.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -80,6 +80,7 @@ namespace hal
             DEVBOARD_SEEEDSTUDIO_XIAO_M0,
 
             // Teensy boards.
+            DEVBOARD_TEENSY_30,
             DEVBOARD_TEENSY_35,
 
             DEVBOARD_COUNT
@@ -123,6 +124,7 @@ namespace hal
             "Arduino Nano 33 IoT",
             "Arduino Zero",
             "Seeed Studio Xiao SAMD21",
+            "Teensy 3.0",
             "Teensy 3.5"};
     };
 } // namespace hal

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -84,6 +84,8 @@ namespace hal
             DEVBOARD_TEENSY_31,
             DEVBOARD_TEENSY_35,
             DEVBOARD_TEENSY_36,
+            DEVBOARD_TEENSY_40,
+            DEVBOARD_TEENSY_41,
 
             DEVBOARD_COUNT
         } ct_devboards_t;
@@ -129,6 +131,8 @@ namespace hal
             "Teensy 3.0",
             "Teensy 3.1/3.2",
             "Teensy 3.5",
-            "Teensy 3.6"};
+            "Teensy 3.6",
+            "Teensy 4.0",
+            "Teensy 4.1"};
     };
 } // namespace hal

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -84,6 +84,9 @@ namespace hal
         if (uart_port != nullptr)
         {
             uart_port->~Uart();
+
+            // Debug.
+            Serial.println("\n[Development Board | INFO]: Deleted previous UART port.");
         }
 
         // Set the UART port.
@@ -91,21 +94,36 @@ namespace hal
         {
             case 0:
                 uart_port = &Serial1;
+
+                // Debug.
+                Serial.println("\n[Development Board | INFO]: Using Serial1.");
                 break;
 
             case 1: // TO-DO: Fix this.
                 uart_port = new Uart(&sercom2, rx, tx, SERCOM_RX_PAD_1, UART_TX_PAD_0);
+
+                // Debug.
+                Serial.println("\n[Development Board | INFO]: Using Serial2.");
                 break;
 
             default:
                 uart_port = nullptr;
+
+                // Debug.
+                Serial.println("\n[Development Board | ERROR]: No UART port was defined.");
                 break;
         }
 #elif defined(TEENSYDUINO)
         // Default to Serial1 if Teensyduino is being used. May expand this in the future, if requested.
         uart_port = &Serial1;
+
+        // Debug.
+        Serial.println("\n[Development Board | INFO]: Using Serial1.");
 #else
         uart_port = nullptr;
+
+        // Debug.
+        Serial.println("\n[Development Board | ERROR]: No UART port was defined.");
 #endif
     }
 

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -2,8 +2,8 @@
  * @file DevBoards.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the DevBoards implementation file. It is used to configure CRSF for Arduino for specific development boards.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -101,6 +101,9 @@ namespace hal
                 uart_port = nullptr;
                 break;
         }
+#elif defined(TEENSYDUINO)
+        // Default to Serial1 if Teensyduino is being used. May expand this in the future, if requested.
+        uart_port = &Serial1;
 #else
         uart_port = nullptr;
 #endif
@@ -111,7 +114,9 @@ namespace hal
         // If UART port was defined beforehand, delete it.
         if (uart_port != nullptr)
         {
+#ifndef TEENSYDUINO
             uart_port->~Uart();
+#endif
         }
     }
 
@@ -156,6 +161,14 @@ namespace hal
         // Write a byte to the UART port.
         return uart_port->write(c);
     }
+
+#if defined(TEENSYDUINO)
+    size_t DevBoards::write(const uint8_t *buffer, size_t size)
+    {
+        // Write a buffer to the UART port.
+        return uart_port->write(buffer, size);
+    }
+#endif
 
     DevBoards::operator bool()
     {

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -86,7 +86,7 @@ namespace hal
             uart_port->~Uart();
 
             // Debug.
-            Serial.println("\n[Development Board | INFO]: Deleted previous UART port.");
+            Serial.println("[Development Board | DEBUG]: Deleted previous UART port.");
         }
 
         // Set the UART port.
@@ -96,21 +96,21 @@ namespace hal
                 uart_port = &Serial1;
 
                 // Debug.
-                Serial.println("\n[Development Board | INFO]: Using Serial1.");
+                Serial.println("[Development Board | DEBUG]: Using Serial1.");
                 break;
 
             case 1: // TO-DO: Fix this.
                 uart_port = new Uart(&sercom2, rx, tx, SERCOM_RX_PAD_1, UART_TX_PAD_0);
 
                 // Debug.
-                Serial.println("\n[Development Board | INFO]: Using Serial2.");
+                Serial.println("[Development Board | DEBUG]: Using Serial2.");
                 break;
 
             default:
                 uart_port = nullptr;
 
                 // Debug.
-                Serial.println("\n[Development Board | ERROR]: No UART port was defined.");
+                Serial.println("[Development Board | ERROR]: No UART port was defined.");
                 break;
         }
 #elif defined(TEENSYDUINO)
@@ -118,12 +118,12 @@ namespace hal
         uart_port = &Serial1;
 
         // Debug.
-        Serial.println("\n[Development Board | INFO]: Using Serial1.");
+        Serial.println("[Development Board | DEBUG]: Using Serial1.");
 #else
         uart_port = nullptr;
 
         // Debug.
-        Serial.println("\n[Development Board | ERROR]: No UART port was defined.");
+        Serial.println("[Development Board | ERROR]: No UART port was defined.");
 #endif
     }
 

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
@@ -35,7 +35,10 @@
 
 namespace hal
 {
-    class DevBoards : private HardwareSerial
+    class DevBoards
+#ifndef TEENSYDUINO
+        : private HardwareSerial
+#endif
     {
       public:
         DevBoards();
@@ -52,7 +55,11 @@ namespace hal
         int read(void);
         void flush(void);
         size_t write(uint8_t c);
+#if defined(TEENSYDUINO)
+        size_t write(const uint8_t *buffer, size_t size);
+#else
         using Print::write; // pull in write(str) and write(buf, size) from Print
+#endif
         operator bool();
 
         // Critical section functions.

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
@@ -2,8 +2,8 @@
  * @file DevBoards.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains the DevBoards class, which is used to configure CRSF for Arduino for specific development boards.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/Hardware.h
+++ b/src/lib/CRSFforArduino/src/Hardware/Hardware.h
@@ -2,8 +2,8 @@
  * @file Hardware.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file is the top level of the hardware abstraction layer.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
@@ -2,8 +2,8 @@
  * @file CRC.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class implementation.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.h
@@ -2,8 +2,8 @@
  * @file CRC.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class declaration.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
@@ -2,8 +2,8 @@
  * @file CRSF.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class implementation.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.h
@@ -2,8 +2,8 @@
  * @file CRSF.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class definition.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.h
@@ -2,8 +2,8 @@
  * @file CRSFProtocol.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -2,8 +2,8 @@
  * @file SerialBuffer.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class implementation.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.h
@@ -2,8 +2,8 @@
  * @file SerialBuffer.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class definition.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -59,6 +59,8 @@ namespace serialReceiver
 
     bool SerialReceiver::begin()
     {
+        // Debug.
+        Serial.print("[Serial Receiver | INFO]: Initialising... ");
         // board->enterCriticalSection();
 
         // Initialize the RC Channels.
@@ -81,6 +83,9 @@ namespace serialReceiver
             if (_rxPin == 0xffu && _txPin == 0xffu)
             {
                 // board->exitCriticalSection();
+
+                // Debug.
+                Serial.println("\n[Serial Receiver | ERROR]: RX and TX pins are not set.");
                 return false;
             }
 
@@ -93,6 +98,9 @@ namespace serialReceiver
             if (crsf == nullptr)
             {
                 board->exitCriticalSection();
+
+                // Debug.
+                Serial.println("\n[Serial Receiver | FATAL ERROR]: CRSF Protocol could not be initialized.");
                 return false;
             }
 
@@ -108,6 +116,9 @@ namespace serialReceiver
             if (telemetry == nullptr)
             {
                 board->exitCriticalSection();
+
+                // Debug.
+                Serial.println("\n[Serial Receiver | FATAL ERROR]: Telemetry could not be initialized.");
                 return false;
             }
 
@@ -121,11 +132,17 @@ namespace serialReceiver
             {
                 board->read();
             }
+
+            // Debug.
+            Serial.println("Done.");
             return true;
         }
         else
         {
             // board->exitCriticalSection();
+
+            // Debug.
+            Serial.println("\n[Serial Receiver | ERROR]: Devboard is not compatible.");
             return false;
         }
     }

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -2,8 +2,8 @@
  * @file SerialReceiver.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the implementation file for the Serial Receiver Interface.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -59,7 +59,7 @@ namespace serialReceiver
 
     bool SerialReceiver::begin()
     {
-        board->enterCriticalSection();
+        // board->enterCriticalSection();
 
         // Initialize the RC Channels.
         // Throttle is set to 172 (988us) to prevent the ESCs from arming. All other channels are set to 992 (1500us).
@@ -80,9 +80,11 @@ namespace serialReceiver
         {
             if (_rxPin == 0xffu && _txPin == 0xffu)
             {
-                board->exitCriticalSection();
+                // board->exitCriticalSection();
                 return false;
             }
+
+            board->enterCriticalSection();
 
             // Initialize the CRSF Protocol.
             crsf = new CRSF();
@@ -123,7 +125,7 @@ namespace serialReceiver
         }
         else
         {
-            board->exitCriticalSection();
+            // board->exitCriticalSection();
             return false;
         }
     }

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.h
@@ -2,8 +2,8 @@
  * @file SerialReceiver.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the header file for the Serial Receiver Interface.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -2,8 +2,8 @@
  * @file Telemetry.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class implementation.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.h
@@ -2,8 +2,8 @@
  * @file Telemetry.h
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class definition.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/library.json
+++ b/src/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "CRSFforArduino",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Arduino library for Crossfire protocol",
     "keywords": [
         "adafruit",

--- a/src/src/main_gps-telemetry.cpp
+++ b/src/src/main_gps-telemetry.cpp
@@ -2,8 +2,8 @@
  * @file main_telemetry.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates how to use CRSF for Arduino to send GPS telemetry to an ExpressLRS RC receiver.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/src/main_rc.cpp
+++ b/src/src/main_rc.cpp
@@ -2,8 +2,8 @@
  * @file main_rc.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
- * @version 0.4.0
- * @date 2023-08-08
+ * @version 0.5.0
+ * @date 2023-09-17
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
## Overview

This Pull Request adds support for Teensy development boards.

## Tasks

The following lists the boards that are being added to CRSF for Arduino's Compatibility Table:

- [x] Teensy 3.0
- [x] Teensy 3.1/3.2
- [x] Teensy 3.5
- [x] Teensy 3.6
- [x] Teensy 4.0
- [x] Teensy 4.1

So far, only `Serial1` is used, because this is in early stages of development and board support takes priority.  
Options to use other UART ports may be added in future, if requested.

## Additional notes

Regarding [Teensy 3.x](https://www.pjrc.com/store/teensy35.html):  
>  Not recommended for new designs or projects.
PJRC recommends use of Teensy 4.0 / 4.1 for new projects. We do not believe supply of chips for Teensy 3.x is likely to ever fully recover. These chips are made with 90 nm silicon process. Most of the world's semiconductor fabs are focusing on 45 nm or smaller, leaving limited supply for older chips. We anticipate the cost of these chips is likely to increase as the supply continues to dwindle. 

With this being said, I have decided to add support for the entire Teensy 3.x and 4.x range.
Initially I was _only_ going to support Teensy 4.0 and later and not bother with Teensy 3.x due to it being discontinued. However, I have since changed my mind on this. I _am_ adding full support for all Teensy 3.x development boards _with caveats:_  
If you compile CRSF for Arduino for one of the Teensy 3.x boards, you _will_ see a compilation warning stating that these boards have been discontinued and that Teensy 4.0 (and later) is recommended for new projects.

If and when PJRC fully discontinues their entire Teensy 3.x range (IE No longer being available for purchase from their website), I will deprecate (and eventually remove) support for Teensy 3.x, later on down the track.