### PR TITLE
refactor(compatibility table): Permissive Incompatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -65,7 +65,6 @@ body:
         - Arduino MKR WiFi 1010
         - Arduino MKR ZERO
         - Arduino Nano 33 IoT
-        - Arduino Nano ESP32
         - Arduino Zero
         - Espressif ESP32-C3 DevKitC-02
         - Espressif ESP32-C3 DevKitM-1

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -48,7 +48,6 @@ body:
         - Adafruit Metro M0 Express
         - Adafruit Metro M4 Express
         - Adafruit Metro M4 AirLift Lite
-        - Adafruit QtPy ESP32
         - Adafruit QtPy ESP32 Pico
         - Adafruit QtPy ESP32-C3
         - Adafruit QtPy ESP32-S2

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -73,6 +73,8 @@ body:
         - SparkFun ESP32 Thing
         - SparkFun ESP32 Thing Plus
         - SparkFun ESP32-S2 Thing Plus
+        - Seeed Studio Xiao ESP32-C3
+        - Seeed Studio Xiao ESP32-S3
         - Seeed Studio XIAO SAMD21
         - Teensy 3.0
         - Teensy 3.1/3.2

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -68,13 +68,13 @@ body:
         - Espressif ESP32-C3 DevKitC-02
         - Espressif ESP32-C3 DevKitM-1
         - Espressif ESP32-S3 DevKitC-1-N8
+        - Seeed Studio Xiao ESP32-C3
+        - Seeed Studio Xiao ESP32-S3
+        - Seeed Studio XIAO SAMD21
         - SparkFun ESP32 RedBoard IoT
         - SparkFun ESP32 Thing
         - SparkFun ESP32 Thing Plus
         - SparkFun ESP32-S2 Thing Plus
-        - Seeed Studio Xiao ESP32-C3
-        - Seeed Studio Xiao ESP32-S3
-        - Seeed Studio XIAO SAMD21
         - Teensy 3.0
         - Teensy 3.1/3.2
         - Teensy 3.5

--- a/src/CRSFforArduino/src/CFA_Config.hpp
+++ b/src/CRSFforArduino/src/CFA_Config.hpp
@@ -88,8 +88,8 @@ information back to your controller. */
 - DEBUG_ENABLED: Enables or disables debug output over the selected serial port.
 - CRSF_DEBUG_SERIAL_PORT: The serial port to use for debug output. Usually the native USB port.
 - CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT: Enables or disables debug output from the compatibility table. */
-#define CRSF_DEBUG_ENABLED     0
-#define CRSF_DEBUG_SERIAL_PORT Serial
+#define CRSF_DEBUG_ENABLED                           0
+#define CRSF_DEBUG_SERIAL_PORT                       Serial
 #define CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT 0
 
 /* All warnings and asserts below this point are to ensure that the configuration is valid. */

--- a/src/CRSFforArduino/src/CFA_Config.hpp
+++ b/src/CRSFforArduino/src/CFA_Config.hpp
@@ -85,9 +85,11 @@ information back to your controller. */
 #define CRSF_TELEMETRY_GPS_ENABLED          1
 
 /* Debug Options
-- DEBUG_ENABLED: Enables or disables debug output over the selected serial port. */
-#define CRSF_DEBUG_ENABLED     0
+- DEBUG_ENABLED: Enables or disables debug output over the selected serial port.
+- CRSF_DEBUG_SERIAL_PORT: The serial port to use for debug output. Usually the native USB port.
+- CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT: Enables or disables debug output from the compatibility table. */
 #define CRSF_DEBUG_SERIAL_PORT Serial
+#define CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT 0
 
 /* All warnings and asserts below this point are to ensure that the configuration is valid. */
 

--- a/src/CRSFforArduino/src/CFA_Config.hpp
+++ b/src/CRSFforArduino/src/CFA_Config.hpp
@@ -88,6 +88,7 @@ information back to your controller. */
 - DEBUG_ENABLED: Enables or disables debug output over the selected serial port.
 - CRSF_DEBUG_SERIAL_PORT: The serial port to use for debug output. Usually the native USB port.
 - CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT: Enables or disables debug output from the compatibility table. */
