### PR TITLE
refactor(rc channels): Use event handler for fail-safe and RC channels

### DIFF
--- a/examples/platformio/main.cpp
+++ b/examples/platformio/main.cpp
@@ -64,26 +64,40 @@ void loop()
 
 void onReceiveRcChannels(serialReceiverLayer::rcChannels_t *rcChannels)
 {
-    static unsigned long lastPrint = 0;
+    static unsigned long lastPrint = millis();
     if (millis() - lastPrint >= 100)
     {
         lastPrint = millis();
-        Serial.print("RC Channels <A: ");
-        Serial.print(crsf->rcToUs(rcChannels->value[0]));
-        Serial.print(", E: ");
-        Serial.print(crsf->rcToUs(rcChannels->value[1]));
-        Serial.print(", T: ");
-        Serial.print(crsf->rcToUs(rcChannels->value[2]));
-        Serial.print(", R: ");
-        Serial.print(crsf->rcToUs(rcChannels->value[3]));
-        Serial.print(", Aux1: ");
-        Serial.print(crsf->rcToUs(rcChannels->value[4]));
-        Serial.print(", Aux2: ");
-        Serial.print(crsf->rcToUs(rcChannels->value[5]));
-        Serial.print(", Aux3: ");
-        Serial.print(crsf->rcToUs(rcChannels->value[6]));
-        Serial.print(", Aux4: ");
-        Serial.print(crsf->rcToUs(rcChannels->value[7]));
-        Serial.println(">");
+
+        static bool initialised = false;
+        static bool lastFailSafe = false;
+        if (rcChannels->failsafe != lastFailSafe || !initialised)
+        {
+            initialised = true;
+            lastFailSafe = rcChannels->failsafe;
+            Serial.print("FailSafe: ");
+            Serial.println(lastFailSafe ? "Active" : "Inactive");
+        }
+
+        if (rcChannels->failsafe == false)
+        {
+            Serial.print("RC Channels <A: ");
+            Serial.print(crsf->rcToUs(rcChannels->value[0]));
+            Serial.print(", E: ");
+            Serial.print(crsf->rcToUs(rcChannels->value[1]));
+            Serial.print(", T: ");
+            Serial.print(crsf->rcToUs(rcChannels->value[2]));
+            Serial.print(", R: ");
+            Serial.print(crsf->rcToUs(rcChannels->value[3]));
+            Serial.print(", Aux1: ");
+            Serial.print(crsf->rcToUs(rcChannels->value[4]));
+            Serial.print(", Aux2: ");
+            Serial.print(crsf->rcToUs(rcChannels->value[5]));
+            Serial.print(", Aux3: ");
+            Serial.print(crsf->rcToUs(rcChannels->value[6]));
+            Serial.print(", Aux4: ");
+            Serial.print(crsf->rcToUs(rcChannels->value[7]));
+            Serial.println(">");
+        }
     }
 }

--- a/examples/platformio/main.cpp
+++ b/examples/platformio/main.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the main development file for CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main.cpp
+++ b/examples/platformio/main.cpp
@@ -29,6 +29,8 @@
 
 CRSFforArduino *crsf = nullptr;
 
+void onReceiveRcChannels(serialReceiverLayer::rcChannels_t *rcChannels);
+
 void setup()
 {
     Serial.begin(115200);
@@ -51,33 +53,37 @@ void setup()
             delay(10);
         }
     }
+
+    crsf->setRcChannelsCallback(onReceiveRcChannels);
 }
 
 void loop()
 {
     crsf->update();
+}
 
