### PR TITLE
build(ci): Trigger CI checks on pull requests

### DIFF
--- a/.github/workflows/arduinoide_build.yml
+++ b/.github/workflows/arduinoide_build.yml
@@ -1,6 +1,6 @@
 name: Arduino
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/platformio_build.yml
+++ b/.github/workflows/platformio_build.yml
@@ -1,6 +1,6 @@
 name: PlatformIO
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

This short Pull Request refactors two of my continuous integration scripts to allow them to be triggered whenever a Pulll Request is submitted to CRSF for Arduino.

## What this addresses

While #40 was being worked on, I noticed that my build checks were waiting in perpetuity for something to report it's status. Using the `pull_request` trigger in these scripts addresses this problem... especially for contirbutors other than myself.