+#define CRSF_DEBUG_ENABLED     0
 #define CRSF_DEBUG_SERIAL_PORT Serial
 #define CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT 0
 

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -318,9 +318,26 @@ as two separate boards. To prevent a false negative, check for both boards. */
         if (strcmp(name, deviceNames[DEVBOARD_IS_INCOMPATIBLE]) == 0)
         {
 #if CRSF_DEBUG_ENABLED > 0
-            // Debug.
-            CRSF_DEBUG_SERIAL_PORT.print("[Compatibility Table | DEBUG]: Board is ");
-            CRSF_DEBUG_SERIAL_PORT.println("incompatible.");
+            // Print a generic error message.
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | ERROR]: The target board is not compatible with CRSF for Arduino.");
+#if defined(F_CPU)
+#if F_CPU >= 48000000
+            // F_CPU must be at least 48 MHz (or higher).
+
+            // Print instructions for requesting board support.
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request compatibility for this board, you may do the following:");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. In the Issues tab of the CRSFforArduino repository, click the New Issue button.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 2. Click the Get Started button next to the \"Devboard Compatibility Request\" issue template.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");
+#else
+            // F_CPU is less than 48 MHz.
+            CRSF_DEBUG_SERIAL_PORT.println("The target board's clock speed is less than 48 MHz. CRSF for Arduino requires a clock speed of at least 48 MHz.");
+#endif
+#else
+            // F_CPU is not defined. This is a fatal error and should not happen under normal circumstances.
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | FATAL ERROR]: F_CPU is not defined.");
+#endif
 #endif
 
             return false;
@@ -343,6 +360,13 @@ as two separate boards. To prevent a false negative, check for both boards. */
             // Warning.
             CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: Board is ");
             CRSF_DEBUG_SERIAL_PORT.println("permissively incompatible (unknown board).");
+
+            // Print instructions for requesting board support.
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request support for this board, you may do the following:");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. In the Issues tab of the CRSF for Arduino repository, click the New Issue button.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 2. Click the Get Started button next to the \"Devboard Compatibility Request\" issue template.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");
 #endif
 
             return true;

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -216,7 +216,7 @@ namespace hal
 // The architecture is known, but the board and chip are not.
 #else
 #warning "Devboard not supported. Please check the compatibility table."
-device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
 // Seeed Studio devboards

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -326,7 +326,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
 
             // Print instructions for requesting board support.
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request compatibility for this board, you may do the following:");
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. In the Issues tab of the CRSFforArduino repository, click the New Issue button.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. Go to CRSFforArduino's repository at: http://tinyurl.com/4je6bzv7");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 2. Click the Get Started button next to the \"Devboard Compatibility Request\" issue template.");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");
@@ -363,7 +363,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
 
             // Print instructions for requesting board support.
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request support for this board, you may do the following:");
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. In the Issues tab of the CRSF for Arduino repository, click the New Issue button.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. Go to CRSFforArduino's repository at: http://tinyurl.com/4je6bzv7");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 2. Click the Get Started button next to the \"Devboard Compatibility Request\" issue template.");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -25,8 +25,12 @@
  * 
  */
 
-#include "./CFA_Config.hpp"
 #include "CompatibilityTable.hpp"
+#if defined(ARDUINO) && defined(PLATFORMIO)
+#include "./CFA_Config.hpp"
+#elif defined(ARDUINO) && !defined(PLATFORMIO)
+#include "./CRSFforArduino/src/CFA_Config.hpp"
+#endif
 
 namespace hal
 {

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -348,6 +348,13 @@ as two separate boards. To prevent a false negative, check for both boards. */
 #if CRSF_DEBUG_ENABLED > 0
             // Warning.
             CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: The target board and the chipset that it's using are unknown. CRSF for Arduino will attempt to run on this board, but it may not work properly.");
+
+            // Print instructions for requesting board support.
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request support for this board and its chipset, you may do the following:");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. Go to CRSFforArduino's repository at: http://tinyurl.com/4je6bzv7");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 2. Click the Get Started button next to the \"Devboard Compatibility Request\" issue template.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");
 #endif
 
             return true;

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -90,8 +90,9 @@ namespace hal
 #elif defined(ARDUINO_NANO_ESP32)
         device.type.devboard = DEVBOARD_ARDUINO_NANO_ESP32;
 #else
+        // The architecture and chip is known, but the board is not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 
 // Arduino SAMD Architecture
@@ -113,9 +114,9 @@ namespace hal
 // Adafruit Metro M0 Express
 #elif USB_PID == 0x8013
         device.type.devboard = DEVBOARD_ADAFRUIT_METRO_M0_EXPRESS;
