### PR TITLE
feat(serial receiver interface): Auto-baud

### DIFF
--- a/examples/channels/channels.ino
+++ b/examples/channels/channels.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This example sketch shows how to receive RC channels from a CRSF receiver using the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/flight_modes/flight_modes.ino
+++ b/examples/flight_modes/flight_modes.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Demonstrates the use of CRSF for Arduino's flight mode functionality.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_flight_modes.cpp
+++ b/examples/platformio/main_flight_modes.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Demonstrates the use of CRSF for Arduino's flight mode functionality.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_rc.cpp
+++ b/examples/platformio/main_rc.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates the full capabilities of CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main_telemetry.cpp
+++ b/examples/platformio/main_telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file demonstrates how to use CRSF for Arduino to send telemetry to your RC transmitter using the CRSF protocol.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/telemetry/telemetry.ino
+++ b/examples/telemetry/telemetry.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This demonstrates how to use CRSF for Arduino to send telemetry to your RC transmitter using the CRSF protocol.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  * 
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Top level header for CRSF for Arduino, to help with Arduino IDE compatibility.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/CFA_Config.hpp
+++ b/src/CRSFforArduino/src/CFA_Config.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the configuration file for CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *
@@ -37,7 +37,7 @@ namespace crsfForArduinoConfig
 Versioning is done using Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION       "1.0.0"
-#define CRSFFORARDUINO_VERSION_DATE  "2024-1-20"
+#define CRSFFORARDUINO_VERSION_DATE  "2024-1-24"
 #define CRSFFORARDUINO_VERSION_MAJOR 1
 #define CRSFFORARDUINO_VERSION_MINOR 0
 #define CRSFFORARDUINO_VERSION_PATCH 0

--- a/src/CRSFforArduino/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino/src/CRSFforArduino.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino/src/CRSFforArduino.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF for Arduino facilitates the use of ExpressLRS RC receivers in Arduino projects.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.cpp
@@ -4,7 +4,7 @@
  * @brief This is the implementation of the Compatibility Table.
  * It is used to determine if the target development board is compatible with CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/CRSFforArduino/src/Hardware/CompatibilityTable/CompatibilityTable.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the Compatibility Table header file.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/Hardware.hpp
+++ b/src/CRSFforArduino/src/Hardware/Hardware.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file is the top level of the hardware abstraction layer.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.cpp
+++ b/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the hw_uart implementation file. It is used to configure CRSF for Arduino for specific development boards.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.hpp
+++ b/src/CRSFforArduino/src/Hardware/hw_uart/hw_uart.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains the hw_uart class, which is used to configure CRSF for Arduino for specific development boards.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class implementation.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRC/CRC.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRC class declaration.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
@@ -123,7 +123,7 @@ namespace serialReceiver
         timePerFrame = ((1000000 * packetCount) / (baudRate / (CRSF_FRAME_SIZE_MAX - 1)));
     }
 
-    bool CRSF::receiveFrames(uint8_t rxByte)
+    bool CRSF::receiveFrames(uint8_t rxByte, bool *rxFrameValid)
     {
         static uint8_t framePosition = 0;
         static uint32_t frameStartTime = 0;
@@ -144,6 +144,11 @@ namespace serialReceiver
         // Reset the frame start time if the frame position is 0.
         if (framePosition == 0)
         {
+            if (rxFrameValid != nullptr)
+            {
+                *rxFrameValid = false;
+            }
+            
             frameStartTime = currentTime;
         }
 
@@ -178,6 +183,11 @@ namespace serialReceiver
                                 rcFrameReceived = true;
                             }
                             break;
+                    }
+
+                    if (rxFrameValid != nullptr)
+                    {
+                        *rxFrameValid = true;
                     }
                 }
                 // #ifdef USE_DMA

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class implementation.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
@@ -56,7 +56,7 @@ namespace serialReceiver
         [[deprecated("Use the destructor instead.")]]
         void end();
         void setFrameTime(uint32_t baudRate, uint8_t packetCount = 10);
-        bool receiveFrames(uint8_t rxByte);
+        bool receiveFrames(uint8_t rxByte, bool *rxFrameValid = nullptr);
         void getRcChannels(uint16_t *rcChannels);
 
       private:

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
@@ -51,7 +51,9 @@ namespace serialReceiver
       public:
         CRSF();
         virtual ~CRSF();
+        [[deprecated("Use the constructor instead.")]]
         void begin();
+        [[deprecated("Use the destructor instead.")]]
         void end();
         void setFrameTime(uint32_t baudRate, uint8_t packetCount = 10);
         bool receiveFrames(uint8_t rxByte);
@@ -61,8 +63,8 @@ namespace serialReceiver
         bool rcFrameReceived;
         uint16_t frameCount;
         uint32_t timePerFrame;
-        crsfProtocol::frame_t rxFrame;
-        crsfProtocol::frame_t rcChannelsFrame;
+        crsfProtocol::frame_t *rxFrame;
+        crsfProtocol::frame_t *rcChannelsFrame;
         CRC *crc8;
         uint8_t calculateFrameCRC();
     };

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief CRSF class definition.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -237,6 +237,9 @@ namespace crsfProtocol
 
     enum baudRate_e
     {
-        BAUD_RATE = 420000
+        BAUD_RATE_LEGACY = 200000,
+        BAUD_RATE_KISS = 400000,
+        BAUD_RATE_TBS = 416666,
+        BAUD_RATE_ELRS = 420000
     };
 } // namespace crsfProtocol

--- a/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class implementation.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief SerialBuffer class definition.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the implementation file for the Serial Receiver Interface.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/SerialReceiver.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the header file for the Serial Receiver Interface.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class implementation.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Telemetry class definition.
  * @version 1.0.0
- * @date 2024-1-20
+ * @date 2024-1-24
  *
  * @copyright Copyright (c) 2023, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
## Overview

This _will not_ make it into the upcoming Version 1.0.0 release.  
This is simply an experiment that I want to mess around with. It is a first look at how an auto-baud _might_ be integrated into CRSF for Arduino.

## Details

During the initialisation phase, the Serial Receiver's initialiser starts up at a low baud rate, then iterates upwards until 7 valid frames out of 10 total frames are received.  
Then, the auto-baus "locks" onto a particular baud-rate. Thus, allowing the rest of the initialiser to continue.

The current implementation comes with a catch:  
Your controller (and by extension transmitter module) `MUST` be connected ot your receiver in order for the initialisation process to complete. Otherwise, if there is no valid connection (EG "Fail-safe" or your receiver is in Wi-Fi mode), CRSF for Arduino _will_ fail to initialise.

I am not entirely sure on how much this will impact CRSF for Arduino's quality-of-life, here. So, I may leave this Pull Request for the time being, and leave it up for consideration to you guys.

Tell me what you think on this: Yay or nay?  
I would like to hear your thoughts, comments, questions, love it/loathe it/hate it on this.