### PR TITLE
refactor(rc channels): Improve readability of RC Channels in Serial Plotter

### DIFF
--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -146,23 +146,14 @@ void loop()
     if (millis() - lastPrint >= 100)
     {
         lastPrint = millis();
-        Serial.print("RC Channels <A: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(1)));
-        Serial.print(", E: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(2)));
-        Serial.print(", T: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(3)));
-        Serial.print(", R: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(4)));
-        Serial.print(", Aux1: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(5)));
-        Serial.print(", Aux2: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(6)));
-        Serial.print(", Aux3: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(7)));
-        Serial.print(", Aux4: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(8)));
-        Serial.println(">");
+        for(int i = 1; i <= crsfProtocol::RC_CHANNEL_COUNT; i++){
+          //Serial.print("Channel");
+          Serial.print(i);
+          Serial.print(":");
+          Serial.print(crsf.rcToUs(crsf.getChannel(i)));
+          Serial.print("\t");
+        }
+        Serial.println();    
     }
 }
 

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -109,6 +109,8 @@
 #define SERIAL_RX_PIN 0 // Set SERIAL_RX_PIN to the pin that the CRSF receiver's TX pin is connected to.
 #define SERIAL_TX_PIN 1 // Set SERIAL_TX_PIN to the pin that the CRSF receiver's RX pin is connected to.
 
+const int channelCount = crsfProtocol::RC_CHANNEL_COUNT; // I'm not sure if this is right, but we can always manually put in the number of channels desired
+
 CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
 
 void setup()
@@ -146,7 +148,7 @@ void loop()
     if (millis() - lastPrint >= 100)
     {
         lastPrint = millis();
-        for(int i = 1; i <= crsfProtocol::RC_CHANNEL_COUNT; i++){
+        for(int i = 1; i <= channelCount; i++){
           //Serial.print("Channel");
           Serial.print(i);
           Serial.print(":");

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -46,6 +46,8 @@ float speed = 500.0F;                 // Speed is in cm/s
 float groundCourse = 275.8F;          // Ground Course is in degrees.
 uint8_t satellites = 4;
 
+const int channelCount = crsfProtocol::RC_CHANNEL_COUNT; // I'm not sure if this is right, but we can always manually put in the number of channels desired
+
 CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
 
 void setup()
@@ -142,7 +144,7 @@ void loop()
     if (timeNow - lastPrint >= 100)
     {
         lastPrint = timeNow;
-        for(int i = 1; i <= crsfProtocol::RC_CHANNEL_COUNT; i++){
+        for(int i = 1; i <= channelCount; i++){
           //Serial.print("Channel");
           Serial.print(i);
           Serial.print(":");

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -112,6 +112,21 @@ void loop()
         speed = random(0, 6625);
         groundCourse = random(0, 359);
         satellites = random(0, 16);
+        
+        Serial.print("Lat:");
+        Serial.print(latitude);
+        Serial.print("\tLon:");
+        Serial.print(longitude);
+        Serial.print("\tAlt:");
+        Serial.print(altitude);
+        Serial.print("\tSpeed:");
+        Serial.print(speed);
+        Serial.print("\tGroundCourse:");
+        Serial.print(groundCourse);
+        Serial.print("\tSatellites:");
+        Serial.print(satellites);
+        Serial.println();
+        
 #endif
 
         // Update the GPS telemetry data with the new values.
@@ -127,23 +142,14 @@ void loop()
     if (timeNow - lastPrint >= 100)
     {
         lastPrint = timeNow;
-        Serial.print("RC Channels <A: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(1)));
-        Serial.print(", E: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(2)));
-        Serial.print(", T: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(3)));
-        Serial.print(", R: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(4)));
-        Serial.print(", Aux1: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(5)));
-        Serial.print(", Aux2: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(6)));
-        Serial.print(", Aux3: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(7)));
-        Serial.print(", Aux4: ");
-        Serial.print(crsf.rcToUs(crsf.getChannel(8)));
-        Serial.println(">");
+        for(int i = 1; i <= crsfProtocol::RC_CHANNEL_COUNT; i++){
+          //Serial.print("Channel");
+          Serial.print(i);
+          Serial.print(":");
+          Serial.print(crsf.rcToUs(crsf.getChannel(i)));
+          Serial.print("\t");
+        }
+        Serial.println();     
     }
 #endif
 }


### PR DESCRIPTION
Minor modifications to the Arduino example codes channels.ino and gps_telemetry.ino

Serial.prints more channels. Not sure if I did it right, but I have set it to Serial.print all the channels, based on the channel count crsfProtocol::RC_CHANNEL_COUNT 

Arduino serial plotter compatibility for easier readability
<img width="1920" alt="image" src="https://github.com/ZZ-Cat/CRSFforArduino/assets/19630847/09f35e06-8ff4-4e94-9da0-94c7e182c3de">



Hope this is useful to you! 


(did i do it right?)