-// Device is not supported
+// The architecture and chip is known, but the board is not.
 #else
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif
 
@@ -129,9 +130,9 @@ namespace hal
 // Adafruit Metro M4 AirLift Lite
 #elif USB_PID == 0x8037
         device.type.devboard = DEVBOARD_ADAFRUIT_METRO_M4_AIRLIFT_LITE;
-// Device is not supported
+// The architecture and chip is known, but the board is not.
 #else
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif
 
@@ -139,9 +140,9 @@ namespace hal
 // Adafruit ItsyBitsy M4 Express
 #if USB_PID == 0x802B
         device.type.devboard = DEVBOARD_ADAFRUIT_ITSYBITSY_M4_EXPRESS;
-// Device is not supported
+// The architecture and chip is known, but the board is not.
 #else
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif
 
@@ -149,9 +150,9 @@ namespace hal
 // Adafruit Grand Central M4
 #if USB_PID == 0x8020
         device.type.devboard = DEVBOARD_ADAFRUIT_GRAND_CENTRAL_M4;
-// Device is not supported
+// The architecture and chip is known, but the board is not.
 #else
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif
 
@@ -159,14 +160,14 @@ namespace hal
 // Adafruit Feather M4 CAN
 #if USB_PID == 0x80CD
         device.type.devboard = DEVBOARD_ADAFRUIT_FEATHER_M4_CAN;
-// Device is not supported
+// The architecture and chip is known, but the board is not.
 #else
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif
-#else // Incompatible devboards
+#else // The architecture is known, but the board and chip are not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
 // Arduino devboards
@@ -203,11 +204,15 @@ namespace hal
 // Arduino Nano 33 IoT
 #elif USB_PID == 0x8057
         device.type.devboard = DEVBOARD_ARDUINO_NANO_33_IOT;
-// Device is not supported
+// The architecture and chip is known, but the board is not.
 #else
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif
+// The architecture is known, but the board and chip are not.
+#else
+#warning "Devboard not supported. Please check the compatibility table."
+device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
 // Seeed Studio devboards
@@ -218,18 +223,18 @@ namespace hal
 #if USB_PID == 0x802F
         device.type.devboard = DEVBOARD_SEEEDSTUDIO_XIAO_M0;
 
-// Device is not supported
+// The architecture and chip is known, but the board is not.
 #else
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #warning "Devboard not supported. Please check the compatibility table."
 #endif
 
-#else // Incompatible devboards
+#else // The architecture is known, but the board and chip are not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
-#else // Incompatible devboards
+#else // Unable to verify the vendor ID. Board is incompatible.
 #warning "Devboard not supported. Please check the compatibility table."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_SAMD_ADAFRUIT
@@ -240,8 +245,9 @@ namespace hal
         device.type.devboard = DEVBOARD_TEENSY_30;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else
+        // The architecture and chip is known, but the board is not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #elif defined(__MK20DX256__)
 /* PlatformIO treats Teensy 3.1 and Teensy 3.2 as the same board, but the Arduino IDE treats them
@@ -249,38 +255,38 @@ as two separate boards. To prevent a false negative, check for both boards. */
 #if defined(ARDUINO_TEENSY31) || defined(ARDUINO_TEENSY32)
         device.type.devboard = DEVBOARD_TEENSY_31_32;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
-#else // Incompatible devboards
+#else // The architecture and chip is known, but the board is not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #elif defined(__MK64FX512__)
 #if defined(ARDUINO_TEENSY35)
         device.type.devboard = DEVBOARD_TEENSY_35;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
-#else // Incompatible devboards
+#else // The architecture and chip is known, but the board is not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #elif defined(__MK66FX1M0__)
 #if defined(ARDUINO_TEENSY36)
         device.type.devboard = DEVBOARD_TEENSY_36;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
-#else // Incompatible devboards
+#else // The architecture and chip is known, but the board is not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #elif defined(__IMXRT1062__)
 #if defined(ARDUINO_TEENSY40)
         device.type.devboard = DEVBOARD_TEENSY_40;
 #elif defined(ARDUINO_TEENSY41)
         device.type.devboard = DEVBOARD_TEENSY_41;
-#else // Incompatible devboards
+#else // The architecture and chip is known, but the board is not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
-#else // Incompatible devboards
+#else // The architecture is known, but the board and chip are not.
 #warning "Devboard not supported. Please check the compatibility table."
