### PR TITLE
fix(platformio): Remove `$PROJECT_DIR` from all relevant paths.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,8 +11,8 @@ extra_configs =
     targets/seeed_studio_samd21.ini
     targets/sparkfun_unified_esp32.ini
     targets/teensy_unified.ini
-core_dir = $PROJECT_DIR/.pio/core
-include_dir = $PROJECT_DIR/src/platformio/include
-lib_dir = $PROJECT_DIR/src
-src_dir = $PROJECT_DIR/examples/platformio
-test_dir = $PROJECT_DIR/src/platformio/test
+core_dir = .pio/core
+include_dir = src/platformio/include
+lib_dir = src
+src_dir = examples/platformio
+test_dir = src/platformio/test


### PR DESCRIPTION
A recent update to PlatformIO caused the build/compile/verify process to fail on _all_ PlatformIO targets. This is the fix for that.