### PR TITLE
fix(compatibility table): Add missing Arduino Nano 33 IoT compatibility

### DIFF
--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -2,8 +2,8 @@
  * @file channels.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/flight_modes/flight_modes.ino
+++ b/examples/flight_modes/flight_modes.ino
@@ -2,8 +2,8 @@
  * @file main_flight_modes.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Demonstrates the use of CRSF for Arduino's flight mode functionality.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_flight_modes.cpp
+++ b/examples/platformio/main_flight_modes.cpp
@@ -2,8 +2,8 @@
  * @file main_flight_modes.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Demonstrates the use of CRSF for Arduino's flight mode functionality.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_rc.cpp
+++ b/examples/platformio/main_rc.cpp
@@ -2,8 +2,8 @@
  * @file main_rc.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_telemetry.cpp
+++ b/examples/platformio/main_telemetry.cpp
@@ -2,8 +2,8 @@
  * @file main_telemetry.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates how to use CRSF for Arduino to send telemetry to your RC transmitter using the CRSF protocol.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/telemetry/telemetry.ino
+++ b/examples/telemetry/telemetry.ino
@@ -2,8 +2,8 @@
  * @file telemetry.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This demonstrates how to use CRSF for Arduino to send telemetry to your RC transmitter using the CRSF protocol.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  * 
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRSFforArduino
-version=0.5.0
+version=1.0.0
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=An Arduino Library for communicating with ExpressLRS receivers.

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,8 +11,8 @@ extra_configs =
     targets/seeed_studio_samd21.ini
     targets/sparkfun_unified_esp32.ini
     targets/teensy_unified.ini