-        device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
+        device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
 #else // Unsupported architecture
@@ -314,6 +320,28 @@ as two separate boards. To prevent a false negative, check for both boards. */
 #endif
 
             return false;
+        }
+
+        else if (strcmp(name, deviceNames[DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP]) == 0)
+        {
+#if CRSF_DEBUG_ENABLED > 0
+            // Warning.
+            CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: Board is ");
+            CRSF_DEBUG_SERIAL_PORT.println("permissively incompatible (unknown board and chip).");
+#endif
+
+            return true;
+        }
+
+        else if (strcmp(name, deviceNames[DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD]) == 0)
+        {
+#if CRSF_DEBUG_ENABLED > 0
+            // Warning.
+            CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: Board is ");
+            CRSF_DEBUG_SERIAL_PORT.println("permissively incompatible (unknown board).");
+#endif
+
+            return true;
         }
 
         else

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -374,7 +374,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
 
         else
         {
-#if CRSF_DEBUG_ENABLED > 0
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
             // Debug.
             CRSF_DEBUG_SERIAL_PORT.print("[Compatibility Table | DEBUG]: Board is ");
             CRSF_DEBUG_SERIAL_PORT.println("compatible.");
@@ -403,7 +403,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
             return deviceNames[DEVBOARD_IS_INCOMPATIBLE];
         }
 