-    /* Print RC channels every 100 ms. Do this using the millis() function to avoid blocking the main loop. */
+void onReceiveRcChannels(serialReceiverLayer::rcChannels_t *rcChannels)
+{
     static unsigned long lastPrint = 0;
     if (millis() - lastPrint >= 100)
     {
         lastPrint = millis();
         Serial.print("RC Channels <A: ");
-        Serial.print(crsf->rcToUs(crsf->getChannel(1)));
+        Serial.print(crsf->rcToUs(rcChannels->value[0]));
         Serial.print(", E: ");
-        Serial.print(crsf->rcToUs(crsf->getChannel(2)));
+        Serial.print(crsf->rcToUs(rcChannels->value[1]));
         Serial.print(", T: ");
-        Serial.print(crsf->rcToUs(crsf->getChannel(3)));
+        Serial.print(crsf->rcToUs(rcChannels->value[2]));
         Serial.print(", R: ");
-        Serial.print(crsf->rcToUs(crsf->getChannel(4)));
+        Serial.print(crsf->rcToUs(rcChannels->value[3]));
         Serial.print(", Aux1: ");
-        Serial.print(crsf->rcToUs(crsf->getChannel(5)));
+        Serial.print(crsf->rcToUs(rcChannels->value[4]));
         Serial.print(", Aux2: ");
-        Serial.print(crsf->rcToUs(crsf->getChannel(6)));
+        Serial.print(crsf->rcToUs(rcChannels->value[5]));
         Serial.print(", Aux3: ");
-        Serial.print(crsf->rcToUs(crsf->getChannel(7)));
+        Serial.print(crsf->rcToUs(rcChannels->value[6]));
         Serial.print(", Aux4: ");
-        Serial.print(crsf->rcToUs(crsf->getChannel(8)));
+        Serial.print(crsf->rcToUs(rcChannels->value[7]));
         Serial.println(">");
     }
 }

--- a/examples/rc_channels/rc_channels.ino
+++ b/examples/rc_channels/rc_channels.ino
@@ -94,42 +94,45 @@ void loop()
 
 void onReceiveRcChannels(serialReceiverLayer::rcChannels_t *rcChannels)
 {
-    /* Print RC channels every 100 ms. */
-    unsigned long thisTime = millis();
-    static unsigned long lastTime = millis();
-
-    /* Compensate for millis() overflow. */
-    if (thisTime < lastTime)
+    if (rcChannels->failsafe == false)
     {
-        lastTime = thisTime;
-    }
+        /* Print RC channels every 100 ms. */
+        unsigned long thisTime = millis();
+        static unsigned long lastTime = millis();
 
-    if (thisTime - lastTime >= 100)
-    {
-        lastTime = thisTime;
+        /* Compensate for millis() overflow. */
+        if (thisTime < lastTime)
+        {
+            lastTime = thisTime;
+        }
+
+        if (thisTime - lastTime >= 100)
+        {
+            lastTime = thisTime;
 #if USE_SERIAL_PLOTTER > 0
-        for (int i = 1; i <= rcChannelCount; i++)
-        {
-            Serial.print(i);
-            Serial.print(":");
-            Serial.print(crsf->rcToUs(crsf->getChannel(i)));
-            Serial.print("\t");
-        }
-        Serial.println();
-#else
-        Serial.print("RC Channels <");
-        for (int i = 1; i <= rcChannelCount; i++)
-        {
-            Serial.print(rcChannelNames[i - 1]);
-            Serial.print(": ");
-            Serial.print(crsf->rcToUs(crsf->getChannel(i)));
-
-            if (i < rcChannelCount)
+            for (int i = 1; i <= rcChannelCount; i++)
             {
-                Serial.print(", ");
+                Serial.print(i);
+                Serial.print(":");
+                Serial.print(crsf->rcToUs(crsf->getChannel(i)));
+                Serial.print("\t");
             }
-        }
-        Serial.println(">");
+            Serial.println();
+#else
+            Serial.print("RC Channels <");
+            for (int i = 1; i <= rcChannelCount; i++)
+            {
+                Serial.print(rcChannelNames[i - 1]);
+                Serial.print(": ");
+                Serial.print(crsf->rcToUs(crsf->getChannel(i)));
+
+                if (i < rcChannelCount)
+                {
+                    Serial.print(", ");
+                }
+            }
+            Serial.println(">");
 #endif
+        }
     }
 }

--- a/examples/rc_channels/rc_channels.ino
+++ b/examples/rc_channels/rc_channels.ino
@@ -49,6 +49,8 @@ const char *rcChannelNames[] = {
     "Aux11",
     "Aux12"};
 
