### PR TITLE
refactor(hal): Deprecate `DevBoards` class and bring `HardwareSerial` class up to the Sketch Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ With that being said, installation from the Releases tab is nearly identical to 
 ### The API
 
 1. Add my library to your sketch with `#include "CRSFforArduino.h"`
-2. Underneath that, you need to declare `CRSFforArduino crsf = CRSFforArduino()`. For now, you can leave the parentheses empty. There is ongoing work to allow you to specify what pins your receiver is connected to. For now, it defaults to pins 0 and 1 for Tx and Rx respectively.
+2. Underneath that, you need to declare `CRSFforArduino crsf = CRSFforArduino(HardwareSerial *serialPort)`.
+  The parameter `serialPort` is where you can provide your own hardware UART port and pin definitions.
 3. In your `setup()`, do `crsf.begin()` to start communicating with your connected ExpressLRS receiver. In case something goes wrong, `crsf.begin()` returns a boolean value of `true` if initialisation is successful, and `false` if it is not.
 4. In your `loop()`, you need to call `crsf.update()`. This handles all of the data processing (including receiving RC channels and sending telemetry) and should be called as often as possible. You no longer need to read back the return value of `crsf.update()`, as it no longer returns anything. Everything is handled internally now.
 5. To read your RC channel values, use `crsf.readRcChannel(n)`. Here, `n` refers to your channel number from 1 to 16.
@@ -108,9 +109,9 @@ The example below demonstrates what your code should look like, using the instru
 /* 1. Add Cassie Robinson's CRSFforArduino.h library. */
 #include "CRSFforArduino.h"
 
-/* 2. Declare a CRSFforArduino object.
+/* 2. Declare a CRSFforArduino object with your board's default UART port.
 You can call it literally anything you want. */