-#if CRSF_DEBUG_ENABLED > 0
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
         // Debug.
         CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | DEBUG]: Board is ");
         CRSF_DEBUG_SERIAL_PORT.println(deviceNames[device.type.devboard]);

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -347,8 +347,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
         {
 #if CRSF_DEBUG_ENABLED > 0
             // Warning.
-            CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: Board is ");
-            CRSF_DEBUG_SERIAL_PORT.println("permissively incompatible (unknown board and chip).");
+            CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: The target board and the chipset that it's using are unknown. CRSF for Arduino will attempt to run on this board, but it may not work properly.");
 #endif
 
             return true;
@@ -358,8 +357,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
         {
 #if CRSF_DEBUG_ENABLED > 0
             // Warning.
-            CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: Board is ");
-            CRSF_DEBUG_SERIAL_PORT.println("permissively incompatible (unknown board).");
+            CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: The target board is unknown. CRSF for Arduino will attempt to run on this board, but it may not work properly.");
 
             // Print instructions for requesting board support.
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request support for this board, you may do the following:");

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -95,7 +95,7 @@ namespace hal
         device.type.devboard = DEVBOARD_ARDUINO_NANO_ESP32;
 #else
         // The architecture and chip is known, but the board is not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 
@@ -121,7 +121,7 @@ namespace hal
 // The architecture and chip is known, but the board is not.
 #else
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
 #endif
 
 #elif defined(__SAMD51J19A__)
@@ -137,7 +137,7 @@ namespace hal
 // The architecture and chip is known, but the board is not.
 #else
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
 #endif
 
 #elif defined(__SAMD51G19A__)
@@ -147,7 +147,7 @@ namespace hal
 // The architecture and chip is known, but the board is not.
 #else
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
 #endif
 
 #elif defined(__SAMD51P20A__)
@@ -157,7 +157,7 @@ namespace hal
 // The architecture and chip is known, but the board is not.
 #else
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
 #endif
 
 #elif defined(__SAME51J19A__)
@@ -167,10 +167,10 @@ namespace hal
 // The architecture and chip is known, but the board is not.
 #else
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
 #endif
 #else // The architecture is known, but the board and chip are not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board and the chipset that it's using are unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
@@ -211,11 +211,11 @@ namespace hal
 // The architecture and chip is known, but the board is not.
 #else
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
 #endif
 // The architecture is known, but the board and chip are not.
 #else
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board and the chipset that it's using are unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
@@ -230,16 +230,16 @@ namespace hal
 // The architecture and chip is known, but the board is not.
 #else
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
 #endif
 
 #else // The architecture is known, but the board and chip are not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board and the chipset that it's using are unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
 #else // Unable to verify the vendor ID. Board is incompatible.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_SAMD_ADAFRUIT
 
@@ -250,7 +250,7 @@ namespace hal
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else
         // The architecture and chip is known, but the board is not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #elif defined(__MK20DX256__)
@@ -260,7 +260,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
         device.type.devboard = DEVBOARD_TEENSY_31_32;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else // The architecture and chip is known, but the board is not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #elif defined(__MK64FX512__)
@@ -268,7 +268,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
         device.type.devboard = DEVBOARD_TEENSY_35;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else // The architecture and chip is known, but the board is not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #elif defined(__MK66FX1M0__)
@@ -276,7 +276,7 @@ as two separate boards. To prevent a false negative, check for both boards. */
         device.type.devboard = DEVBOARD_TEENSY_36;
 #pragma message "Teensy 3.x is not recommended for new projects. Please consider using Teensy 4.0 or later instead."
 #else // The architecture and chip is known, but the board is not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #elif defined(__IMXRT1062__)
@@ -285,16 +285,16 @@ as two separate boards. To prevent a false negative, check for both boards. */
 #elif defined(ARDUINO_TEENSY41)
         device.type.devboard = DEVBOARD_TEENSY_41;
 #else // The architecture and chip is known, but the board is not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board is unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD;
 #endif
 #else // The architecture is known, but the board and chip are not.
-#warning "Devboard not supported. Please check the compatibility table."
+#warning "The target board and the chipset that it's using are unknown. Please enable CRSF_DEBUG_ENABLED and CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT in CFA_Config.hpp for more information."
         device.type.devboard = DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP;
 #endif
 
 #else // Unsupported architecture
-#error "Unsupported architecture. Please check the compatibility table."
+#error "Unsupported architecture. CRSF for Arduino only supports the ESP32, SAMD, and Teensy architectures."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_ARCH_SAMD
 

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -25,6 +25,7 @@
  * 
  */
 
+#include "./CFA_Config.hpp"
 #include "CompatibilityTable.hpp"
 
 namespace hal
@@ -304,21 +305,24 @@ as two separate boards. To prevent a false negative, check for both boards. */
      */
     bool CompatibilityTable::isDevboardCompatible(const char *name)
     {
-        // Debug.
-        // Serial.print("[Compatibility Table | DEBUG]: Board is ");
-
         if (strcmp(name, deviceNames[DEVBOARD_IS_INCOMPATIBLE]) == 0)
         {
+#if CRSF_DEBUG_ENABLED > 0
             // Debug.
-            // Serial.println("incompatible.");
+            CRSF_DEBUG_SERIAL_PORT.print("[Compatibility Table | DEBUG]: Board is ");
+            CRSF_DEBUG_SERIAL_PORT.println("incompatible.");
+#endif
 
             return false;
         }
 
         else
         {
+#if CRSF_DEBUG_ENABLED > 0
             // Debug.
-            // Serial.println("compatible.");
+            CRSF_DEBUG_SERIAL_PORT.print("[Compatibility Table | DEBUG]: Board is ");
+            CRSF_DEBUG_SERIAL_PORT.println("compatible.");
+#endif
 
             return true;
         }
@@ -335,15 +339,19 @@ as two separate boards. To prevent a false negative, check for both boards. */
     {
         if (device.type.devboard >= DEVBOARD_COUNT)
         {
+#if CRSF_DEBUG_ENABLED > 0
             // Debug.
-            // Serial.println("\r\n[Compatibility Table | FATAL ERROR]: Board index is out of bounds.");
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | FATAL ERROR]: Board index is out of bounds.");
+#endif
 
             return deviceNames[DEVBOARD_IS_INCOMPATIBLE];
         }
 
+#if CRSF_DEBUG_ENABLED > 0
         // Debug.
-        // Serial.print("\r\n[Compatibility Table | DEBUG]: Board is ");
-        // Serial.println(deviceNames[device.type.devboard]);
+        CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | DEBUG]: Board is ");
+        CRSF_DEBUG_SERIAL_PORT.println(deviceNames[device.type.devboard]);
+#endif
 
         return deviceNames[device.type.devboard];
     }

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -317,37 +317,15 @@ as two separate boards. To prevent a false negative, check for both boards. */
     {
         if (strcmp(name, deviceNames[DEVBOARD_IS_INCOMPATIBLE]) == 0)
         {
-#if CRSF_DEBUG_ENABLED > 0
-            // Print a generic error message.
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            // Error.
             CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | ERROR]: The target board is not compatible with CRSF for Arduino.");
+#endif
+
 #if defined(F_CPU)
 #if F_CPU >= 48000000
-            // F_CPU must be at least 48 MHz (or higher).
-
-            // Print instructions for requesting board support.
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request compatibility for this board, you may do the following:");
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. Go to CRSFforArduino's repository at: http://tinyurl.com/4je6bzv7");
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 2. Click the Get Started button next to the \"Devboard Compatibility Request\" issue template.");
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");
-#else
-            // F_CPU is less than 48 MHz.
-            CRSF_DEBUG_SERIAL_PORT.println("The target board's clock speed is less than 48 MHz. CRSF for Arduino requires a clock speed of at least 48 MHz.");
-#endif
-#else
-            // F_CPU is not defined. This is a fatal error and should not happen under normal circumstances.
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | FATAL ERROR]: F_CPU is not defined.");
-#endif
-#endif
-
-            return false;
-        }
-
-        else if (strcmp(name, deviceNames[DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP]) == 0)
-        {
-#if CRSF_DEBUG_ENABLED > 0
-            // Warning.
-            CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: The target board and the chipset that it's using are unknown. CRSF for Arduino will attempt to run on this board, but it may not work properly.");
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\t\t\t       CRSF for Arduino will not run on this board.");
 
             // Print instructions for requesting board support.
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request support for this board and its chipset, you may do the following:");
@@ -356,22 +334,95 @@ as two separate boards. To prevent a false negative, check for both boards. */
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");
 #endif
+#else
+            // F_CPU is less than 48 MHz.
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | ERROR]: The target board's clock speed is less than 48 MHz. CRSF for Arduino requires a clock speed of at least 48 MHz or higher.");
+#endif
+#endif
+#else
+            // F_CPU is not defined. This is a fatal error and should not happen under normal circumstances.
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | FATAL ERROR]: F_CPU is not defined.");
+#endif
+#endif
+
+            return false;
+        }
+
+        else if (strcmp(name, deviceNames[DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP]) == 0)
+        {
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            // Warning.
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | WARNING]: The target board and its chipset may not be compatible with CRSF for Arduino.");
+#endif
+
+#if defined(F_CPU)
+#if F_CPU >= 48000000
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\t\t\t\t The target board and the chipset that it's using are unknown.\r\n\t\t\t\t CRSF for Arduino will attempt to run on this board, but it may not work properly.");
+
+            // Print instructions for requesting board support.
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request support for this board and its chipset, you may do the following:");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. Go to CRSFforArduino's repository at: http://tinyurl.com/4je6bzv7");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 2. Click the Get Started button next to the \"Devboard Compatibility Request\" issue template.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");
+#endif
+#else
+            // F_CPU is less than 48 MHz.
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | ERROR]: The target board's clock speed is less than 48 MHz. CRSF for Arduino requires a clock speed of at least 48 MHz or higher.");
+#endif
+
+            return false;
+#endif
+#else
+            // F_CPU is not defined. This is a fatal error and should not happen under normal circumstances.
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | FATAL ERROR]: F_CPU is not defined.");
+#endif
+
+            return false;
+#endif
 
             return true;
         }
 
         else if (strcmp(name, deviceNames[DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD]) == 0)
         {
-#if CRSF_DEBUG_ENABLED > 0
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
             // Warning.
-            CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | WARNING]: The target board is unknown. CRSF for Arduino will attempt to run on this board, but it may not work properly.");
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | WARNING]: The target board may not be compatible with CRSF for Arduino.");
+#endif
+
+#if defined(F_CPU)
+#if F_CPU >= 48000000
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\t\t\t\t The target board is unknown.\r\n\t\t\t\t CRSF for Arduino will attempt to run on this board, but it may not work properly.");
 
             // Print instructions for requesting board support.