-core_dir = $PROJECT_DIR/.pio/core
-include_dir = $PROJECT_DIR/src/platformio/include
-lib_dir = $PROJECT_DIR/src
-src_dir = $PROJECT_DIR/examples/platformio
-test_dir = $PROJECT_DIR/src/platformio/test
+core_dir = .pio/core
+include_dir = src/platformio/include
+lib_dir = src
+src_dir = examples/platformio
+test_dir = src/platformio/test

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/library.json
+++ b/src/CRSFforArduino/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "CRSFforArduino",
-    "version": "0.5.0",
+    "version": "1.0.0",
     "description": "Arduino library for Crossfire protocol",
     "keywords": [
         "adafruit",

--- a/src/CRSFforArduino/src/CFA_Config.hpp
+++ b/src/CRSFforArduino/src/CFA_Config.hpp
@@ -2,8 +2,8 @@
  * @file CFA_Config.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the configuration file for CRSF for Arduino.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *
@@ -36,8 +36,8 @@ namespace crsfForArduinoConfig
 /* CRSFforArduino version
 Versioning is done using Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
-#define CRSFFORARDUINO_VERSION       "0.5.0"
-#define CRSFFORARDUINO_VERSION_DATE  "2023-11-1"
+#define CRSFFORARDUINO_VERSION       "1.0.0"
+#define CRSFFORARDUINO_VERSION_DATE  "2024-1-15"
 #define CRSFFORARDUINO_VERSION_MAJOR 0
 #define CRSFFORARDUINO_VERSION_MINOR 5
 #define CRSFFORARDUINO_VERSION_PATCH 0

--- a/src/CRSFforArduino/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino/src/CRSFforArduino.cpp
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino/src/CRSFforArduino.hpp
@@ -2,8 +2,8 @@
  * @file CRSFforArduino.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -196,12 +196,12 @@ namespace hal
 // Arduino MKRZERO
 #elif USB_PID == 0x804F
         device.type.devboard = DEVBOARD_ARDUINO_MKRZERO;
-// Arduino Zero
-#elif USB_PID == 0x804D
-        device.type.devboard = DEVBOARD_ARDUINO_ZERO;
 // Arduino Nano 33 IoT
 #elif USB_PID == 0x8057
         device.type.devboard = DEVBOARD_ARDUINO_NANO_33_IOT;
+// Arduino Zero
+#elif USB_PID == 0x804D
+        device.type.devboard = DEVBOARD_ARDUINO_ZERO;
 // Device is not supported
 #else
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -199,7 +199,7 @@ namespace hal
 // Arduino Zero
 #elif USB_PID == 0x804D
         device.type.devboard = DEVBOARD_ARDUINO_ZERO;
-// Arduino Nano 33 IoT
+// Arduino Nano 33 IoT -
 #elif USB_PID == 0x8057
         device.type.devboard = DEVBOARD_ARDUINO_NANO_33_IOT;
 // Device is not supported

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -199,7 +199,7 @@ namespace hal
 // Arduino Zero
 #elif USB_PID == 0x804D
         device.type.devboard = DEVBOARD_ARDUINO_ZERO;
-// Arduino Nano 33 IoT -
+// Arduino Nano 33 IoT
 #elif USB_PID == 0x8057
         device.type.devboard = DEVBOARD_ARDUINO_NANO_33_IOT;
 // Device is not supported

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -199,6 +199,9 @@ namespace hal
 // Arduino Zero
 #elif USB_PID == 0x804D
         device.type.devboard = DEVBOARD_ARDUINO_ZERO;
+// Arduino Nano 33 IoT
+#elif USB_PID == 0x8057
+        device.type.devboard = DEVBOARD_ARDUINO_NANO_33_IOT;
 // Device is not supported
 #else
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -3,8 +3,8 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the implementation of the Compatibility Table.
  * It is used to determine if the target development board is compatible with CRSF for Arduino.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -196,12 +196,12 @@ namespace hal
 // Arduino MKRZERO
 #elif USB_PID == 0x804F
         device.type.devboard = DEVBOARD_ARDUINO_MKRZERO;
-// Arduino Nano 33 IoT
-#elif USB_PID == 0x8057
-        device.type.devboard = DEVBOARD_ARDUINO_NANO_33_IOT;
 // Arduino Zero
 #elif USB_PID == 0x804D
         device.type.devboard = DEVBOARD_ARDUINO_ZERO;
+// Arduino Nano 33 IoT
+#elif USB_PID == 0x8057
+        device.type.devboard = DEVBOARD_ARDUINO_NANO_33_IOT;
 // Device is not supported
 #else
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
@@ -2,8 +2,8 @@
  * @file CompatibilityTable.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the Compatibility Table header file.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -2,8 +2,8 @@
  * @file DevBoards.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the DevBoards implementation file. It is used to configure CRSF for Arduino for specific development boards.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp
@@ -2,8 +2,8 @@
  * @file DevBoards.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains the DevBoards class, which is used to configure CRSF for Arduino for specific development boards.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/Hardware.hpp
+++ b/src/CRSFforArduino/src/Hardware/Hardware.hpp
@@ -2,8 +2,8 @@
  * @file Hardware.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file is the top level of the hardware abstraction layer.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
@@ -2,8 +2,8 @@
  * @file CRC.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class implementation.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.hpp
@@ -2,8 +2,8 @@
  * @file CRC.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class declaration.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
@@ -2,8 +2,8 @@
  * @file CRSF.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class implementation.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
@@ -2,8 +2,8 @@
  * @file CRSF.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class definition.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -2,8 +2,8 @@
  * @file CRSFProtocol.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -2,8 +2,8 @@
  * @file SerialBuffer.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class implementation.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -2,8 +2,8 @@
  * @file SerialBuffer.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class definition.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -2,8 +2,8 @@
  * @file SerialReceiver.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the implementation file for the Serial Receiver Interface.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
@@ -2,8 +2,8 @@
  * @file SerialReceiver.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the header file for the Serial Receiver Interface.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -2,8 +2,8 @@
  * @file Telemetry.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class implementation.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -2,8 +2,8 @@
  * @file Telemetry.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class definition.
- * @version 0.5.0
- * @date 2023-11-1
+ * @version 1.0.0
+ * @date 2024-1-15
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/targets/arduino_unified_samd21.ini
+++ b/targets/arduino_unified_samd21.ini
@@ -30,6 +30,10 @@ board = mkrwifi1010
 extends = env_common_samd21
 board = mkrzero
 
+[env:nano_33_iot]
+extends = env_common_samd21
+board = nano_33_iot
+
 [env:zero]
 extends = env_common_samd21
 board = zero


### PR DESCRIPTION
Have not  tested as I have not received my CRSF compatible receiver, but it begins without the unsupported error and seems to act normally with no data connected.