+void onReceiveRcChannels(serialReceiverLayer::rcChannels_t *rcChannels);
+
 void setup()
 {
     // Initialise the serial port & wait for the port to open.
@@ -76,6 +78,8 @@ void setup()
 
     rcChannelCount = rcChannelCount > crsfProtocol::RC_CHANNEL_COUNT ? crsfProtocol::RC_CHANNEL_COUNT : rcChannelCount;
 
+    crsf->setRcChannelsCallback(onReceiveRcChannels);
+
     // Show the user that the sketch is ready.
     Serial.println("RC Channels Example");
     delay(1000);
@@ -86,7 +90,10 @@ void setup()
 void loop()
 {
     crsf->update();
+}
 
+void onReceiveRcChannels(serialReceiverLayer::rcChannels_t *rcChannels)
+{
     /* Print RC channels every 100 ms. */
     unsigned long thisTime = millis();
     static unsigned long lastTime = millis();

--- a/examples/rc_channels/rc_channels.ino
+++ b/examples/rc_channels/rc_channels.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read rc channels from a receiver.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 core_dir = .pio/core
-default_envs = development
+; default_envs = development
 extra_configs =
     targets/common.ini
     targets/unified_esp32.ini
@@ -23,16 +23,16 @@ lib_dir = src
 src_dir = src
 test_dir = 
 
-[env:development]
-board = adafruit_metro_m4
-build_src_filter = 
-    +<../examples/platformio/main.cpp>
-    +<hal/CompatibilityTable/*.cpp>
-    +<SerialReceiver/*.cpp>
-    +<SerialReceiver/CRC/*.cpp>
-    +<SerialReceiver/CRSF/*.cpp>
-    +<SerialReceiver/SerialBuffer/*.cpp>
-    +<SerialReceiver/Telemetry/*.cpp>
-    +<*.cpp>
-build_type = debug
-platform = atmelsam@8.2.0
+; [env:development]
+; board = adafruit_metro_m4
+; build_src_filter = 
+;     +<../examples/platformio/main.cpp>
+;     +<hal/CompatibilityTable/*.cpp>
+;     +<SerialReceiver/*.cpp>
+;     +<SerialReceiver/CRC/*.cpp>
+;     +<SerialReceiver/CRSF/*.cpp>
+;     +<SerialReceiver/SerialBuffer/*.cpp>
+;     +<SerialReceiver/Telemetry/*.cpp>
+;     +<*.cpp>
+; build_type = debug
+; platform = atmelsam@8.2.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 core_dir = .pio/core
-; default_envs = development
+default_envs = development
 extra_configs =
     targets/common.ini
     targets/unified_esp32.ini
@@ -23,16 +23,16 @@ lib_dir = src
 src_dir = src
 test_dir = 
 
-; [env:development]
-; board = adafruit_metro_m4
-; build_src_filter = 
-;     +<../examples/platformio/main.cpp>
-;     +<hal/CompatibilityTable/*.cpp>
-;     +<SerialReceiver/*.cpp>
-;     +<SerialReceiver/CRC/*.cpp>
-;     +<SerialReceiver/CRSF/*.cpp>
-;     +<SerialReceiver/SerialBuffer/*.cpp>
-;     +<SerialReceiver/Telemetry/*.cpp>
-;     +<*.cpp>
-; build_type = debug
-; platform = atmelsam@8.2.0
+[env:development]
+board = adafruit_metro_m4
+build_src_filter = 
+    +<../examples/platformio/main.cpp>
+    +<hal/CompatibilityTable/*.cpp>
+    +<SerialReceiver/*.cpp>
+    +<SerialReceiver/CRC/*.cpp>
+    +<SerialReceiver/CRSF/*.cpp>
+    +<SerialReceiver/SerialBuffer/*.cpp>
+    +<SerialReceiver/Telemetry/*.cpp>
+    +<*.cpp>
+build_type = debug
+platform = atmelsam@8.2.0

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -42,7 +42,7 @@ See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION_MINOR 0
 #define CRSFFORARDUINO_VERSION_PATCH 0
 
-#define CRSF_FAILSAFE_LQI_THRESHOLD 80
+#define CRSF_FAILSAFE_LQI_THRESHOLD  80
 #define CRSF_FAILSAFE_RSSI_THRESHOLD 105
 
 /* RC Options

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -42,6 +42,9 @@ See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION_MINOR 0
 #define CRSFFORARDUINO_VERSION_PATCH 0
 
+#define CRSF_FAILSAFE_LQI_THRESHOLD 80
+#define CRSF_FAILSAFE_RSSI_THRESHOLD 105
+
 /* RC Options
 - RC_ENABLED: Enables or disables the RC API.
 - RC_MAX_CHANNELS: The maximum number of RC channels to be received.

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -42,6 +42,11 @@ See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION_MINOR 0
 #define CRSFFORARDUINO_VERSION_PATCH 0
 
+/* Failsafe Options
+- CRSF_FAILSAFE_LQI_THRESHOLD: The minimum LQI value for the receiver to be considered connected.
+- CRSF_FAILSAFE_RSSI_THRESHOLD: The minimum RSSI value for the receiver to be considered connected.
+  - NB: It is considered good practice to set this value to the same as the RSSI Sensitivity Limit in your Lua script.
+*/
 #define CRSF_FAILSAFE_LQI_THRESHOLD  80
 #define CRSF_FAILSAFE_RSSI_THRESHOLD 105
 

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -98,7 +98,7 @@ information back to your controller. */
 - DEBUG_ENABLED: Enables or disables debug output over the selected serial port.
 - CRSF_DEBUG_SERIAL_PORT: The serial port to use for debug output. Usually the native USB port.
 - CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT: Enables or disables debug output from the compatibility table. */
-#define CRSF_DEBUG_ENABLED                           1
+#define CRSF_DEBUG_ENABLED                           0
 #define CRSF_DEBUG_SERIAL_PORT                       Serial
 #define CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT 0
 

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -90,7 +90,7 @@ information back to your controller. */
 - DEBUG_ENABLED: Enables or disables debug output over the selected serial port.
 - CRSF_DEBUG_SERIAL_PORT: The serial port to use for debug output. Usually the native USB port.
 - CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT: Enables or disables debug output from the compatibility table. */
-#define CRSF_DEBUG_ENABLED                           0
+#define CRSF_DEBUG_ENABLED                           1
 #define CRSF_DEBUG_SERIAL_PORT                       Serial
 #define CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT 0
 

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the configuration file for CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *
@@ -37,7 +37,7 @@ namespace crsfForArduinoConfig
 Versioning is done using Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION       "1.0.0"
-#define CRSFFORARDUINO_VERSION_DATE  "2024-2-6"
+#define CRSFFORARDUINO_VERSION_DATE  "2024-2-7"
 #define CRSFFORARDUINO_VERSION_MAJOR 1
 #define CRSFFORARDUINO_VERSION_MINOR 0
 #define CRSFFORARDUINO_VERSION_PATCH 0

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -118,6 +118,7 @@ namespace sketchLayer
      *
      * @return The RC value.
      */
+    [[deprecated("Use RC channel callback instead")]]
     uint16_t CRSFforArduino::readRcChannel(uint8_t channel, bool raw)
     {
 #if CRSF_RC_ENABLED > 0
@@ -138,6 +139,7 @@ namespace sketchLayer
      * @param channel The channel to read.
      * @return The RC value.
      */
+    [[deprecated("Use RC channel callback instead")]]
     uint16_t CRSFforArduino::getChannel(uint8_t channel)
     {
 #if CRSF_RC_ENABLED > 0
@@ -167,6 +169,16 @@ namespace sketchLayer
 
         // Return 0 if RC is disabled
         return 0;
+#endif
+    }
+
+    void CRSFforArduino::setRcChannelsCallback(void (*callback)(serialReceiverLayer::rcChannels_t *rcChannels))
+    {
+#if CRSF_RC_ENABLED > 0
+        _serialReceiver->setRcChannelsCallback(callback);
+#else
+        // Prevent compiler warnings
+        (void)callback;
 #endif
     }
 

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -118,8 +118,7 @@ namespace sketchLayer
      *
      * @return The RC value.
      */
-    [[deprecated("Use RC channel callback instead")]]
-    uint16_t CRSFforArduino::readRcChannel(uint8_t channel, bool raw)
+    [[deprecated("Use RC channel callback instead")]] uint16_t CRSFforArduino::readRcChannel(uint8_t channel, bool raw)
     {
 #if CRSF_RC_ENABLED > 0
         return _serialReceiver->readRcChannel(channel - 1, raw);
@@ -139,8 +138,7 @@ namespace sketchLayer
      * @param channel The channel to read.
      * @return The RC value.
      */
-    [[deprecated("Use RC channel callback instead")]]
-    uint16_t CRSFforArduino::getChannel(uint8_t channel)
+    [[deprecated("Use RC channel callback instead")]] uint16_t CRSFforArduino::getChannel(uint8_t channel)
     {
 #if CRSF_RC_ENABLED > 0
         return _serialReceiver->getChannel(channel - 1);

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -4,7 +4,7 @@
  * @brief This is the Sketch Layer, which is a simplified API for CRSF for Arduino.
  * It is intended to be used by the user in their sketches.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -4,7 +4,7 @@
  * @brief This is the Sketch Layer, which is a simplified API for CRSF for Arduino.
  * It is intended to be used by the user in their sketches.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -46,6 +46,7 @@ namespace sketchLayer
         uint16_t getChannel(uint8_t channel);
         uint16_t rcToUs(uint16_t rc);
         uint16_t readRcChannel(uint8_t channel, bool raw = false);
+        void setRcChannelsCallback(void (*callback)(serialReceiverLayer::rcChannels_t *rcChannels));
 
         // Link statistics functions.
         void setLinkStatisticsCallback(void (*callback)(serialReceiverLayer::link_statistics_t linkStatistics));

--- a/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/SerialReceiver/CRC/CRC.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic CRC8 implementation for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRC/CRC.hpp
+++ b/src/SerialReceiver/CRC/CRC.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic CRC8 implementation for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -163,6 +163,18 @@ namespace serialReceiverLayer
         return false;
     }
 
+    void CRSF::getFailSafe(bool *failSafe)
+    {
+        if (linkStatistics.lqi <= CRSF_FAILSAFE_LQI_THRESHOLD || linkStatistics.rssi >= CRSF_FAILSAFE_RSSI_THRESHOLD)
+        {
+            *failSafe = true;
+        }
+        else
+        {
+            *failSafe = false;
+        }
+    }
+
     void CRSF::getRcChannels(uint16_t *rcChannels)
     {
         if (rcFrameReceived)

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This decodes CRSF frames from a serial port.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/SerialReceiver/CRSF/CRSF.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This decodes CRSF frames from a serial port.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/SerialReceiver/CRSF/CRSF.hpp
@@ -62,6 +62,7 @@ namespace serialReceiverLayer
         void end();
         void setFrameTime(uint32_t baudRate, uint8_t packetCount = 10);
         bool receiveFrames(uint8_t rxByte);
+        void getFailSafe(bool *failSafe);
         void getRcChannels(uint16_t *rcChannels);
         void getLinkStatistics(link_statistics_t *linkStats);
 

--- a/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic serial buffer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic serial buffer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Serial Receiver layer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -256,6 +256,7 @@ namespace serialReceiverLayer
 
 #if CRSF_RC_ENABLED > 0
         // Update the RC Channels.
+        crsf->getFailSafe(&_rcChannels->failsafe);
         crsf->getRcChannels(_rcChannels->value);
         if (_rcChannelsCallback != nullptr)
         {

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Serial Receiver layer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -47,6 +47,16 @@ namespace serialReceiverLayer
         FLIGHT_MODE_COUNT
     } flightModeId_t;
 
+    typedef struct rcChannels_s
+    {
+        bool valid;
+        bool failsafe;
+        uint16_t value[crsfProtocol::RC_CHANNEL_COUNT];
+    } rcChannels_t;
+
+    // Function pointer for RC Channels Callback
+    typedef void (*rcChannelsCallback_t)(rcChannels_t *);
+
     // Function pointer for Flight Mode Callback
     typedef void (*flightModeCallback_t)(flightModeId_t);
 
@@ -72,6 +82,7 @@ namespace serialReceiverLayer
 #endif
 
 #if CRSF_RC_ENABLED > 0
+        void setRcChannelsCallback(rcChannelsCallback_t callback);
         uint16_t getChannel(uint8_t channel);
         uint16_t rcToUs(uint16_t rc);
         uint16_t usToRc(uint16_t us);
@@ -101,7 +112,8 @@ namespace serialReceiverLayer
 #endif
 
 #if CRSF_RC_ENABLED > 0
-        uint16_t *_rcChannels;
+        rcChannels_t *_rcChannels = nullptr;
+        rcChannelsCallback_t _rcChannelsCallback = nullptr;
 #endif
 
 #if CRSF_TELEMETRY_ENABLED > 0

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This encodes data into CRSF telemetry frames for transmission to the RC handset.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This encodes data into CRSF telemetry frames for transmission to the RC handset.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/hal/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Compatibility Table determines if the target development board is compatible with CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/hal/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Compatibility Table determines if the target development board is compatible with CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-6
+ * @date 2024-2-7
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
## Overview

This Pull Request re-factors the old API for reading RC Channels, and puts them into their own event handler.  
This same event handler also reads the receiver's fail-safe state based on the RSSI and LQI thresholds set in the `CFA_Config.hpp` file.

## Details

Like the other event handlers, you register the callback using `CRSFforArduino::setRcCallback(serialReceiverLayer::rcChannels_t *)`  
The underlying `_rcChannels` array has been rewritten as a data structure, which now holds not only your raw RC channels data, but also holds a `failsafe` flag which you can read out in the Event's callback function.

Here is what the RC Channels Event Handler API looks like:
```cpp
#include "Arduino.h"
#include "CRSFforArduino.hpp"

/* Declare CRSF for Arduino up here as a null pointer. */
CRSFforArduino *crsf = nullptr;

/* As is the case with other callback functions, this is required to be here. */
void onReceiveRcChannels(serialReceiverLayer::rcChannels_t *rcChannels);

void setup()
{
    Serial.begin(115200);
    while (!Serial)
    {
        delay(10);
    }

    /* Instantiate CRSF for Arduino and initialise it. */
    crsf = new CRSFforArduino();
    if (!crsf->begin())
    {
        Serial.println("CRSF for Arduino failed to initialise.");

        delete crsf;
        crsf = nullptr;

        while (1)
        {
            delay(10);
        }
    }

    /* Register your RC Channels callback function. */
    crsf->setRcChannelsCallback(onReceiveRcChannels);
}

void loop()
{
    /* Update CRSF for Arduino in the main loop. */
    crsf->update();

  /* Note how there is nothing else to do in the main loop anymore.
  This is all handled by the new events system. */
}

/* The RC Channels callback is executed when RC Channels are received. */
void onReceiveRcChannels(serialReceiverLayer::rcChannels_t *rcChannels)
{
    static unsigned long lastPrint = millis();
    if (millis() - lastPrint >= 100)
    {
        lastPrint = millis();

        static bool initialised = false;
        static bool lastFailSafe = false;
        if (rcChannels->failsafe != lastFailSafe || !initialised)
        {
            initialised = true;
            lastFailSafe = rcChannels->failsafe;
            Serial.print("FailSafe: ");
            Serial.println(lastFailSafe ? "Active" : "Inactive");
        }

        if (rcChannels->failsafe == false)
        {
            /* Here, you can read back your RC channels. */
            Serial.print("RC Channels <A: ");
            Serial.print(crsf->rcToUs(rcChannels->value[0]));
            Serial.print(", E: ");
            Serial.print(crsf->rcToUs(rcChannels->value[1]));
            Serial.print(", T: ");
            Serial.print(crsf->rcToUs(rcChannels->value[2]));
            Serial.print(", R: ");
            Serial.print(crsf->rcToUs(rcChannels->value[3]));
            Serial.print(", Aux1: ");
            Serial.print(crsf->rcToUs(rcChannels->value[4]));
            Serial.print(", Aux2: ");
            Serial.print(crsf->rcToUs(rcChannels->value[5]));
            Serial.print(", Aux3: ");
            Serial.print(crsf->rcToUs(rcChannels->value[6]));
            Serial.print(", Aux4: ");
            Serial.print(crsf->rcToUs(rcChannels->value[7]));
            Serial.println(">");
        }
        else
        {
            /* Here, you may add in your own fail-safe handling code.
            For now, simply do nothing. */
        }
    }
}
```

In `CFA_Config.hpp` you have two options:
- `CRSF_FAILSAFE_LQI_THRESHOLD`
- `CRSF_FAILSAFE_RSSI_THRESHOLD`

The `CRSF_FAILSAFE_LQI_THRESHOLD` is the minimum Link Quality value that the receiver considers to be connected. You can set this to any arbitrary value from `0` to `100`.  
The `CRSF_FAILSAFE_RSSI_THRESHOLD` is the minimum RSSI. It is recommended that you set this to the same value as your packet rate's RSSI Sensitivity Limit.

When either one of these thresholds are crossed, _this_ is what constitutes a fail-safe.  
This is pretty rudimentary, but it will do for now, and it can be expanded later on down the track, if the need to do so arises.

## Additional notes

I decided to leave out the ability to read back whether-or-not a received CRSF packet has either passed or failed its checksum for the time being. I know this was a part of what was brought up in #51, however, later on down the track, it may be better to automatically incorporate multiple checksum fails into "what constitutes a fail-safe".