-            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request support for this board, you may do the following:");
+            CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: If you would like to request support for this board and its chipset, you may do the following:");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 1. Go to CRSFforArduino's repository at: http://tinyurl.com/4je6bzv7");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 2. Click the Get Started button next to the \"Devboard Compatibility Request\" issue template.");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: 3. Fill out the template and submit the issue.");
             CRSF_DEBUG_SERIAL_PORT.println("[Compatibility Table | INFO]: Remember to check that your issue does not already exist before submitting it.");
+#endif
+#else
+            // F_CPU is less than 48 MHz.
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | ERROR]: The target board's clock speed is less than 48 MHz. CRSF for Arduino requires a clock speed of at least 48 MHz or higher.");
+#endif
+
+            return false;
+#endif
+#else
+            // F_CPU is not defined. This is a fatal error and should not happen under normal circumstances.
+#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Compatibility Table | FATAL ERROR]: F_CPU is not defined.");
+#endif
+
+            return false;
 #endif
 
             return true;
@@ -379,16 +430,8 @@ as two separate boards. To prevent a false negative, check for both boards. */
 
         else
         {
-#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
-            // Debug.
-            CRSF_DEBUG_SERIAL_PORT.print("[Compatibility Table | DEBUG]: Board is ");
-            CRSF_DEBUG_SERIAL_PORT.println("compatible.");
-#endif
-
             return true;
         }