-CRSFforArduino crsf = CRSFforArduino();
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 void setup()
 {
@@ -195,7 +196,7 @@ float lat, lon, alt, spd, gCourse;
 int numSats;
 
 /* 3. Declare a CRSFforArduino object. */
-CRSFforArduino crsf = CRSFforArduino();
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 void setup()
 {
@@ -433,6 +434,8 @@ If your development board outputs a logic level of 5 volts on its serial pins, y
 
 ## Telemetry
 
+CRSF for Arduino supports full telemetry feedback, and you can view it all in one convenient place if you're using a LUA script like the INAV Telemetry Widget for OpenTX/EdgeTX controllers.
+
 The following telemetry data is supported:
 
 - Attitude/Artificial Horizon data:
@@ -466,10 +469,10 @@ The following telemetry data is supported:
 ## Known issues and limitations
 
 - CRSF for Arduino is not compatible with AVR based microcontrollers.
-  - This is because the AVR microcontrollers are simply not powerful enough to meet the minimum requirements of the CRSF protocol.
-- DMA for both SAMD21 and SAMD51 targets is currently broken, and is disabled for the time being.
-  If you build CRSF for Arduino with `USE_DMA` enabled, you will see this warning message: `DMA is enabled. This is an experimental feature and may not work as expected.`
-  At this point, DMA may be removed from CRSF for Arduino, as it brings _very little_ benefit to the project... if any at all.
+  - CRSF for Arduino uses a _lot_ of dynamic memory, to which all AVR microcontrollers simply don't have enough of.
+  - There are ongoing tests to see what other reasons why AVR microcontrollers aren't compatible.
+- DMA for both SAMD21 and SAMD51 targets is no longer available.
+  - DMA may be re-factored later on down the track. However, it is not a priority right now.
 - Software serial is not supported.
   - This is because software serial is not capable of running at the required baud rate of 420 KB/s.
   - This also means that CRSF for Arduino is restricted to using hardware serial only.
@@ -493,14 +496,14 @@ I give credit where credit is due. Because CRSF for Arduino isn't entirely my ow
     - [Source Code](https://github.com/ExpressLRS/ExpressLRS)
     - [Website](https://www.expresslrs.org/3.0/)
   - [Team BlackSheep FPV](https://github.com/tbs-fpv) - The folks behind the CRSF protocol that both ExpressLRS and CRSF for Arduino uses.
-  - [This issue](https://github.com/tbs-fpv/freedomtx/issues/26) on [FreedomTX's repository.](https://github.com/tbs-fpv/freedomtx/issues/26)
-    - This gets a mention here, because I will benefit _greatly_ from an officially documented public repository for the CRSF protocol. The evolution of the protocol itself will help shape CRSF for Arduino, and I will be able to refer to that in addition to my references here.
 - References for CRSF for Arduino
   - [BetaFlight](https://github.com/betaflight)
     - [Development Team](https://github.com/orgs/betaflight/people)
     - [License](https://github.com/betaflight/betaflight/blob/master/LICENSE)
     - [Source Code](https://github.com/betaflight/betaflight)
     - [Website](https://betaflight.com/)
+  - [CRSF-WG](https://github.com/crsf-wg/crsf)
+    - This is the official repository for The CRSF Protocol, which CRSF for Arduino is based on.
   - [RotorFlight](https://github.com/rotorflight)
     - [Development Team](https://github.com/rotorflight#credits)
     - [License](https://github.com/rotorflight/rotorflight-firmware/blob/master/LICENSE)

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -108,7 +108,7 @@
 
 const int channelCount = crsfProtocol::RC_CHANNEL_COUNT; // I'm not sure if this is right, but we can always manually put in the number of channels desired
 
-CRSFforArduino crsf = CRSFforArduino();
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 void setup()
 {

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -145,14 +145,15 @@ void loop()
     if (millis() - lastPrint >= 100)
     {
         lastPrint = millis();
-        for(int i = 1; i <= channelCount; i++){
-          //Serial.print("Channel");
-          Serial.print(i);
-          Serial.print(":");
-          Serial.print(crsf.rcToUs(crsf.getChannel(i)));
-          Serial.print("\t");
+        for (int i = 1; i <= channelCount; i++)
+        {
+            //Serial.print("Channel");
+            Serial.print(i);
+            Serial.print(":");
+            Serial.print(crsf.rcToUs(crsf.getChannel(i)));
+            Serial.print("\t");
         }
-        Serial.println();    
+        Serial.println();
     }
 }
 

--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -106,12 +106,9 @@
 
 #include "CRSFforArduino.hpp"
 
-#define SERIAL_RX_PIN 0 // Set SERIAL_RX_PIN to the pin that the CRSF receiver's TX pin is connected to.
-#define SERIAL_TX_PIN 1 // Set SERIAL_TX_PIN to the pin that the CRSF receiver's RX pin is connected to.
-
 const int channelCount = crsfProtocol::RC_CHANNEL_COUNT; // I'm not sure if this is right, but we can always manually put in the number of channels desired
 
-CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
+CRSFforArduino crsf = CRSFforArduino();
 
 void setup()
 {

--- a/examples/flight_modes/flight_modes.ino
+++ b/examples/flight_modes/flight_modes.ino
@@ -59,7 +59,7 @@
 #define FLIGHT_MODE_HORIZON_MIN     1700
 #define FLIGHT_MODE_HORIZON_MAX     2100
 
-CRSFforArduino crsf = CRSFforArduino();
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 void onFlightModeUpdate(serialReceiver::flightModeId_t);
 

--- a/examples/flight_modes/flight_modes.ino
+++ b/examples/flight_modes/flight_modes.ino
@@ -59,10 +59,7 @@
 #define FLIGHT_MODE_HORIZON_MIN     1700
 #define FLIGHT_MODE_HORIZON_MAX     2100
 
-#define SERIAL_RX_PIN 0 // Set SERIAL_RX_PIN to the pin that the CRSF receiver's TX pin is connected to.
-#define SERIAL_TX_PIN 1 // Set SERIAL_TX_PIN to the pin that the CRSF receiver's RX pin is connected to.
-
-CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
+CRSFforArduino crsf = CRSFforArduino();
 
 void onFlightModeUpdate(serialReceiver::flightModeId_t);
 

--- a/examples/flight_modes/flight_modes.ino
+++ b/examples/flight_modes/flight_modes.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Demonstrates the use of CRSF for Arduino's flight mode functionality.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_flight_modes.cpp
+++ b/examples/platformio/main_flight_modes.cpp
@@ -58,10 +58,7 @@
 #define FLIGHT_MODE_HORIZON_MIN     1700
 #define FLIGHT_MODE_HORIZON_MAX     2100
 
-#define SERIAL_RX_PIN 0 // Set SERIAL_RX_PIN to the pin that the CRSF receiver's TX pin is connected to.
-#define SERIAL_TX_PIN 1 // Set SERIAL_TX_PIN to the pin that the CRSF receiver's RX pin is connected to.
-
-CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
+CRSFforArduino crsf = CRSFforArduino();
 
 void onFlightModeUpdate(serialReceiver::flightModeId_t);
 

--- a/examples/platformio/main_flight_modes.cpp
+++ b/examples/platformio/main_flight_modes.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Demonstrates the use of CRSF for Arduino's flight mode functionality.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_flight_modes.cpp
+++ b/examples/platformio/main_flight_modes.cpp
@@ -58,7 +58,7 @@
 #define FLIGHT_MODE_HORIZON_MIN     1700
 #define FLIGHT_MODE_HORIZON_MAX     2100
 
-CRSFforArduino crsf = CRSFforArduino();
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 void onFlightModeUpdate(serialReceiver::flightModeId_t);
 

--- a/examples/platformio/main_rc.cpp
+++ b/examples/platformio/main_rc.cpp
@@ -33,7 +33,7 @@
 
 #include "CRSFforArduino.hpp"
 
-CRSFforArduino crsf = CRSFforArduino();
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 void setup()
 {

--- a/examples/platformio/main_rc.cpp
+++ b/examples/platformio/main_rc.cpp
@@ -33,10 +33,7 @@
 
 #include "CRSFforArduino.hpp"
 
-#define SERIAL_RX_PIN 0 // Set SERIAL_RX_PIN to the pin that the CRSF receiver's TX pin is connected to.
-#define SERIAL_TX_PIN 1 // Set SERIAL_TX_PIN to the pin that the CRSF receiver's RX pin is connected to.
-
-CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
+CRSFforArduino crsf = CRSFforArduino();
 
 void setup()
 {

--- a/examples/platformio/main_rc.cpp
+++ b/examples/platformio/main_rc.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_telemetry.cpp
+++ b/examples/platformio/main_telemetry.cpp
@@ -62,7 +62,7 @@ float speed = 500.0F;                 // Speed is in cm/s
 float groundCourse = 275.8F;          // Ground Course is in degrees.
 uint8_t satellites = 7;               // 7 satellites are in view (implies a 3D fix).
 
-CRSFforArduino crsf = CRSFforArduino();
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 #if VIEW_RC_CHANNELS > 0
 const int channelCount = 8;

--- a/examples/platformio/main_telemetry.cpp
+++ b/examples/platformio/main_telemetry.cpp
@@ -36,8 +36,6 @@ To work around this, preprocessor directives are used to exclude the main_teleme
 #define VIEW_RC_CHANNELS             0 // Set VIEW_RC_CHANNELS to 1 to view the RC channel data in the serial monitor.
 #define GENERATE_RANDOM_BATTERY_DATA 0 // Set GENERATE_RANDOM_BATTERY_DATA to 1 to generate random battery sensor telemetry data.
 #define GENERATE_RANDOM_GPS_DATA     0 // Set GENERATE_RANDOM_GPS_DATA to 1 to generate random GPS telemetry data.
-#define SERIAL_RX_PIN                0 // Set SERIAL_RX_PIN to the pin that the CRSF receiver's TX pin is connected to.
-#define SERIAL_TX_PIN                1 // Set SERIAL_TX_PIN to the pin that the CRSF receiver's RX pin is connected to.
 
 uint32_t timeNow = 0;
 
@@ -64,7 +62,7 @@ float speed = 500.0F;                 // Speed is in cm/s
 float groundCourse = 275.8F;          // Ground Course is in degrees.
 uint8_t satellites = 7;               // 7 satellites are in view (implies a 3D fix).
 
-CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
+CRSFforArduino crsf = CRSFforArduino();
 
 #if VIEW_RC_CHANNELS > 0
 const int channelCount = 8;

--- a/examples/platformio/main_telemetry.cpp
+++ b/examples/platformio/main_telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates how to use CRSF for Arduino to send telemetry to your RC transmitter using the CRSF protocol.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/telemetry/telemetry.ino
+++ b/examples/telemetry/telemetry.ino
@@ -35,8 +35,6 @@
 #define USE_SERIAL_PLOTTER           1 // Set USE_SERIAL_PLOTTER to 1 to view this example's data in the Arduino IDE's serial plotter.
 #define GENERATE_RANDOM_BATTERY_DATA 0 // Set GENERATE_RANDOM_BATTERY_DATA to 1 to generate random battery sensor telemetry data.
 #define GENERATE_RANDOM_GPS_DATA     0 // Set GENERATE_RANDOM_GPS_DATA to 1 to generate random GPS telemetry data.
-#define SERIAL_RX_PIN                0 // Set SERIAL_RX_PIN to the pin that the CRSF receiver's TX pin is connected to.
-#define SERIAL_TX_PIN                1 // Set SERIAL_TX_PIN to the pin that the CRSF receiver's RX pin is connected to.
 
 uint32_t timeNow = 0;
 
@@ -69,7 +67,7 @@ const int channelCount = crsfProtocol::RC_CHANNEL_COUNT; // I'm not sure if this
 So, an assert is needed to prevent channelCount from being set to any arbitary number that is higher than 16. */
 static_assert(channelCount <= crsfProtocol::RC_CHANNEL_COUNT, "The number of RC channels must be less than or equal to the maximum number of RC channels supported by CRSF.");
 
-CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
+CRSFforArduino crsf = CRSFforArduino();
 
 #if USE_SERIAL_PLOTTER == 0 && VIEW_RC_CHANNELS > 0
 const char *channelNames[crsfProtocol::RC_CHANNEL_COUNT] = {

--- a/examples/telemetry/telemetry.ino
+++ b/examples/telemetry/telemetry.ino
@@ -67,7 +67,7 @@ const int channelCount = crsfProtocol::RC_CHANNEL_COUNT; // I'm not sure if this
 So, an assert is needed to prevent channelCount from being set to any arbitary number that is higher than 16. */
 static_assert(channelCount <= crsfProtocol::RC_CHANNEL_COUNT, "The number of RC channels must be less than or equal to the maximum number of RC channels supported by CRSF.");
 
-CRSFforArduino crsf = CRSFforArduino();
+CRSFforArduino crsf = CRSFforArduino(&Serial1);
 
 #if USE_SERIAL_PLOTTER == 0 && VIEW_RC_CHANNELS > 0
 const char *channelNames[crsfProtocol::RC_CHANNEL_COUNT] = {

--- a/examples/telemetry/telemetry.ino
+++ b/examples/telemetry/telemetry.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This demonstrates how to use CRSF for Arduino to send telemetry to your RC transmitter using the CRSF protocol.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  * 
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/CFA_Config.hpp
+++ b/src/CRSFforArduino/src/CFA_Config.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the configuration file for CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *
@@ -37,7 +37,7 @@ namespace crsfForArduinoConfig
 Versioning is done using Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION       "1.0.0"
-#define CRSFFORARDUINO_VERSION_DATE  "2024-1-15"
+#define CRSFFORARDUINO_VERSION_DATE  "2024-1-20"
 #define CRSFFORARDUINO_VERSION_MAJOR 0
 #define CRSFFORARDUINO_VERSION_MINOR 5
 #define CRSFFORARDUINO_VERSION_PATCH 0

--- a/src/CRSFforArduino/src/CFA_Config.hpp
+++ b/src/CRSFforArduino/src/CFA_Config.hpp
@@ -38,8 +38,8 @@ Versioning is done using Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION       "1.0.0"
 #define CRSFFORARDUINO_VERSION_DATE  "2024-1-20"
-#define CRSFFORARDUINO_VERSION_MAJOR 0
-#define CRSFFORARDUINO_VERSION_MINOR 5
+#define CRSFFORARDUINO_VERSION_MAJOR 1
+#define CRSFFORARDUINO_VERSION_MINOR 0
 #define CRSFFORARDUINO_VERSION_PATCH 0
 
 /* RC Options

--- a/src/CRSFforArduino/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino/src/CRSFforArduino.cpp
@@ -45,10 +45,10 @@ namespace sketchLayer
      * @param rxPin 
      * @param txPin 
      */
-    CRSFforArduino::CRSFforArduino(uint8_t rxPin, uint8_t txPin)
+    CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort)
     {
 #if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0
-        _serialReceiver = new SerialReceiver(rxPin, txPin);
+        _serialReceiver = new SerialReceiver(serialPort);
 #else
         // Prevent compiler warnings
         (void)rxPin;

--- a/src/CRSFforArduino/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino/src/CRSFforArduino.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino/src/CRSFforArduino.hpp
@@ -40,7 +40,7 @@ namespace sketchLayer
     {
       public:
         CRSFforArduino();
-        CRSFforArduino(uint8_t RxPin, uint8_t TxPin);
+        CRSFforArduino(HardwareSerial *serialPort);
         ~CRSFforArduino();
         bool begin();
         void end();

--- a/src/CRSFforArduino/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino/src/CRSFforArduino.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -4,7 +4,7 @@
  * @brief This is the implementation of the Compatibility Table.
  * It is used to determine if the target development board is compatible with CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the Compatibility Table header file.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -136,13 +136,14 @@ namespace hal
 
     void DevBoards::clearUART()
     {
+        return;
         // If UART port was defined beforehand, delete it.
-        if (uart_port != nullptr)
-        {
-#if not(defined(TEENSYDUINO) || defined(ARDUINO_ARCH_ESP32))
-            uart_port->~Uart();
-#endif
-        }
+        //         if (uart_port != nullptr)
+        //         {
+        // #if not(defined(TEENSYDUINO) || defined(ARDUINO_ARCH_ESP32))
+        //             uart_port->~Uart();
+        // #endif
+        //         }
     }
 
     void DevBoards::begin(unsigned long baudrate, int config)

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -28,32 +28,32 @@
 
 namespace hal
 {
-#if defined(USE_DMA)
-#if defined(ARDUINO_ARCH_SAMD)
-#define DMA_BUFFER_SIZE 64
+    // #if defined(USE_DMA)
+    // #if defined(ARDUINO_ARCH_SAMD)
+    // #define DMA_BUFFER_SIZE 64
 
-    Adafruit_ZeroDMA *dma_memcopy;
-    Adafruit_ZeroDMA *dma_memset;
+    //     Adafruit_ZeroDMA *dma_memcopy;
+    //     Adafruit_ZeroDMA *dma_memset;
 
-    DmacDescriptor *descriptor_memcopy;
-    DmacDescriptor *descriptor_memset;
+    //     DmacDescriptor *descriptor_memcopy;
+    //     DmacDescriptor *descriptor_memset;
 
-    volatile bool dma_memcopy_transfer_complete = false;
-    volatile bool dma_memset_transfer_complete = false;
+    //     volatile bool dma_memcopy_transfer_complete = false;
+    //     volatile bool dma_memset_transfer_complete = false;
 
-    void dma_callback(Adafruit_ZeroDMA *dma)
-    {
-        if (dma == dma_memcopy)
-        {
-            dma_memcopy_transfer_complete = true;
-        }
-        else if (dma == dma_memset)
-        {
-            dma_memset_transfer_complete = true;
-        }
-    }
-#endif
-#endif
+    //     void dma_callback(Adafruit_ZeroDMA *dma)
+    //     {
+    //         if (dma == dma_memcopy)
+    //         {
+    //             dma_memcopy_transfer_complete = true;
+    //         }
+    //         else if (dma == dma_memset)
+    //         {
+    //             dma_memset_transfer_complete = true;
+    //         }
+    //     }
+    // #endif
+    // #endif
 
     DevBoards::DevBoards()
     {
@@ -61,20 +61,20 @@ namespace hal
 
     DevBoards::~DevBoards()
     {
-#ifdef USE_DMA
-#if defined(ARDUINO_ARCH_SAMD)
-        // If DMA memory was initialized, delete it.
-        if (dma_memcopy != nullptr)
-        {
-            delete dma_memcopy;
-        }
+        // #ifdef USE_DMA
+        // #if defined(ARDUINO_ARCH_SAMD)
+        //         // If DMA memory was initialized, delete it.
+        //         if (dma_memcopy != nullptr)
+        //         {
+        //             delete dma_memcopy;
+        //         }
 
-        if (dma_memset != nullptr)
-        {
-            delete dma_memset;
-        }
-#endif
-#endif
+        //         if (dma_memset != nullptr)
+        //         {
+        //             delete dma_memset;
+        //         }
+        // #endif
+        // #endif
     }
 
     void DevBoards::setUART(uint8_t port, uint8_t rx, uint8_t tx)
@@ -227,166 +227,166 @@ namespace hal
         }
     }
 
-#if defined(USE_DMA)
-    void DevBoards::memcpy_dma(void *dest, void *src, size_t size)
-    {
-#if defined(ARDUINO_ARCH_SAMD)
-        // If DMA memory was not initialized, initialize it.
-        if (dma_memcopy == nullptr)
-        {
-            enterCriticalSection();
+    // #if defined(USE_DMA)
+    //     void DevBoards::memcpy_dma(void *dest, void *src, size_t size)
+    //     {
+    // #if defined(ARDUINO_ARCH_SAMD)
+    //         // If DMA memory was not initialized, initialize it.
+    //         if (dma_memcopy == nullptr)
+    //         {
+    //             enterCriticalSection();
 
-            dma_memcopy = new Adafruit_ZeroDMA();
+    //             dma_memcopy = new Adafruit_ZeroDMA();
 
-            // Check if DMA memory was initialized.
-            if (dma_memcopy == nullptr)
-            {
-                exitCriticalSection();
-                return;
-            }
+    //             // Check if DMA memory was initialized.
+    //             if (dma_memcopy == nullptr)
+    //             {
+    //                 exitCriticalSection();
+    //                 return;
+    //             }
 
-            // Allocate DMA channel for memory & check if it was allocated.
-            if (dma_memcopy->allocate() != DMA_STATUS_OK)
-            {
-                delete dma_memcopy;
-                exitCriticalSection();
-                return;
-            }
+    //             // Allocate DMA channel for memory & check if it was allocated.
+    //             if (dma_memcopy->allocate() != DMA_STATUS_OK)
+    //             {
+    //                 delete dma_memcopy;
+    //                 exitCriticalSection();
+    //                 return;
+    //             }
 
-            // Allocate DMA descriptors for memory & check if they were allocated.
-            descriptor_memcopy = dma_memcopy->addDescriptor(
-                NULL, // No source data to start with.
-                NULL, // No destination to start with.
-                0     // No data to start with.
-            );
+    //             // Allocate DMA descriptors for memory & check if they were allocated.
+    //             descriptor_memcopy = dma_memcopy->addDescriptor(
+    //                 NULL, // No source data to start with.
+    //                 NULL, // No destination to start with.
+    //                 0     // No data to start with.
+    //             );
 
-            if (descriptor_memcopy == nullptr)
-            {
-                delete dma_memcopy;
-                exitCriticalSection();
-                return;
-            }
+    //             if (descriptor_memcopy == nullptr)
+    //             {
+    //                 delete dma_memcopy;
+    //                 exitCriticalSection();
+    //                 return;
+    //             }
 
-            // Set the DMA callback function.
-            dma_memcopy->setCallback(dma_callback);
+    //             // Set the DMA callback function.
+    //             dma_memcopy->setCallback(dma_callback);
 
-            // Set the DMA transfer complete flag.
-            dma_memcopy_transfer_complete = true;
+    //             // Set the DMA transfer complete flag.
+    //             dma_memcopy_transfer_complete = true;
 
-            exitCriticalSection();
-        }
+    //             exitCriticalSection();
+    //         }
 
-        // Check if the DMA transfer is complete.
-        if (dma_memcopy_transfer_complete == true)
-        {
-            // Reset the DMA transfer complete flag.
-            dma_memcopy_transfer_complete = false;
+    //         // Check if the DMA transfer is complete.
+    //         if (dma_memcopy_transfer_complete == true)
+    //         {
+    //             // Reset the DMA transfer complete flag.
+    //             dma_memcopy_transfer_complete = false;
 
-            // Change the DMA descriptor.
-            dma_memcopy->changeDescriptor(
-                descriptor_memcopy,
-                src,
-                dest,
-                size);
+    //             // Change the DMA descriptor.
+    //             dma_memcopy->changeDescriptor(
+    //                 descriptor_memcopy,
+    //                 src,
+    //                 dest,
+    //                 size);
 
-            // Start the DMA transfer.
-            if (dma_memcopy->startJob() == DMA_STATUS_OK)
-            {
-                dma_memcopy->trigger();
+    //             // Start the DMA transfer.
+    //             if (dma_memcopy->startJob() == DMA_STATUS_OK)
+    //             {
+    //                 dma_memcopy->trigger();
 
-                // Wait for the DMA transfer to complete.
-                while (dma_memcopy_transfer_complete == false)
-                {
-                    ;
-                }
-            }
-        }
-#else
-        // Default to memcpy if DMA is not supported.
-        memcpy(dest, src, size);
-#endif
-    }
+    //                 // Wait for the DMA transfer to complete.
+    //                 while (dma_memcopy_transfer_complete == false)
+    //                 {
+    //                     ;
+    //                 }
+    //             }
+    //         }
+    // #else
+    //         // Default to memcpy if DMA is not supported.
+    //         memcpy(dest, src, size);
+    // #endif
+    //     }
 
-    void DevBoards::memset_dma(void *dest, int value, size_t size)
-    {
-#if defined(ARDUINO_ARCH_SAMD)
-        // If DMA memory was not initialized, initialize it.
-        if (dma_memset == nullptr)
-        {
-            enterCriticalSection();
+    //     void DevBoards::memset_dma(void *dest, int value, size_t size)
+    //     {
+    // #if defined(ARDUINO_ARCH_SAMD)
+    //         // If DMA memory was not initialized, initialize it.
+    //         if (dma_memset == nullptr)
+    //         {
+    //             enterCriticalSection();
 
-            dma_memset = new Adafruit_ZeroDMA();
+    //             dma_memset = new Adafruit_ZeroDMA();
 
-            // Check if DMA memory was initialized.
-            if (dma_memset == nullptr)
-            {
-                exitCriticalSection();
-                return;
-            }
+    //             // Check if DMA memory was initialized.
+    //             if (dma_memset == nullptr)
+    //             {
+    //                 exitCriticalSection();
+    //                 return;
+    //             }
 
-            // Allocate DMA channel for memory & check if it was allocated.
-            if (dma_memset->allocate() != DMA_STATUS_OK)
-            {
-                delete dma_memset;
-                exitCriticalSection();
-                return;
-            }
+    //             // Allocate DMA channel for memory & check if it was allocated.
+    //             if (dma_memset->allocate() != DMA_STATUS_OK)
+    //             {
+    //                 delete dma_memset;
+    //                 exitCriticalSection();
+    //                 return;
+    //             }
 
-            // Allocate DMA descriptors for memory & check if they were allocated.
-            descriptor_memset = dma_memset->addDescriptor(
-                NULL,               // No source data to start with.
-                NULL,               // No destination to start with.
-                0,                  // No data to start with.
-                DMA_BEAT_SIZE_BYTE, // Transfer 1 byte at a time.
-                false,              // Don't increment the source address.
-                true                // Increment the destination address.
-            );
+    //             // Allocate DMA descriptors for memory & check if they were allocated.
+    //             descriptor_memset = dma_memset->addDescriptor(
+    //                 NULL,               // No source data to start with.
+    //                 NULL,               // No destination to start with.
+    //                 0,                  // No data to start with.
+    //                 DMA_BEAT_SIZE_BYTE, // Transfer 1 byte at a time.
+    //                 false,              // Don't increment the source address.
+    //                 true                // Increment the destination address.
+    //             );
 
-            if (descriptor_memset == nullptr)
-            {
-                delete dma_memset;
-                exitCriticalSection();
-                return;
-            }
+    //             if (descriptor_memset == nullptr)
+    //             {
+    //                 delete dma_memset;
+    //                 exitCriticalSection();
+    //                 return;
+    //             }
 
-            // Set the DMA callback function.
-            dma_memset->setCallback(dma_callback);
+    //             // Set the DMA callback function.
+    //             dma_memset->setCallback(dma_callback);
 
-            // Set the DMA transfer complete flag.
-            dma_memset_transfer_complete = true;
+    //             // Set the DMA transfer complete flag.
+    //             dma_memset_transfer_complete = true;
 
-            exitCriticalSection();
-        }
+    //             exitCriticalSection();
+    //         }
 
-        // Check if the DMA transfer is complete.
-        if (dma_memset_transfer_complete == true)
-        {
-            // Reset the DMA transfer complete flag.
-            dma_memset_transfer_complete = false;
+    //         // Check if the DMA transfer is complete.
+    //         if (dma_memset_transfer_complete == true)
+    //         {
+    //             // Reset the DMA transfer complete flag.
+    //             dma_memset_transfer_complete = false;
 
-            // Change the DMA descriptor.
-            dma_memset->changeDescriptor(
-                descriptor_memset,
-                &value,
-                dest,
-                size);
+    //             // Change the DMA descriptor.
+    //             dma_memset->changeDescriptor(
+    //                 descriptor_memset,
+    //                 &value,
+    //                 dest,
+    //                 size);
 
-            // Start the DMA transfer.
-            if (dma_memset->startJob() == DMA_STATUS_OK)
-            {
-                dma_memset->trigger();
+    //             // Start the DMA transfer.
+    //             if (dma_memset->startJob() == DMA_STATUS_OK)
+    //             {
+    //                 dma_memset->trigger();
 
-                // Wait for the DMA transfer to complete.
-                while (dma_memset_transfer_complete == false)
-                {
-                    ;
-                }
-            }
-        }
-#else
-        // Default to memset if DMA is not supported.
-        memset(dest, value, size);
-#endif
-    }
-#endif
+    //                 // Wait for the DMA transfer to complete.
+    //                 while (dma_memset_transfer_complete == false)
+    //                 {
+    //                     ;
+    //                 }
+    //             }
+    //         }
+    // #else
+    //         // Default to memset if DMA is not supported.
+    //         memset(dest, value, size);
+    // #endif
+    //     }
+    // #endif
 } // namespace hal

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -79,58 +79,59 @@ namespace hal
 
     void DevBoards::setUART(uint8_t port, uint8_t rx, uint8_t tx)
     {
-#if defined(ARDUINO_ARCH_SAMD)
-        // If UART port was defined beforehand, delete it.
-        if (uart_port != nullptr)
-        {
-            uart_port->~Uart();
+        return;
+        // #if defined(ARDUINO_ARCH_SAMD)
+        //         // If UART port was defined beforehand, delete it.
+        //         if (uart_port != nullptr)
+        //         {
+        //             uart_port->~Uart();
 
-            // Debug.
-            // Serial.println("[Development Board | DEBUG]: Deleted previous UART port.");
-        }
+        //             // Debug.
+        //             // Serial.println("[Development Board | DEBUG]: Deleted previous UART port.");
+        //         }
 
-        // Set the UART port.
-        switch (port)
-        {
-            case 0:
-                uart_port = &Serial1;
+        //         // Set the UART port.
+        //         switch (port)
+        //         {
+        //             case 0:
+        //                 uart_port = &Serial1;
 
-                // Debug.
-                // Serial.println("[Development Board | DEBUG]: Using Serial1.");
-                break;
+        //                 // Debug.
+        //                 // Serial.println("[Development Board | DEBUG]: Using Serial1.");
+        //                 break;
 
-            case 1: // TO-DO: Fix this.
-                uart_port = new Uart(&sercom2, rx, tx, SERCOM_RX_PAD_1, UART_TX_PAD_0);
+        //             case 1: // TO-DO: Fix this.
+        //                 uart_port = new Uart(&sercom2, rx, tx, SERCOM_RX_PAD_1, UART_TX_PAD_0);
 
-                // Debug.
-                // Serial.println("[Development Board | DEBUG]: Using Serial2.");
-                break;
+        //                 // Debug.
+        //                 // Serial.println("[Development Board | DEBUG]: Using Serial2.");
+        //                 break;
 
-            default:
-                uart_port = nullptr;
+        //             default:
+        //                 uart_port = nullptr;
 
-                // Debug.
-                // Serial.println("[Development Board | ERROR]: No UART port was defined.");
-                break;
-        }
-#elif defined(TEENSYDUINO)
-        // Default to Serial1 if Teensyduino is being used. May expand this in the future, if requested.
-        uart_port = &Serial1;
+        //                 // Debug.
+        //                 // Serial.println("[Development Board | ERROR]: No UART port was defined.");
+        //                 break;
+        //         }
+        // #elif defined(TEENSYDUINO)
+        //         // Default to Serial1 if Teensyduino is being used. May expand this in the future, if requested.
+        //         uart_port = &Serial1;
 
-        // Debug.
-        // Serial.println("[Development Board | DEBUG]: Using Serial1.");
-#elif defined(ARDUINO_ARCH_ESP32)
-        // Default to Serial1 if ESP32 is being used. May expand this in the future, if requested.
-        uart_port = &Serial1;
+        //         // Debug.
+        //         // Serial.println("[Development Board | DEBUG]: Using Serial1.");
+        // #elif defined(ARDUINO_ARCH_ESP32)
+        //         // Default to Serial1 if ESP32 is being used. May expand this in the future, if requested.
+        //         uart_port = &Serial1;
 
-        // Debug.
-        // Serial.println("[Development Board | DEBUG]: Using Serial1.");
-#else
-        uart_port = nullptr;
+        //         // Debug.
+        //         // Serial.println("[Development Board | DEBUG]: Using Serial1.");
+        // #else
+        //         uart_port = nullptr;
 
-        // Debug.
-        // Serial.println("[Development Board | ERROR]: No UART port was defined.");
-#endif
+        //         // Debug.
+        //         // Serial.println("[Development Board | ERROR]: No UART port was defined.");
+        // #endif
     }
 
     void DevBoards::clearUART()

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the DevBoards implementation file. It is used to configure CRSF for Arduino for specific development boards.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains the DevBoards class, which is used to configure CRSF for Arduino for specific development boards.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp
+++ b/src/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp
@@ -27,12 +27,12 @@
 #pragma once
 
 #include "Arduino.h"
-#ifdef USE_DMA
-#warning "DMA is enabled. This is an experimental feature and may not work as expected."
-#if defined(ARDUINO_ARCH_SAMD)
-#include "Adafruit_ZeroDMA.h"
-#endif
-#endif
+// #ifdef USE_DMA
+// #warning "DMA is enabled. This is an experimental feature and may not work as expected."
+// #if defined(ARDUINO_ARCH_SAMD)
+// #include "Adafruit_ZeroDMA.h"
+// #endif
+// #endif
 
 namespace hal
 {
@@ -61,11 +61,11 @@ namespace hal
         void enterCriticalSection();
         void exitCriticalSection();
 
-#ifdef USE_DMA
-        // DMA functions.
-        void memcpy_dma(void *dest, void *src, size_t size);
-        void memset_dma(void *dest, int value, size_t size);
-#endif
+        // #ifdef USE_DMA
+        //         // DMA functions.
+        //         void memcpy_dma(void *dest, void *src, size_t size);
+        //         void memset_dma(void *dest, int value, size_t size);
+        // #endif
 
       private:
         uint16_t critical_section_counter = 0;

--- a/src/CRSFforArduino/src/Hardware/Hardware.hpp
+++ b/src/CRSFforArduino/src/Hardware/Hardware.hpp
@@ -32,7 +32,7 @@
 #include "../CFA_Config.hpp"
 #endif
 #include "CompatibilityTable/CompatibilityTable.hpp"
-#include "hw_uart/hw_uart.hpp"
+// #include "hw_uart/hw_uart.hpp"
 
 using namespace crsfForArduinoConfig;
 using namespace hal;

--- a/src/CRSFforArduino/src/Hardware/Hardware.hpp
+++ b/src/CRSFforArduino/src/Hardware/Hardware.hpp
@@ -32,7 +32,7 @@
 #include "../CFA_Config.hpp"
 #endif
 #include "CompatibilityTable/CompatibilityTable.hpp"
-#include "DevBoards/DevBoards.hpp"
+#include "hw_uart/hw_uart.hpp"
 
 using namespace crsfForArduinoConfig;
 using namespace hal;

--- a/src/CRSFforArduino/src/Hardware/Hardware.hpp
+++ b/src/CRSFforArduino/src/Hardware/Hardware.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file is the top level of the hardware abstraction layer.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.cpp
+++ b/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.cpp
@@ -1,7 +1,7 @@
 /**
- * @file DevBoards.cpp
+ * @file hw_uart.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
- * @brief This is the DevBoards implementation file. It is used to configure CRSF for Arduino for specific development boards.
+ * @brief This is the hw_uart implementation file. It is used to configure CRSF for Arduino for specific development boards.
  * @version 1.0.0
  * @date 2024-1-20
  *
@@ -24,7 +24,7 @@
  * 
  */
 
-#include "DevBoards.hpp"
+#include "hw_uart.hpp"
 
 namespace hal
 {
@@ -55,11 +55,11 @@ namespace hal
     // #endif
     // #endif
 
-    DevBoards::DevBoards()
+    hw_uart::hw_uart()
     {
     }
 
-    DevBoards::~DevBoards()
+    hw_uart::~hw_uart()
     {
         // #ifdef USE_DMA
         // #if defined(ARDUINO_ARCH_SAMD)
@@ -77,7 +77,7 @@ namespace hal
         // #endif
     }
 
-    void DevBoards::setUART(uint8_t port, uint8_t rx, uint8_t tx)
+    void hw_uart::setUART(uint8_t port, uint8_t rx, uint8_t tx)
     {
         return;
         // #if defined(ARDUINO_ARCH_SAMD)
@@ -134,7 +134,7 @@ namespace hal
         // #endif
     }
 
-    void DevBoards::clearUART()
+    void hw_uart::clearUART()
     {
         return;
         // If UART port was defined beforehand, delete it.
@@ -146,61 +146,61 @@ namespace hal
         //         }
     }
 
-    void DevBoards::begin(unsigned long baudrate, int config)
+    void hw_uart::begin(unsigned long baudrate, int config)
     {
         // Begin the UART port.
         uart_port->begin(baudrate, config);
     }
 
-    void DevBoards::end()
+    void hw_uart::end()
     {
         // End the UART port.
         uart_port->end();
     }
 
-    int DevBoards::available(void)
+    int hw_uart::available(void)
     {
         // Return the number of bytes available in the UART port.
         return uart_port->available();
     }
 
-    int DevBoards::peek(void)
+    int hw_uart::peek(void)
     {
         // Return the next byte in the UART port without removing it from the buffer.
         return uart_port->peek();
     }
 
-    int DevBoards::read(void)
+    int hw_uart::read(void)
     {
         // Return the next byte in the UART port and remove it from the buffer.
         return uart_port->read();
     }
 
-    void DevBoards::flush(void)
+    void hw_uart::flush(void)
     {
         // Flush the UART port.
         uart_port->flush();
     }
 
-    size_t DevBoards::write(uint8_t c)
+    size_t hw_uart::write(uint8_t c)
     {
         // Write a byte to the UART port.
         return uart_port->write(c);
     }
 
-    size_t DevBoards::write(const uint8_t *buffer, size_t size)
+    size_t hw_uart::write(const uint8_t *buffer, size_t size)
     {
         // Write a buffer to the UART port.
         return uart_port->write(buffer, size);
     }
 
-    DevBoards::operator bool()
+    hw_uart::operator bool()
     {
         // Return if the UART port is available.
         return uart_port->operator bool();
     }
 
-    void DevBoards::enterCriticalSection()
+    void hw_uart::enterCriticalSection()
     {
         // Enter a critical section.
 #if defined(ARDUINO_ARCH_SAMD)
@@ -213,7 +213,7 @@ namespace hal
         critical_section_counter++;
     }
 
-    void DevBoards::exitCriticalSection()
+    void hw_uart::exitCriticalSection()
     {
         // Decrement the critical section counter.
         critical_section_counter--;
@@ -230,7 +230,7 @@ namespace hal
     }
 
     // #if defined(USE_DMA)
-    //     void DevBoards::memcpy_dma(void *dest, void *src, size_t size)
+    //     void hw_uart::memcpy_dma(void *dest, void *src, size_t size)
     //     {
     // #if defined(ARDUINO_ARCH_SAMD)
     //         // If DMA memory was not initialized, initialize it.
@@ -309,7 +309,7 @@ namespace hal
     // #endif
     //     }
 
-    //     void DevBoards::memset_dma(void *dest, int value, size_t size)
+    //     void hw_uart::memset_dma(void *dest, int value, size_t size)
     //     {
     // #if defined(ARDUINO_ARCH_SAMD)
     //         // If DMA memory was not initialized, initialize it.

--- a/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.cpp
+++ b/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.cpp
@@ -57,10 +57,26 @@ namespace hal
 
     hw_uart::hw_uart()
     {
+        uart_port = &Serial1;
+    }
+
+    hw_uart::hw_uart(uint8_t port, uint8_t rx, uint8_t tx)
+    {
+        switch (port)
+        {
+        default:
+            uart_port = nullptr;
+            break;
+
+        case 1:
+            uart_port = &Serial1;
+            break;
+        }
     }
 
     hw_uart::~hw_uart()
     {
+        uart_port = nullptr;
         // #ifdef USE_DMA
         // #if defined(ARDUINO_ARCH_SAMD)
         //         // If DMA memory was initialized, delete it.

--- a/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.cpp
+++ b/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.cpp
@@ -57,26 +57,20 @@ namespace hal
 
     hw_uart::hw_uart()
     {
-        uart_port = &Serial1;
+        _uart_port = nullptr;
     }
 
-    hw_uart::hw_uart(uint8_t port, uint8_t rx, uint8_t tx)
+    hw_uart::hw_uart(HardwareSerial *uart_port)
     {
-        switch (port)
+        if (uart_port != nullptr)
         {
-        default:
-            uart_port = nullptr;
-            break;
-
-        case 1:
-            uart_port = &Serial1;
-            break;
+            _uart_port = uart_port;
         }
     }
 
     hw_uart::~hw_uart()
     {
-        uart_port = nullptr;
+        _uart_port = nullptr;
         // #ifdef USE_DMA
         // #if defined(ARDUINO_ARCH_SAMD)
         //         // If DMA memory was initialized, delete it.
@@ -98,9 +92,9 @@ namespace hal
         return;
         // #if defined(ARDUINO_ARCH_SAMD)
         //         // If UART port was defined beforehand, delete it.
-        //         if (uart_port != nullptr)
+        //         if (_uart_port != nullptr)
         //         {
-        //             uart_port->~Uart();
+        //             _uart_port->~Uart();
 
         //             // Debug.
         //             // Serial.println("[Development Board | DEBUG]: Deleted previous UART port.");
@@ -110,21 +104,21 @@ namespace hal
         //         switch (port)
         //         {
         //             case 0:
-        //                 uart_port = &Serial1;
+        //                 _uart_port = &Serial1;
 
         //                 // Debug.
         //                 // Serial.println("[Development Board | DEBUG]: Using Serial1.");
         //                 break;
 
         //             case 1: // TO-DO: Fix this.
-        //                 uart_port = new Uart(&sercom2, rx, tx, SERCOM_RX_PAD_1, UART_TX_PAD_0);
+        //                 _uart_port = new Uart(&sercom2, rx, tx, SERCOM_RX_PAD_1, UART_TX_PAD_0);
 
         //                 // Debug.
         //                 // Serial.println("[Development Board | DEBUG]: Using Serial2.");
         //                 break;
 
         //             default:
-        //                 uart_port = nullptr;
+        //                 _uart_port = nullptr;
 
         //                 // Debug.
         //                 // Serial.println("[Development Board | ERROR]: No UART port was defined.");
@@ -132,18 +126,18 @@ namespace hal
         //         }
         // #elif defined(TEENSYDUINO)
         //         // Default to Serial1 if Teensyduino is being used. May expand this in the future, if requested.
-        //         uart_port = &Serial1;
+        //         _uart_port = &Serial1;
 
         //         // Debug.
         //         // Serial.println("[Development Board | DEBUG]: Using Serial1.");
         // #elif defined(ARDUINO_ARCH_ESP32)
         //         // Default to Serial1 if ESP32 is being used. May expand this in the future, if requested.
-        //         uart_port = &Serial1;
+        //         _uart_port = &Serial1;
 
         //         // Debug.
         //         // Serial.println("[Development Board | DEBUG]: Using Serial1.");
         // #else
-        //         uart_port = nullptr;
+        //         _uart_port = nullptr;
 
         //         // Debug.
         //         // Serial.println("[Development Board | ERROR]: No UART port was defined.");
@@ -154,10 +148,10 @@ namespace hal
     {
         return;
         // If UART port was defined beforehand, delete it.
-        //         if (uart_port != nullptr)
+        //         if (_uart_port != nullptr)
         //         {
         // #if not(defined(TEENSYDUINO) || defined(ARDUINO_ARCH_ESP32))
-        //             uart_port->~Uart();
+        //             _uart_port->~Uart();
         // #endif
         //         }
     }
@@ -165,55 +159,55 @@ namespace hal
     void hw_uart::begin(unsigned long baudrate, int config)
     {
         // Begin the UART port.
-        uart_port->begin(baudrate, config);
+        _uart_port->begin(baudrate, config);
     }
 
     void hw_uart::end()
     {
         // End the UART port.
-        uart_port->end();
+        _uart_port->end();
     }
 
     int hw_uart::available(void)
     {
         // Return the number of bytes available in the UART port.
-        return uart_port->available();
+        return _uart_port->available();
     }
 
     int hw_uart::peek(void)
     {
         // Return the next byte in the UART port without removing it from the buffer.
-        return uart_port->peek();
+        return _uart_port->peek();
     }
 
     int hw_uart::read(void)
     {
         // Return the next byte in the UART port and remove it from the buffer.
-        return uart_port->read();
+        return _uart_port->read();
     }
 
     void hw_uart::flush(void)
     {
         // Flush the UART port.
-        uart_port->flush();
+        _uart_port->flush();
     }
 
     size_t hw_uart::write(uint8_t c)
     {
         // Write a byte to the UART port.
-        return uart_port->write(c);
+        return _uart_port->write(c);
     }
 
     size_t hw_uart::write(const uint8_t *buffer, size_t size)
     {
         // Write a buffer to the UART port.
-        return uart_port->write(buffer, size);
+        return _uart_port->write(buffer, size);
     }
 
     hw_uart::operator bool()
     {
         // Return if the UART port is available.
-        return uart_port->operator bool();
+        return _uart_port->operator bool();
     }
 
     void hw_uart::enterCriticalSection()

--- a/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.hpp
+++ b/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.hpp
@@ -40,6 +40,7 @@ namespace hal
     {
       public:
         hw_uart();
+        hw_uart(uint8_t port, uint8_t rx, uint8_t tx);
         virtual ~hw_uart();
 
         void setUART(uint8_t port, uint8_t rx, uint8_t tx);
@@ -70,10 +71,6 @@ namespace hal
       private:
         uint16_t critical_section_counter = 0;
 
-#if defined(ARDUINO_ARCH_SAMD)
-        Uart *uart_port;
-#else
         HardwareSerial *uart_port;
-#endif
     };
 } // namespace hal

--- a/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.hpp
+++ b/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.hpp
@@ -1,7 +1,7 @@
 /**
- * @file DevBoards.hpp
+ * @file hw_uart.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
- * @brief This file contains the DevBoards class, which is used to configure CRSF for Arduino for specific development boards.
+ * @brief This file contains the hw_uart class, which is used to configure CRSF for Arduino for specific development boards.
  * @version 1.0.0
  * @date 2024-1-20
  *
@@ -36,11 +36,11 @@
 
 namespace hal
 {
-    class DevBoards : private Stream
+    class hw_uart : private Stream
     {
       public:
-        DevBoards();
-        virtual ~DevBoards();
+        hw_uart();
+        virtual ~hw_uart();
 
         void setUART(uint8_t port, uint8_t rx, uint8_t tx);
         void clearUART();

--- a/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.hpp
+++ b/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.hpp
@@ -40,7 +40,7 @@ namespace hal
     {
       public:
         hw_uart();
-        hw_uart(uint8_t port, uint8_t rx, uint8_t tx);
+        hw_uart(HardwareSerial *uart_port);
         virtual ~hw_uart();
 
         void setUART(uint8_t port, uint8_t rx, uint8_t tx);
@@ -71,6 +71,6 @@ namespace hal
       private:
         uint16_t critical_section_counter = 0;
 
-        HardwareSerial *uart_port;
+        HardwareSerial *_uart_port;
     };
 } // namespace hal

--- a/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class implementation.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class declaration.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
@@ -46,24 +46,24 @@ namespace serialReceiver
         frameCount = 0;
         timePerFrame = 0;
 
-#ifdef USE_DMA
-        memset_dma(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-        memset_dma(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-#else
+        // #ifdef USE_DMA
+        //         memset_dma(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
+        //         memset_dma(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
+        // #else
         memset(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
         memset(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-#endif
+        // #endif
     }
 
     void CRSF::end()
     {
-#ifdef USE_DMA
-        memset_dma(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-        memset_dma(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-#else
+        // #ifdef USE_DMA
+        //         memset_dma(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
+        //         memset_dma(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
+        // #else
         memset(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
         memset(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-#endif
+        // #endif
 
         timePerFrame = 0;
         frameCount = 0;
@@ -118,25 +118,25 @@ namespace serialReceiver
                         case crsfProtocol::CRSF_FRAMETYPE_RC_CHANNELS_PACKED:
                             if (rxFrame.frame.deviceAddress == CRSF_ADDRESS_FLIGHT_CONTROLLER)
                             {
-#ifdef USE_DMA
-#ifdef __SAMD51__
-                                memcpy(&rcChannelsFrame, &rxFrame, CRSF_FRAME_SIZE_MAX); // ◄ This is a workaround for the crash on SAMD51.
-#else
-                                memcpy_dma(&rcChannelsFrame, &rxFrame, CRSF_FRAME_SIZE_MAX); // ◄ This is the line that causes the crash on SAMD51.
-#endif
-#else
+                                // #ifdef USE_DMA
+                                // #ifdef __SAMD51__
+                                //                                 memcpy(&rcChannelsFrame, &rxFrame, CRSF_FRAME_SIZE_MAX); // ◄ This is a workaround for the crash on SAMD51.
+                                // #else
+                                //                                 memcpy_dma(&rcChannelsFrame, &rxFrame, CRSF_FRAME_SIZE_MAX); // ◄ This is the line that causes the crash on SAMD51.
+                                // #endif
+                                // #else
                                 memcpy(&rcChannelsFrame, &rxFrame, CRSF_FRAME_SIZE_MAX);
-#endif
+                                // #endif
                                 rcFrameReceived = true;
                             }
                             break;
                     }
                 }
-#ifdef USE_DMA
-                memset_dma(&rxFrame, 0, CRSF_FRAME_SIZE_MAX); // ◄ This line works fine on both SAMD21 and SAMD51.
-#else
+                // #ifdef USE_DMA
+                //                 memset_dma(&rxFrame, 0, CRSF_FRAME_SIZE_MAX); // ◄ This line works fine on both SAMD21 and SAMD51.
+                // #else
                 memset(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-#endif
+                // #endif
                 framePosition = 0;
 
                 return true;

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class implementation.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
@@ -29,14 +29,14 @@
 #include "Arduino.h"
 #include "CRSFProtocol.hpp"
 #if defined(ARDUINO) && defined(PLATFORMIO)
-#ifdef USE_DMA
-#include "Hardware/DevBoards/DevBoards.hpp"
-#endif
+// #ifdef USE_DMA
+// #include "Hardware/DevBoards/DevBoards.hpp"
+// #endif
 #include "SerialReceiver/CRC/CRC.hpp"
 #elif defined(ARDUINO) && !defined(PLATFORMIO)
-#ifdef USE_DMA
-#include "lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp"
-#endif
+// #ifdef USE_DMA
+// #include "lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp"
+// #endif
 #include "../CRC/CRC.hpp"
 #endif
 // #include "Hardware.h"
@@ -44,9 +44,9 @@
 namespace serialReceiver
 {
     class CRSF
-#ifdef USE_DMA
-        : private hal::DevBoards
-#endif
+    // #ifdef USE_DMA
+    //         : private hal::DevBoards
+    // #endif
     {
       public:
         CRSF();

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class definition.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -50,11 +50,11 @@ namespace genericStreamBuffer
     {
         bufferIndex = 0;
         bufferLength = 0;
-#ifdef USE_DMA
-        memset_dma(buffer, 0, bufferSizeMax);
-#else
+        // #ifdef USE_DMA
+        //         memset_dma(buffer, 0, bufferSizeMax);
+        // #else
         memset(buffer, 0, bufferSizeMax);
-#endif
+        // #endif
     }
 
     // Write signed integers in little endian

--- a/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class implementation.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class definition.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -28,20 +28,20 @@
 
 #include "Arduino.h"
 
-#ifdef USE_DMA
-#if defined(ARDUINO) && defined(PLATFORMIO)
-#include "Hardware/DevBoards/DevBoards.hpp"
-#elif defined(ARDUINO) && !defined(PLATFORMIO)
-#include "lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp"
-#endif
-#endif
+// #ifdef USE_DMA
+// #if defined(ARDUINO) && defined(PLATFORMIO)
+// #include "Hardware/DevBoards/DevBoards.hpp"
+// #elif defined(ARDUINO) && !defined(PLATFORMIO)
+// #include "lib/CRSFforArduino/src/Hardware/DevBoards/DevBoards.hpp"
+// #endif
+// #endif
 
 namespace genericStreamBuffer
 {
     class SerialBuffer
-#ifdef USE_DMA
-        : public hal::DevBoards
-#endif
+    // #ifdef USE_DMA
+    //         : public hal::DevBoards
+    // #endif
     {
       public:
         SerialBuffer(size_t size);

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -43,9 +43,9 @@ namespace serialReceiver
 #endif
     }
 
-    SerialReceiver::SerialReceiver(uint8_t rxPin, uint8_t txPin)
+    SerialReceiver::SerialReceiver(HardwareSerial *hwUartPort)
     {
-        _uart = new hw_uart(1, rxPin, txPin);
+        _uart = new hw_uart(hwUartPort);
         ct = new CompatibilityTable();
 
 #if CRSF_RC_ENABLED > 0

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -32,8 +32,6 @@ namespace serialReceiver
 {
     SerialReceiver::SerialReceiver()
     {
-        _rxPin = 0;
-        _txPin = 1;
         _uart = new hw_uart();
         ct = new CompatibilityTable();
 
@@ -47,9 +45,7 @@ namespace serialReceiver
 
     SerialReceiver::SerialReceiver(uint8_t rxPin, uint8_t txPin)
     {
-        _rxPin = rxPin;
-        _txPin = txPin;
-        _uart = new hw_uart();
+        _uart = new hw_uart(1, rxPin, txPin);
         ct = new CompatibilityTable();
 
 #if CRSF_RC_ENABLED > 0
@@ -62,8 +58,6 @@ namespace serialReceiver
 
     SerialReceiver::~SerialReceiver()
     {
-        _rxPin = 0xffu;
-        _txPin = 0xffu;
         delete _uart;
         delete ct;
 
@@ -127,17 +121,6 @@ namespace serialReceiver
         // Check if the _uart is compatible.
         if (ct->isDevboardCompatible(ct->getDevboardName()))
         {
-            if (_rxPin == 0xffu && _txPin == 0xffu)
-            {
-                // _uart->exitCriticalSection();
-
-#if CRSF_DEBUG_ENABLED > 0
-                // Debug.
-                CRSF_DEBUG_SERIAL_PORT.println("\n[Serial Receiver | ERROR]: RX and TX pins are not set.");
-#endif
-                return false;
-            }
-
             _uart->enterCriticalSection();
 
             // Initialize the CRSF Protocol.
@@ -157,7 +140,6 @@ namespace serialReceiver
 
             crsf->begin();
             crsf->setFrameTime(BAUD_RATE, 10);
-            _uart->setUART(0, _rxPin, _txPin);
             _uart->begin(BAUD_RATE);
 
 #if CRSF_TELEMETRY_ENABLED > 0

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the implementation file for the Serial Receiver Interface.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -32,7 +32,7 @@ namespace serialReceiver
 {
     SerialReceiver::SerialReceiver()
     {
-        _uart = new hw_uart();
+        _uart = &Serial1;
         ct = new CompatibilityTable();
 
 #if CRSF_RC_ENABLED > 0
@@ -45,7 +45,7 @@ namespace serialReceiver
 
     SerialReceiver::SerialReceiver(HardwareSerial *hwUartPort)
     {
-        _uart = new hw_uart(hwUartPort);
+        _uart = hwUartPort;
         ct = new CompatibilityTable();
 
 #if CRSF_RC_ENABLED > 0
@@ -58,7 +58,7 @@ namespace serialReceiver
 
     SerialReceiver::~SerialReceiver()
     {
-        delete _uart;
+        _uart = nullptr;
         delete ct;
 
 #if CRSF_RC_ENABLED > 0
@@ -121,7 +121,7 @@ namespace serialReceiver
         // Check if the _uart is compatible.
         if (ct->isDevboardCompatible(ct->getDevboardName()))
         {
-            _uart->enterCriticalSection();
+            // _uart->enterCriticalSection();
 
             // Initialize the CRSF Protocol.
             crsf = new CRSF();
@@ -129,7 +129,7 @@ namespace serialReceiver
             // Check that the CRSF Protocol was initialized successfully.
             if (crsf == nullptr)
             {
-                _uart->exitCriticalSection();
+                // _uart->exitCriticalSection();
 
 #if CRSF_DEBUG_ENABLED > 0
                 // Debug.
@@ -149,7 +149,7 @@ namespace serialReceiver
             // Check that the telemetry was initialised successfully.
             if (telemetry == nullptr)
             {
-                _uart->exitCriticalSection();
+                // _uart->exitCriticalSection();
 
 #if CRSF_DEBUG_ENABLED > 0
                 // Debug.
@@ -161,7 +161,7 @@ namespace serialReceiver
             telemetry->begin();
 #endif
 
-            _uart->exitCriticalSection();
+            // _uart->exitCriticalSection();
 
             // Clear the UART buffer.
             _uart->flush();
@@ -197,9 +197,9 @@ namespace serialReceiver
             _uart->read();
         }
 
-        _uart->enterCriticalSection();
+        // _uart->enterCriticalSection();
         _uart->end();
-        _uart->clearUART();
+        // _uart->clearUART();
 
         // Check if the CRSF Protocol was initialized.
         if (crsf != nullptr)
@@ -216,7 +216,7 @@ namespace serialReceiver
             delete telemetry;
         }
 #endif
-        _uart->exitCriticalSection();
+        // _uart->exitCriticalSection();
     }
 
 #if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
@@ -98,9 +98,6 @@ namespace serialReceiver
         Telemetry *telemetry;
 #endif
 
-        uint8_t _rxPin = 0xffu;
-        uint8_t _txPin = 0xffu;
-
 #if CRSF_RC_ENABLED > 0
         uint16_t *_rcChannels;
 #endif

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
@@ -58,7 +58,7 @@ namespace serialReceiver
     {
       public:
         SerialReceiver();
-        SerialReceiver(uint8_t rxPin, uint8_t txPin);
+        SerialReceiver(HardwareSerial *hwUartPort);
         virtual ~SerialReceiver();
 
         bool begin();

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
@@ -54,7 +54,7 @@ namespace serialReceiver
     // Function pointer for Flight Mode Callback
     typedef void (*flightModeCallback_t)(flightModeId_t);
 
-    class SerialReceiver : /* private CRSF, */ private CompatibilityTable, private DevBoards
+    class SerialReceiver : /* private CRSF, */ private CompatibilityTable, private hw_uart
     {
       public:
         SerialReceiver();
@@ -92,7 +92,7 @@ namespace serialReceiver
       private:
         CRSF *crsf;
         CompatibilityTable *ct;
-        DevBoards *board;
+        hw_uart *_uart;
 
 #if CRSF_TELEMETRY_ENABLED > 0
         Telemetry *telemetry;

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the header file for the Serial Receiver Interface.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
@@ -54,7 +54,7 @@ namespace serialReceiver
     // Function pointer for Flight Mode Callback
     typedef void (*flightModeCallback_t)(flightModeId_t);
 
-    class SerialReceiver : /* private CRSF, */ private CompatibilityTable, private hw_uart
+    class SerialReceiver : /* private CRSF, */ private CompatibilityTable/* , private hw_uart */
     {
       public:
         SerialReceiver();
@@ -92,7 +92,8 @@ namespace serialReceiver
       private:
         CRSF *crsf;
         CompatibilityTable *ct;
-        hw_uart *_uart;
+        HardwareSerial *_uart;
+        // hw_uart *_uart;
 
 #if CRSF_TELEMETRY_ENABLED > 0
         Telemetry *telemetry;

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
@@ -54,7 +54,7 @@ namespace serialReceiver
     // Function pointer for Flight Mode Callback
     typedef void (*flightModeCallback_t)(flightModeId_t);
 
-    class SerialReceiver : /* private CRSF, */ private CompatibilityTable/* , private hw_uart */
+    class SerialReceiver : /* private CRSF, */ private CompatibilityTable /* , private hw_uart */
     {
       public:
         SerialReceiver();

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -223,7 +223,7 @@ namespace serialReceiver
 #endif
     }
 
-    void Telemetry::sendTelemetryData(hw_uart *db)
+    void Telemetry::sendTelemetryData(HardwareSerial *db)
     {
         uint8_t *buffer = SerialBuffer::getBuffer();
         size_t length = SerialBuffer::getLength();

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -223,7 +223,7 @@ namespace serialReceiver
 #endif
     }
 
-    void Telemetry::sendTelemetryData(DevBoards *db)
+    void Telemetry::sendTelemetryData(hw_uart *db)
     {
         uint8_t *buffer = SerialBuffer::getBuffer();
         size_t length = SerialBuffer::getLength();

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class implementation.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class definition.
  * @version 1.0.0
- * @date 2024-1-15
+ * @date 2024-1-20
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -29,12 +29,12 @@
 #include "Arduino.h"
 
 #if defined(ARDUINO) && defined(PLATFORMIO)
-#include "Hardware/hw_uart/hw_uart.hpp"
+// #include "Hardware/hw_uart/hw_uart.hpp"
 #include "SerialReceiver/CRC/CRC.hpp"
 #include "SerialReceiver/CRSF/CRSFProtocol.hpp"
 #include "SerialReceiver/SerialBuffer/SerialBuffer.hpp"
 #elif defined(ARDUINO) && !defined(PLATFORMIO)
-#include "../../Hardware/hw_uart/hw_uart.hpp"
+// #include "../../Hardware/hw_uart/hw_uart.hpp"
 #include "../CRC/CRC.hpp"
 #include "../CRSF/CRSFProtocol.hpp"
 #include "../SerialBuffer/SerialBuffer.hpp"
@@ -44,8 +44,8 @@ namespace serialReceiver
 {
     class Telemetry : private CRC, private genericStreamBuffer::SerialBuffer
 // #ifndef USE_DMA
-        ,
-                      private hal::hw_uart
+        /*`,
+                      private hal::hw_uart */
 // #endif
     {
       public:
@@ -64,7 +64,7 @@ namespace serialReceiver
         void setGPSData(float latitude, float longitude, float altitude, float speed, float course, uint8_t satellites);
         // void setVarioData(float vario);
 
-        void sendTelemetryData(hw_uart *db);
+        void sendTelemetryData(HardwareSerial *db);
 
       private:
         uint8_t _telemetryFrameScheduleCount;

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -29,12 +29,12 @@
 #include "Arduino.h"
 
 #if defined(ARDUINO) && defined(PLATFORMIO)
-#include "Hardware/DevBoards/DevBoards.hpp"
+#include "Hardware/hw_uart/hw_uart.hpp"
 #include "SerialReceiver/CRC/CRC.hpp"
 #include "SerialReceiver/CRSF/CRSFProtocol.hpp"
 #include "SerialReceiver/SerialBuffer/SerialBuffer.hpp"
 #elif defined(ARDUINO) && !defined(PLATFORMIO)
-#include "../../Hardware/DevBoards/DevBoards.hpp"
+#include "../../Hardware/hw_uart/hw_uart.hpp"
 #include "../CRC/CRC.hpp"
 #include "../CRSF/CRSFProtocol.hpp"
 #include "../SerialBuffer/SerialBuffer.hpp"
@@ -43,10 +43,10 @@
 namespace serialReceiver
 {
     class Telemetry : private CRC, private genericStreamBuffer::SerialBuffer
-#ifndef USE_DMA
+// #ifndef USE_DMA
         ,
-                      private hal::DevBoards
-#endif
+                      private hal::hw_uart
+// #endif
     {
       public:
         Telemetry();
@@ -64,7 +64,7 @@ namespace serialReceiver
         void setGPSData(float latitude, float longitude, float altitude, float speed, float course, uint8_t satellites);
         // void setVarioData(float vario);
 
-        void sendTelemetryData(DevBoards *db);
+        void sendTelemetryData(hw_uart *db);
 
       private:
         uint8_t _telemetryFrameScheduleCount;

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -43,10 +43,10 @@
 namespace serialReceiver
 {
     class Telemetry : private CRC, private genericStreamBuffer::SerialBuffer
-// #ifndef USE_DMA
-        /*`,
+    // #ifndef USE_DMA
+    /*`,
                       private hal::hw_uart */
-// #endif
+    // #endif
     {
       public:
         Telemetry();


### PR DESCRIPTION
## Overview

This Pull Request deprecates the original `DevBoards` Hardware Abstraction Layer class and is replaced by Arduino's `HardwareSerial` class

## Details

After a couple of failed attempts at trying to implement a system where you could pick your UART pins vicariously through simply picking which port you wanted, I have decided to bring the `HardwareSerial` class up to the Sketch Layer.  
Here, this gives you more freedom to feed in your own hardware-specific UART port that you want CRSF for Arduino to use.

## API Change

This introduces a change to CRSF for Arduino's API - Specifically to do with the constructor.  
Instead of passing in the pins your receiver is connected to, you are passing in your chosen `HardwareSerial` class.

### The old way

You would create an instance of CRSF for Arduino in the following ways:

```cpp
/* As a fixed global instance - This is how Arduino shows most makers.*/
#include <CRSFforArduino.hpp>

#define SERIAL_RX_PIN 0
#define SERIAL_TX_PIN 1

/* This is how we used to do it. */
CRSFforArduino crsf = CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
```

```cpp
/* Allocated in dynamic memory (for the C++ Aficionados among us) */
#include <CRSFforArduino.hpp>
#include <new>
using namespace std;

#define SERIAL_RX_PIN 0
#define SERIAL_TX_PIN 1

CRSFforArduino *crsf = nullptr;

void setup()
{
    /* This is how we used to do it. */
    crsf = new CRSFforArduino(SERIAL_RX_PIN, SERIAL_TX_PIN);
}
```

### The new way

Now, you create an instance of CRSF for Arduino in the following ways:

```cpp
/* As a fixed global instance - This is how Arduino shows most makers.*/
#include <CRSFforArduino.hpp>


/* With your board's default UART port - Serial1: */
CRSFforArduino crsf = CRSFforArduino(&Serial1);
```

```cpp
/* Allocated in dynamic memory (for the C++ Aficionados among us) */
#include <CRSFforArduino.hpp>
#include <new>
using namespace std;

CRSFforArduino *crsf = nullptr;

void setup()
{
    /* This is how we do it now. */
    crsf = new CRSFforArduino(&Serial1);
}
```