### PR TITLE
feat(serial receiver interface): Add custom Flight Mode strings as telemetry

### DIFF
--- a/examples/flight_modes/flight_modes.ino
+++ b/examples/flight_modes/flight_modes.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read flight modes from a receiver.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/link_stats/link_stats.ino
+++ b/examples/link_stats/link_stats.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read link statistics from a receiver.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main.cpp
+++ b/examples/platformio/main.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the main development file for CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/rc_channels/rc_channels.ino
+++ b/examples/rc_channels/rc_channels.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read rc channels from a receiver.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/telemetry/telemetry.ino
+++ b/examples/telemetry/telemetry.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to send telemetry back to your RC handset using CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -86,10 +86,15 @@ information back to your controller. */
 - TELEMETRY_GPS_ENABLED: Enables or disables GPS telemetry output.
 - TELEMETRY_SIMULATE_ARBITRARY_VALUES: When enabled, arbitrary values are sent for telemetry. */
 #define CRSF_TELEMETRY_ENABLED              1
+
 #define CRSF_TELEMETRY_ATTITUDE_ENABLED     1
 #define CRSF_TELEMETRY_BAROALTITUDE_ENABLED 1
 #define CRSF_TELEMETRY_BATTERY_ENABLED      1
+
+#ifndef CRSF_TELEMETRY_FLIGHTMODE_ENABLED
 #define CRSF_TELEMETRY_FLIGHTMODE_ENABLED   0
+#endif
+
 #define CRSF_TELEMETRY_GPS_ENABLED          1
 
 #define CRSF_LINK_STATISTICS_ENABLED 1

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the configuration file for CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *
@@ -37,7 +37,7 @@ namespace crsfForArduinoConfig
 Versioning is done using Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION       "1.0.0"
-#define CRSFFORARDUINO_VERSION_DATE  "2024-2-10"
+#define CRSFFORARDUINO_VERSION_DATE  "2024-2-14"
 #define CRSFFORARDUINO_VERSION_MAJOR 1
 #define CRSFFORARDUINO_VERSION_MINOR 0
 #define CRSFFORARDUINO_VERSION_PATCH 0

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -85,17 +85,17 @@ information back to your controller. */
 - TELEMETRY_FLIGHTMODE_ENABLED: Enables or disables flight mode telemetry output.
 - TELEMETRY_GPS_ENABLED: Enables or disables GPS telemetry output.
 - TELEMETRY_SIMULATE_ARBITRARY_VALUES: When enabled, arbitrary values are sent for telemetry. */
-#define CRSF_TELEMETRY_ENABLED              1
+#define CRSF_TELEMETRY_ENABLED 1
 
 #define CRSF_TELEMETRY_ATTITUDE_ENABLED     1
 #define CRSF_TELEMETRY_BAROALTITUDE_ENABLED 1
 #define CRSF_TELEMETRY_BATTERY_ENABLED      1
 
 #ifndef CRSF_TELEMETRY_FLIGHTMODE_ENABLED
-#define CRSF_TELEMETRY_FLIGHTMODE_ENABLED   0
+#define CRSF_TELEMETRY_FLIGHTMODE_ENABLED 0
 #endif
 
-#define CRSF_TELEMETRY_GPS_ENABLED          1
+#define CRSF_TELEMETRY_GPS_ENABLED 1
 
 #define CRSF_LINK_STATISTICS_ENABLED 1
 

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -4,7 +4,7 @@
  * @brief This is the Sketch Layer, which is a simplified API for CRSF for Arduino.
  * It is intended to be used by the user in their sketches.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -307,7 +307,7 @@ namespace sketchLayer
      * 
      * @param flightMode The Flight Mode string to send.
      */
