### PR TITLE
feat(devboard): Add support for Espressif's ESP32 Dev Module

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -67,6 +67,7 @@ body:
         - Arduino Nano 33 IoT
         - Arduino Nano ESP32
         - Arduino Zero
+        - Espressif ESP32 Dev Module
         - Espressif ESP32-C3 DevKitC-02
         - Espressif ESP32-C3 DevKitM-1
         - Espressif ESP32-S3 DevKitC-1-N8

--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ CRSF for Arduino is compatible with these development boards:
   - Adafruit QtPy ESP32-S2
   - Adafruit QtPy ESP32-S3
   - Arduino Nano ESP32
+  - Espressif ESP32 Dev Module
   - Espressif ESP32-C3-DevKit
   - Espressif ESP32-S3-DevKit
   - Seeed Studio XIAO ESP32-C3

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -64,6 +64,8 @@ namespace hal
         device.type.devboard = DEVBOARD_ADAFRUIT_QTPY_ESP32_PICO;
 
 // Espressif devboards.
+#elif defined(ARDUINO_ESP32_DEV)
+        device.type.devboard = DEVBOARD_ESPRESSIF_ESP32_DEVMODULE;
 #elif defined(ARDUINO_ESP32C3_DEV)
         device.type.devboard = DEVBOARD_ESPRESSIF_ESP32C3_DEVKIT;
 #elif defined(ARDUINO_ESP32S3_DEV)

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
@@ -92,6 +92,7 @@ namespace hal
             DEVBOARD_ARDUINO_ZERO,
 
             // Espresif ESP32 boards.
+            DEVBOARD_ESPRESSIF_ESP32_DEVMODULE,
             DEVBOARD_ESPRESSIF_ESP32C3_DEVKIT,
             DEVBOARD_ESPRESSIF_ESP32S3_DEVKIT,
 
@@ -165,6 +166,7 @@ namespace hal
             "Arduino MKRZERO",
             "Arduino Nano 33 IoT",
             "Arduino Zero",
+            "Espressif ESP32 Dev Module",
             "Espressif ESP32-C3 DevKit",
             "Espressif ESP32-S3 DevKit",
             "Seeed Studio Xiao ESP32-C3",

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -146,8 +146,13 @@ namespace hal
 
     void DevBoards::begin(unsigned long baudrate, int config)
     {
+#if defined(ARDUINO_ARCH_ESP32)
+        // Begin the UART port.
+        uart_port->begin(baudrate, config, RX, TX);
+#else
         // Begin the UART port.
         uart_port->begin(baudrate, config);
+#endif
     }
 
     void DevBoards::end()

--- a/targets/espressif_unified_esp32.ini
+++ b/targets/espressif_unified_esp32.ini
@@ -1,3 +1,7 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+
 [env:esp32-c3-devkit-02]
 extends = env_common_esp32
 board = esp32-c3-devkitc-02


### PR DESCRIPTION
## Overview

This adds missing support for the ESP32 Dev Module (Target: ESP-WROOM-32).

Default UART is `Serial1`.