-
-        // return strcmp(name, deviceNames[DEVBOARD_IS_INCOMPATIBLE]) != 0 ? true : false;
     }
 
     /**
@@ -407,12 +450,6 @@ as two separate boards. To prevent a false negative, check for both boards. */
 
             return deviceNames[DEVBOARD_IS_INCOMPATIBLE];
         }
-
-#if CRSF_DEBUG_ENABLED > 0 && CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT > 0
-        // Debug.
-        CRSF_DEBUG_SERIAL_PORT.print("\r\n[Compatibility Table | DEBUG]: Board is ");
-        CRSF_DEBUG_SERIAL_PORT.println(deviceNames[device.type.devboard]);
-#endif
 
         return deviceNames[device.type.devboard];
     }

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
@@ -42,8 +42,14 @@ namespace hal
       private:
         typedef enum ct_devboards_e
         {
-            // Unknown device.
+            // Incompatible device. Non-permissive.
             DEVBOARD_IS_INCOMPATIBLE = 0,
+
+            // Permissive incompatibility:
+            // - The architecture and chip is known, but the board is not.
+            // - The architecture is known, but the board and chip are not.
+            DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD,
+            DEVBOARD_IS_PERMISSIVELY_INCOMPATIBLE_UNKNOWN_BOARD_AND_CHIP,
 
             // Adafruit ESP32 boards.
             DEVBOARD_ADAFRUIT_FEATHER_ESP32,
@@ -131,6 +137,8 @@ namespace hal
 
         const char *deviceNames[DEVBOARD_COUNT] = {
             "Incompatible device",
+            "Permissively incompatible device (unknown board)",
+            "Permissively incompatible device (unknown board and chip)",
             "Adafruit Feather ESP32",
             "Adafruit Feather ESP32-S2",
             "Adafruit Feather ESP32-S3",

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
@@ -137,7 +137,7 @@ namespace hal
             "Adafruit Feather ESP32-S3 (no PSRAM)",
             "Adafruit ItsyBitsy ESP32",
             "Adafruit Metro ESP32-S2",
-            "Adafruit QT Py ESP32 C3",
+            "Adafruit QT Py ESP32-C3",
             "Adafruit QT Py ESP32 Pico",
             "Adafruit QT Py ESP32-S2",
             "Adafruit QT Py ESP32-S3",

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -198,10 +198,11 @@ namespace serialReceiver
         {
             // board->exitCriticalSection();
 
-#if CRSF_DEBUG_ENABLED > 0
+            // This is now handled by the Compatibility Table.
+            // #if CRSF_DEBUG_ENABLED > 0
             // Debug.
-            CRSF_DEBUG_SERIAL_PORT.println("\n[Serial Receiver | ERROR]: Devboard is not compatible.");
-#endif
+            //             CRSF_DEBUG_SERIAL_PORT.println("\n[Serial Receiver | ERROR]: Devboard is not compatible.");
+            // #endif
             return false;
         }
     }


### PR DESCRIPTION
## Overview

This implements #67 by allowing CRSF for Arduino to initialise successfully on unknown development boards with unknown chipsets, provided that the overall architecture (EG ESP32, SAMD, TEENSY etc) is known.

## Details

When CRSF for Arduino is flashed onto a development board that is _not_ supported and it has a microcontroller that is _also_ not supported, but the overall architecture _is_ supported, you will be met with instructions on how to request support in the Serial Monitor when `CRSF_DEBUG_ENABLED` is set to `1`.

If your device shows up as completely incompatible (but compilation succeeds), you can set `CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT` to `1` to find out why.

This will help me out a lot with diagnosing bugs during compilation, flashing, and initialising - particularly when you guys submit issues surrounding the Compatibility Table, as _this_ seems to be the thing that is tripping a lot of people up now.

So, if your target has one of CRSF for Arduino's supported architectures, but the board itself isn't known, you can still use my library. But, keep in mind that you will still need to ask me to add compatibility at some point.