-    void CRSFforArduino::telemetryWriteCustomFlightMode(const char * flightMode, bool armed)
+    void CRSFforArduino::telemetryWriteCustomFlightMode(const char *flightMode, bool armed)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
         _serialReceiver->telemetryWriteCustomFlightMode(flightMode, armed);

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -303,6 +303,21 @@ namespace sketchLayer
     }
 
     /**
+     * @brief Sends a CRSF Telemetry Frame with a custom Flight Mode string.
+     * 
+     * @param flightMode The Flight Mode string to send.
+     */
+    void CRSFforArduino::telemetryWriteCustomFlightMode(const char * flightMode, bool armed)
+    {
+#if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
+        _serialReceiver->telemetryWriteCustomFlightMode(flightMode, armed);
+#else
+        // Prevent compiler warnings
+        (void)flightMode;
+#endif
+    }
+
+    /**
      * @brief Sends a CRSF Telemetry Frame with the current GPS data.
      * 
      * @param latitude In decimal degrees.

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -4,7 +4,7 @@
  * @brief This is the Sketch Layer, which is a simplified API for CRSF for Arduino.
  * It is intended to be used by the user in their sketches.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -60,7 +60,7 @@ namespace sketchLayer
         void telemetryWriteBaroAltitude(uint16_t altitude, int16_t vario);
         void telemetryWriteBattery(float voltage, float current, uint32_t fuel, uint8_t percent);
         void telemetryWriteFlightMode(serialReceiverLayer::flightModeId_t flightMode);
-        void telemetryWriteCustomFlightMode(const char * flightMode, bool armed = false);
+        void telemetryWriteCustomFlightMode(const char *flightMode, bool armed = false);
         void telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites);
 
       private:

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -60,6 +60,7 @@ namespace sketchLayer
         void telemetryWriteBaroAltitude(uint16_t altitude, int16_t vario);
         void telemetryWriteBattery(float voltage, float current, uint32_t fuel, uint8_t percent);
         void telemetryWriteFlightMode(serialReceiverLayer::flightModeId_t flightMode);
+        void telemetryWriteCustomFlightMode(const char * flightMode, bool armed = false);
         void telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites);
 
       private:

--- a/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/SerialReceiver/CRC/CRC.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic CRC8 implementation for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRC/CRC.hpp
+++ b/src/SerialReceiver/CRC/CRC.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic CRC8 implementation for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This decodes CRSF frames from a serial port.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/SerialReceiver/CRSF/CRSF.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This decodes CRSF frames from a serial port.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic serial buffer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic serial buffer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -435,12 +435,11 @@ namespace serialReceiverLayer
 #endif
 
 #if CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
-    void SerialReceiver::telemetryWriteCustomFlightMode(const char * flightModeStr, bool armed = true)
+    void SerialReceiver::telemetryWriteCustomFlightMode(const char *flightModeStr, bool armed = true)
     {
         telemetry->setFlightModeData(flightModeStr, armed);
     }
 #endif
-
 
 #if CRSF_TELEMETRY_GPS_ENABLED > 0
     void SerialReceiver::telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites)

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Serial Receiver layer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -434,6 +434,14 @@ namespace serialReceiverLayer
     }
 #endif
 
+#if CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
+    void SerialReceiver::telemetryWriteCustomFlightMode(const char * flightModeStr, bool armed = true)
+    {
+        telemetry->setFlightModeData(flightModeStr, armed);
+    }
+#endif
+
+
 #if CRSF_TELEMETRY_GPS_ENABLED > 0
     void SerialReceiver::telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites)
     {

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -100,6 +100,7 @@ namespace serialReceiverLayer
         void telemetryWriteBaroAltitude(uint16_t altitude, int16_t vario);
         void telemetryWriteBattery(float voltage, float current, uint32_t fuel, uint8_t percent);
         void telemetryWriteFlightMode(flightModeId_t flightMode);
+        void telemetryWriteCustomFlightMode(const char * flightMode, bool armed = true);
         void telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites);
 #endif
 

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Serial Receiver layer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -100,7 +100,7 @@ namespace serialReceiverLayer
         void telemetryWriteBaroAltitude(uint16_t altitude, int16_t vario);
         void telemetryWriteBattery(float voltage, float current, uint32_t fuel, uint8_t percent);
         void telemetryWriteFlightMode(flightModeId_t flightMode);
-        void telemetryWriteCustomFlightMode(const char * flightMode, bool armed = true);
+        void telemetryWriteCustomFlightMode(const char *flightMode, bool armed = true);
         void telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites);
 #endif
 

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This encodes data into CRSF telemetry frames for transmission to the RC handset.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This encodes data into CRSF telemetry frames for transmission to the RC handset.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/hal/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Compatibility Table determines if the target development board is compatible with CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/hal/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Compatibility Table determines if the target development board is compatible with CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-10
+ * @date 2024-2-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
This pull request adds support for custom flight mode strings from the client through the telemetryWriteCustomFlightMode method. This might be a niche use case, but I'm using CRSF for a car based robot and using flight modes to represent different operational modes. Other Arduino users might be doing similar things so I'm sending it as a pull request.

To make it work directly as a Platformio library, I also modified CFA_Config.hpp to allow users to set CRSF_TELEMETRY_FLIGHTMODE_ENABLED externally, allowing me to set it through my platformio.ini build flags. That same pattern might be useful for other #defines, but I only changed the one that I required. 