### PR TITLE
fix(hal): Inherit from Stream instead of HardwareSerial across all supported targets

### DIFF
--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch demonstrates how to pass data from a GPS module into CRSF for Arduino & transmit it as telemetry.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  * 
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/gps_telemetry/gps_telemetry.ino
+++ b/examples/gps_telemetry/gps_telemetry.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch demonstrates how to pass data from a GPS module into CRSF for Arduino & transmit it as telemetry.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  * 
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/platformio.ini
+++ b/platformio.ini
@@ -447,7 +447,7 @@ build_flags =
     -DCRC_OPTIMISATION_LEVEL=0
 
 [platformio]
-default_envs = zero
+default_envs = adafruit_metro_m4
 core_dir = $PROJECT_DIR/.pio/core
 include_dir = src/include
 lib_dir = src/lib

--- a/platformio.ini
+++ b/platformio.ini
@@ -447,7 +447,7 @@ build_flags =
     -DCRC_OPTIMISATION_LEVEL=0
 
 [platformio]
-default_envs = adafruit_metro_m4
+default_envs = zero
 core_dir = $PROJECT_DIR/.pio/core
 include_dir = src/include
 lib_dir = src/lib

--- a/src/CRSFforArduino.h
+++ b/src/CRSFforArduino.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.h
+++ b/src/CRSFforArduino.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/src/CRSFforArduino.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/CRSFforArduino.cpp
+++ b/src/lib/CRSFforArduino/src/CRSFforArduino.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/CRSFforArduino.h
+++ b/src/lib/CRSFforArduino/src/CRSFforArduino.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/CRSFforArduino.h
+++ b/src/lib/CRSFforArduino/src/CRSFforArduino.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -4,7 +4,7 @@
  * @brief This is the implementation of the Compatibility Table.
  * It is used to determine if the target development board is compatible with CRSF for Arduino.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -4,7 +4,7 @@
  * @brief This is the implementation of the Compatibility Table.
  * It is used to determine if the target development board is compatible with CRSF for Arduino.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the Compatibility Table header file.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
+++ b/src/lib/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the Compatibility Table header file.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -186,13 +186,11 @@ namespace hal
         return uart_port->write(c);
     }
 
-#if defined(TEENSYDUINO) || defined(ARDUINO_ARCH_ESP32)
     size_t DevBoards::write(const uint8_t *buffer, size_t size)
     {
         // Write a buffer to the UART port.
         return uart_port->write(buffer, size);
     }
-#endif
 
     DevBoards::operator bool()
     {

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the DevBoards implementation file. It is used to configure CRSF for Arduino for specific development boards.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the DevBoards implementation file. It is used to configure CRSF for Arduino for specific development boards.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains the DevBoards class, which is used to configure CRSF for Arduino for specific development boards.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
@@ -35,8 +35,7 @@
 
 namespace hal
 {
-    class DevBoards
-        : private Stream
+    class DevBoards : private Stream
     {
       public:
         DevBoards();

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains the DevBoards class, which is used to configure CRSF for Arduino for specific development boards.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
+++ b/src/lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.h
@@ -36,9 +36,7 @@
 namespace hal
 {
     class DevBoards
-#if not(defined(TEENSYDUINO) || defined(ARDUINO_ARCH_ESP32))
-        : private HardwareSerial
-#endif
+        : private Stream
     {
       public:
         DevBoards();
@@ -55,11 +53,8 @@ namespace hal
         int read(void);
         void flush(void);
         size_t write(uint8_t c);
-#if defined(TEENSYDUINO) || defined(ARDUINO_ARCH_ESP32)
         size_t write(const uint8_t *buffer, size_t size);
-#else
         using Print::write; // pull in write(str) and write(buf, size) from Print
-#endif
         operator bool();
 
         // Critical section functions.

--- a/src/lib/CRSFforArduino/src/Hardware/Hardware.h
+++ b/src/lib/CRSFforArduino/src/Hardware/Hardware.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file is the top level of the hardware abstraction layer.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/Hardware/Hardware.h
+++ b/src/lib/CRSFforArduino/src/Hardware/Hardware.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file is the top level of the hardware abstraction layer.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class implementation.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class implementation.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class declaration.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRC/CRC.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class declaration.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class implementation.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class implementation.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class definition.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class definition.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class implementation.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class implementation.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class definition.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class definition.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the implementation file for the Serial Receiver Interface.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the implementation file for the Serial Receiver Interface.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the header file for the Serial Receiver Interface.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/SerialReceiver.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the header file for the Serial Receiver Interface.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class implementation.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class implementation.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class definition.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.h
+++ b/src/lib/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.h
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class definition.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/src/main_gps-telemetry.cpp
+++ b/src/src/main_gps-telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates how to use CRSF for Arduino to send GPS telemetry to an ExpressLRS RC receiver.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/src/main_gps-telemetry.cpp
+++ b/src/src/main_gps-telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates how to use CRSF for Arduino to send GPS telemetry to an ExpressLRS RC receiver.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/src/main_rc.cpp
+++ b/src/src/main_rc.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
  * @version 0.5.0
- * @date 2023-09-17
+ * @date 2023-10-19
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/src/main_rc.cpp
+++ b/src/src/main_rc.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
  * @version 0.5.0
- * @date 2023-10-19
+ * @date 2023-10-22
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
## Overview

Fixes #42.  
This is a case of that _one_ line of code causing such a _big_ problem.  
I honestly thought this was going to take a lot longer to fix. But, nope. All it was, was simply one line of code in my Hardware Abstraction Layer.

Anyway... this Pull Request refactors the `DevBoards` class to inherit from Arduino's `Stream` class instead of the `HardwareSerial` class.

This, in future may also help reduce some of the restrictions around hardware compatibility, and reduce the need for me to add in niche code in the Hardware Abstraction Layer that is bespoke to a specific board.

You can now compile CRSF for Arduino for your Arduino Zero and/or any of your Arduino MKR series of development boards with impunity.

## Additional

Please note that the version date has changed.  
This is the old version date:
![Screenshot 2023-10-22 110349](https://github.com/ZZ-Cat/CRSFforArduino/assets/48301275/f4d876b7-a6d5-47de-aa60-ae0728183bdc)

This is the new version date for the upcoming Version 0.5.0:
![Screenshot 2023-10-22 110411](https://github.com/ZZ-Cat/CRSFforArduino/assets/48301275/2c050f2d-e3cc-4e14-a659-69d42006c900)

When Version 0.5.0 is released, I highly recommend you update your source code of CRSF for Arduino to _this_ version, as it will bring in critical fixes, plus new hardware targets.
