### PR TITLE
refactor(library): Flight Modes API and Custom Flight Modes integration, plus code and comments clean-up

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *.c text eol=lf
 *.cpp text eol=lf
 *.h text eol=lf
+*.hpp text eol=lf
 *.ini text eol=lf
 *.ino text eol=lf
 *.json text eol=lf

--- a/.github/workflows/arduinoide_build.yml
+++ b/.github/workflows/arduinoide_build.yml
@@ -22,5 +22,6 @@ jobs:
     - name: Check for correct code formatting with clang-format
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
 
-    - name: Test the code on supported platforms
-      run: python3 ci/build_platform.py metro_m4
+    # Disabled until Adafruit fixes their fault detection issue. 
+    # - name: Test the code on supported platforms
+    #  run: python3 ci/build_platform.py metro_m4

--- a/examples/flight_modes/flight_modes.ino
+++ b/examples/flight_modes/flight_modes.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read flight modes from a receiver.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/link_stats/link_stats.ino
+++ b/examples/link_stats/link_stats.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read link statistics from a receiver.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main.cpp
+++ b/examples/platformio/main.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the main development file for CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/rc_channels/rc_channels.ino
+++ b/examples/rc_channels/rc_channels.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read rc channels from a receiver.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/telemetry/telemetry.ino
+++ b/examples/telemetry/telemetry.ino
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to send telemetry back to your RC handset using CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,5 +27,9 @@ test_dir =
 
 ; [env:development]
 ; board = adafruit_metro_m4
+; build_src_filter = 
+;     +<../examples/platformio/cfa_code_test.cpp>
+;     +<*/*/*.cpp>
+;     +<*.cpp>
 ; build_type = debug
 ; extends = env_common_samd51

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -77,6 +77,12 @@ Pro Tip: You can combine the Flight Mode API with the Telemetry API to send flig
 information back to your controller. */
 #define CRSF_FLIGHTMODES_ENABLED 0
 
+/* Custom Flight Modes
+Enables or disables the Custom Flight Modes.
+When enabled, this allows you to implement flight modes with custom names
+and assign them to a switch on your controller. */
+#define CRSF_CUSTOM_FLIGHT_MODES_ENABLED 0
+
 /* Telemetry Options
 - TELEMETRY_ENABLED: Enables or disables the Telemetry API.
 - TELEMETRY_ATTITUDE_ENABLED: Enables or disables attitude telemetry output.

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the configuration file for CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -279,13 +279,14 @@ namespace sketchLayer
      * 
      * @param flightMode The Flight Mode to send.
      */
-    void CRSFforArduino::telemetryWriteFlightMode(serialReceiverLayer::flightModeId_t flightMode)
+    void CRSFforArduino::telemetryWriteFlightMode(serialReceiverLayer::flightModeId_t flightMode, bool disarmed)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
-        this->SerialReceiver::telemetryWriteFlightMode(flightMode);
+        this->SerialReceiver::telemetryWriteFlightMode(flightMode, disarmed);
 #else
         // Prevent compiler warnings
         (void)flightMode;
+        (void)disarmed;
 #endif
     }
 
@@ -297,7 +298,7 @@ namespace sketchLayer
     void CRSFforArduino::telemetryWriteCustomFlightMode(const char *flightMode, bool armed)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
-        _serialReceiver->telemetryWriteCustomFlightMode(flightMode, armed);
+        this->SerialReceiver::telemetryWriteCustomFlightMode(flightMode, armed);
 #else
         // Prevent compiler warnings
         (void)flightMode;

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -180,6 +180,33 @@ namespace sketchLayer
     /**
      * @brief Assigns a Flight Mode to the specified channel.
      * 
+     * @param flightModeId The ID of the Flight Mode to assign.
+     * @param flightModeName The name of the Flight Mode to assign.
+     * @param channel The channel to assign the Flight Mode to.
+     * @param min The minimum RC value for the Flight Mode to be active.
+     * @param max The maximum RC value for the Flight Mode to be active.
+     * @return true if the Flight Mode was assigned successfully.
+     */
+    bool CRSFforArduino::setFlightMode(serialReceiverLayer::flightModeId_t flightModeId, const char *flightModeName, uint8_t channel, uint16_t min, uint16_t max)
+    {
+#if CRSF_RC_ENABLED > 0 && CRSF_FLIGHTMODES_ENABLED > 0
+        return this->SerialReceiver::setFlightMode(flightModeId, flightModeName, channel - 1, this->SerialReceiver::usToRc(min), this->SerialReceiver::usToRc(max));
+#else
+        // Prevent compiler warnings
+        (void)flightModeId;
+        (void)flightModeName;
+        (void)channel;
+        (void)min;
+        (void)max;
+
+        // Return false if RC is disabled
+        return false;
+#endif
+    }
+
+    /**
+     * @brief Assigns a Flight Mode to the specified channel.
+     * 
      * @param flightMode The Flight Mode to assign.
      * @param channel The channel to assign the Flight Mode to.
      * @param min The minimum RC value for the Flight Mode to be active.

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -4,7 +4,7 @@
  * @brief This is the Sketch Layer, which is a simplified API for CRSF for Arduino.
  * It is intended to be used by the user in their sketches.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -186,7 +186,7 @@ namespace sketchLayer
      * @param max The maximum RC value for the Flight Mode to be active.
      * @return true if the Flight Mode was assigned successfully.
      */
-    bool CRSFforArduino::setFlightMode(serialReceiverLayer::flightModeId_t flightMode, uint8_t channel, uint16_t min, uint16_t max)
+    [[deprecated("This function must pass in the name of the Flight Mode as well as its ID.")]] bool CRSFforArduino::setFlightMode(serialReceiverLayer::flightModeId_t flightMode, uint8_t channel, uint16_t min, uint16_t max)
     {
 #if CRSF_RC_ENABLED > 0 && CRSF_FLIGHTMODES_ENABLED > 0
         return this->SerialReceiver::setFlightMode(flightMode, channel - 1, this->SerialReceiver::usToRc(min), this->SerialReceiver::usToRc(max));

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -295,7 +295,7 @@ namespace sketchLayer
      * 
      * @param flightMode The Flight Mode string to send.
      */
-    void CRSFforArduino::telemetryWriteCustomFlightMode(const char *flightMode, bool armed)
+    [[deprecated("This is nos handled automatically with telemetryWriteFlightMode()")]] void CRSFforArduino::telemetryWriteCustomFlightMode(const char *flightMode, bool armed)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
         this->SerialReceiver::telemetryWriteCustomFlightMode(flightMode, armed);

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -36,9 +36,6 @@ namespace sketchLayer
      */
     CRSFforArduino::CRSFforArduino()
     {
-#if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0
-        _serialReceiver = new SerialReceiver();
-#endif
     }
 
     /**
@@ -49,13 +46,6 @@ namespace sketchLayer
      */
     CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort)
     {
-#if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0
-        _serialReceiver = new SerialReceiver(serialPort);
-#else
-        // Prevent compiler warnings
-        (void)rxPin;
-        (void)txPin;
-#endif
     }
 
     /**
@@ -64,9 +54,6 @@ namespace sketchLayer
      */
     CRSFforArduino::~CRSFforArduino()
     {
-#if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0
-        delete _serialReceiver;
-#endif
     }
 
     /**
@@ -77,7 +64,7 @@ namespace sketchLayer
     bool CRSFforArduino::begin()
     {
 #if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0
-        return _serialReceiver->begin();
+        return this->SerialReceiver::begin();
 #else
         // Return false if RC is disabled
         return false;
@@ -91,7 +78,7 @@ namespace sketchLayer
     void CRSFforArduino::end()
     {
 #if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0
-        _serialReceiver->end();
+        this->SerialReceiver::end();
 #endif
     }
 
@@ -103,11 +90,11 @@ namespace sketchLayer
     void CRSFforArduino::update()
     {
 #if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0
-        _serialReceiver->processFrames();
+        this->SerialReceiver::processFrames();
 #endif
 
 #if CRSF_RC_ENABLED > 0 && CRSF_FLIGHTMODES_ENABLED > 0
-        _serialReceiver->handleFlightMode();
+        this->SerialReceiver::handleFlightMode();
 #endif
     }
 
@@ -121,7 +108,7 @@ namespace sketchLayer
     [[deprecated("Use RC channel callback instead")]] uint16_t CRSFforArduino::readRcChannel(uint8_t channel, bool raw)
     {
 #if CRSF_RC_ENABLED > 0
-        return _serialReceiver->readRcChannel(channel - 1, raw);
+        return this->SerialReceiver::readRcChannel(channel - 1, raw);
 #else
         // Prevent compiler warnings
         (void)channel;
@@ -141,7 +128,7 @@ namespace sketchLayer
     [[deprecated("Use RC channel callback instead")]] uint16_t CRSFforArduino::getChannel(uint8_t channel)
     {
 #if CRSF_RC_ENABLED > 0
-        return _serialReceiver->getChannel(channel - 1);
+        return this->SerialReceiver::getChannel(channel - 1);
 #else
         // Prevent compiler warnings
         (void)channel;
@@ -160,7 +147,7 @@ namespace sketchLayer
     uint16_t CRSFforArduino::rcToUs(uint16_t rc)
     {
 #if CRSF_RC_ENABLED > 0
-        return _serialReceiver->rcToUs(rc);
+        return this->SerialReceiver::rcToUs(rc);
 #else
         // Prevent compiler warnings
         (void)rc;
@@ -173,7 +160,7 @@ namespace sketchLayer
     void CRSFforArduino::setRcChannelsCallback(void (*callback)(serialReceiverLayer::rcChannels_t *rcChannels))
     {
 #if CRSF_RC_ENABLED > 0
-        _serialReceiver->setRcChannelsCallback(callback);
+        this->SerialReceiver::setRcChannelsCallback(callback);
 #else
         // Prevent compiler warnings
         (void)callback;
@@ -183,7 +170,7 @@ namespace sketchLayer
     void CRSFforArduino::setLinkStatisticsCallback(void (*callback)(serialReceiverLayer::link_statistics_t linkStatistics))
     {
 #if CRSF_LINK_STATISTICS_ENABLED > 0
-        _serialReceiver->setLinkStatisticsCallback(callback);
+        this->SerialReceiver::setLinkStatisticsCallback(callback);
 #else
         // Prevent compiler warnings
         (void)callback;
@@ -202,7 +189,7 @@ namespace sketchLayer
     bool CRSFforArduino::setFlightMode(serialReceiverLayer::flightModeId_t flightMode, uint8_t channel, uint16_t min, uint16_t max)
     {
 #if CRSF_RC_ENABLED > 0 && CRSF_FLIGHTMODES_ENABLED > 0
-        return _serialReceiver->setFlightMode(flightMode, channel - 1, _serialReceiver->usToRc(min), _serialReceiver->usToRc(max));
+        return this->SerialReceiver::setFlightMode(flightMode, channel - 1, this->SerialReceiver::usToRc(min), this->SerialReceiver::usToRc(max));
 #else
         // Prevent compiler warnings
         (void)flightMode;
@@ -223,7 +210,7 @@ namespace sketchLayer
     void CRSFforArduino::setFlightModeCallback(void (*callback)(serialReceiverLayer::flightModeId_t flightMode))
     {
 #if CRSF_RC_ENABLED > 0 && CRSF_FLIGHTMODES_ENABLED > 0
-        _serialReceiver->setFlightModeCallback(callback);
+        this->SerialReceiver::setFlightModeCallback(callback);
 #else
         // Prevent compiler warnings
         (void)callback;
@@ -240,7 +227,7 @@ namespace sketchLayer
     void CRSFforArduino::telemetryWriteAttitude(int16_t roll, int16_t pitch, int16_t yaw)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_ATTITUDE_ENABLED > 0
-        _serialReceiver->telemetryWriteAttitude(roll, pitch, yaw);
+        this->SerialReceiver::telemetryWriteAttitude(roll, pitch, yaw);
 #else
         // Prevent compiler warnings
         (void)roll;
@@ -258,7 +245,7 @@ namespace sketchLayer
     void CRSFforArduino::telemetryWriteBaroAltitude(uint16_t altitude, int16_t vario)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_BAROALTITUDE_ENABLED > 0
-        _serialReceiver->telemetryWriteBaroAltitude(altitude, vario);
+        this->SerialReceiver::telemetryWriteBaroAltitude(altitude, vario);
 #else
         // Prevent compiler warnings
         (void)altitude;
@@ -277,7 +264,7 @@ namespace sketchLayer
     void CRSFforArduino::telemetryWriteBattery(float voltage, float current, uint32_t fuel, uint8_t percent)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_BATTERY_ENABLED > 0
-        _serialReceiver->telemetryWriteBattery(voltage, current, fuel, percent);
+        this->SerialReceiver::telemetryWriteBattery(voltage, current, fuel, percent);
 #else
         // Prevent compiler warnings
         (void)voltage;
@@ -295,7 +282,7 @@ namespace sketchLayer
     void CRSFforArduino::telemetryWriteFlightMode(serialReceiverLayer::flightModeId_t flightMode)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
-        _serialReceiver->telemetryWriteFlightMode(flightMode);
+        this->SerialReceiver::telemetryWriteFlightMode(flightMode);
 #else
         // Prevent compiler warnings
         (void)flightMode;
@@ -330,7 +317,7 @@ namespace sketchLayer
     void CRSFforArduino::telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites)
     {
 #if CRSF_TELEMETRY_ENABLED > 0 && CRSF_TELEMETRY_GPS_ENABLED > 0
-        _serialReceiver->telemetryWriteGPS(latitude, longitude, altitude, speed, groundCourse, satellites);
+        this->SerialReceiver::telemetryWriteGPS(latitude, longitude, altitude, speed, groundCourse, satellites);
 #else
         // Prevent compiler warnings
         (void)latitude;

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -52,6 +52,7 @@ namespace sketchLayer
         void setLinkStatisticsCallback(void (*callback)(serialReceiverLayer::link_statistics_t linkStatistics));
 
         // Flight mode functions.
+        bool setFlightMode(serialReceiverLayer::flightModeId_t flightModeId, const char *flightModeName, uint8_t channel, uint16_t min, uint16_t max);
         bool setFlightMode(serialReceiverLayer::flightModeId_t flightMode, uint8_t channel, uint16_t min, uint16_t max);
         void setFlightModeCallback(void (*callback)(serialReceiverLayer::flightModeId_t flightMode));
 

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -59,7 +59,7 @@ namespace sketchLayer
         void telemetryWriteAttitude(int16_t roll, int16_t pitch, int16_t yaw);
         void telemetryWriteBaroAltitude(uint16_t altitude, int16_t vario);
         void telemetryWriteBattery(float voltage, float current, uint32_t fuel, uint8_t percent);
-        void telemetryWriteFlightMode(serialReceiverLayer::flightModeId_t flightMode);
+        void telemetryWriteFlightMode(serialReceiverLayer::flightModeId_t flightMode, bool disarmed = false);
         void telemetryWriteCustomFlightMode(const char *flightMode, bool armed = false);
         void telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites);
 

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -4,7 +4,7 @@
  * @brief This is the Sketch Layer, which is a simplified API for CRSF for Arduino.
  * It is intended to be used by the user in their sketches.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -64,7 +64,6 @@ namespace sketchLayer
         void telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites);
 
       private:
-        SerialReceiver *_serialReceiver;
     };
 } // namespace sketchLayer
 

--- a/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/SerialReceiver/CRC/CRC.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic CRC8 implementation for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/SerialReceiver/CRC/CRC.cpp
@@ -105,6 +105,7 @@ namespace genericCrc
         }
         return crc;
 #elif (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_HARDWARE)
+#error "CRC_OPTIMISATION_LEVEL is set to CRC_OPTIMISATION_HARDWARE, but no hardware implementation is available."
 #endif
     }
 
@@ -132,6 +133,7 @@ namespace genericCrc
         }
         return crc;
 #elif (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_HARDWARE)
+#error "CRC_OPTIMISATION_LEVEL is set to CRC_OPTIMISATION_HARDWARE, but no hardware implementation is available."
 #endif
     }
 } // namespace genericCrc

--- a/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/SerialReceiver/CRC/CRC.cpp
@@ -32,10 +32,8 @@ namespace genericCrc
     GenericCRC::GenericCRC()
     {
 #if (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_SPEED)
-        // Allocate memory for the CRC8 DVB S2 table.
         crc_8_dvb_s2_table = (uint8_t *)malloc(256 * sizeof(uint8_t));
 
-        // Generate the CRC8 DVB S2 table.
         for (uint16_t i = 0; i < 256; i++)
         {
             uint8_t crc = i;
@@ -50,6 +48,7 @@ namespace genericCrc
                     crc <<= 1;
                 }
             }
+
             crc_8_dvb_s2_table[i] = crc & 0xff;
         }
 #endif
@@ -58,7 +57,6 @@ namespace genericCrc
     GenericCRC::~GenericCRC()
     {
 #if (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_SPEED)
-        // Free the memory allocated for the CRC8 DVB S2 table.
         free(crc_8_dvb_s2_table);
 #endif
     }
@@ -85,24 +83,22 @@ namespace genericCrc
     uint8_t GenericCRC::calculate(uint8_t start, uint8_t *data, uint8_t length)
     {
 #if (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_SPEED)
-        // start is the first byte of the data to be GenericCRC'd.
-        // data is a pointer to the data to be GenericCRC'd.
-
-        // Calculate the CRC8 DVB S2 value.
         uint8_t crc = crc_8_dvb_s2_table[0 ^ start];
+
         for (uint8_t i = 0; i < length; i++)
         {
             crc = crc_8_dvb_s2_table[crc ^ data[i]];
         }
 
-        // Return the CRC8 DVB S2 value.
         return crc;
 #elif (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_SIZE)
         uint8_t crc = crc_8_dvb_s2(0, start);
+
         for (uint8_t i = 0; i < length; i++)
         {
             crc = crc_8_dvb_s2(crc, data[i]);
         }
+
         return crc;
 #elif (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_HARDWARE)
 #error "CRC_OPTIMISATION_LEVEL is set to CRC_OPTIMISATION_HARDWARE, but no hardware implementation is available."
@@ -113,24 +109,22 @@ namespace genericCrc
     {
         (void)start;
 #if (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_SPEED)
-        // start is the first byte of the data to be GenericCRC'd.
-        // data is a pointer to the data to be GenericCRC'd.
-
-        // Calculate the CRC8 DVB S2 value.
         uint8_t crc = crc_8_dvb_s2_table[0 ^ data[offset]];
+
         for (uint8_t i = offset + 1; i < length; i++)
         {
             crc = crc_8_dvb_s2_table[crc ^ data[i]];
         }
 
-        // Return the CRC8 DVB S2 value.
         return crc;
 #elif (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_SIZE)
         uint8_t crc = crc_8_dvb_s2(0, data[offset]);
+
         for (uint8_t i = offset + 1; i < length; i++)
         {
             crc = crc_8_dvb_s2(crc, data[i]);
         }
+
         return crc;
 #elif (CRC_OPTIMISATION_LEVEL == CRC_OPTIMISATION_HARDWARE)
 #error "CRC_OPTIMISATION_LEVEL is set to CRC_OPTIMISATION_HARDWARE, but no hardware implementation is available."

--- a/src/SerialReceiver/CRC/CRC.hpp
+++ b/src/SerialReceiver/CRC/CRC.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic CRC8 implementation for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -40,6 +40,7 @@ namespace serialReceiverLayer
     CRSF::~CRSF()
     {
         delete crc8;
+        crc8 = nullptr;
     }
 
     void CRSF::begin()

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This decodes CRSF frames from a serial port.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -48,24 +48,14 @@ namespace serialReceiverLayer
         frameCount = 0;
         timePerFrame = 0;
 
-        // #ifdef USE_DMA
-        //         memset_dma(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-        //         memset_dma(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-        // #else
         memset(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
         memset(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-        // #endif
     }
 
     void CRSF::end()
     {
-        // #ifdef USE_DMA
-        //         memset_dma(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-        //         memset_dma(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-        // #else
         memset(rcChannelsFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
         memset(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-        // #endif
 
         timePerFrame = 0;
         frameCount = 0;
@@ -120,15 +110,7 @@ namespace serialReceiverLayer
                         case crsfProtocol::CRSF_FRAMETYPE_RC_CHANNELS_PACKED:
                             if (rxFrame.frame.deviceAddress == CRSF_ADDRESS_FLIGHT_CONTROLLER)
                             {
-                                // #ifdef USE_DMA
-                                // #ifdef __SAMD51__
-                                //                                 memcpy(&rcChannelsFrame, &rxFrame, CRSF_FRAME_SIZE_MAX); // ◄ This is a workaround for the crash on SAMD51.
-                                // #else
-                                //                                 memcpy_dma(&rcChannelsFrame, &rxFrame, CRSF_FRAME_SIZE_MAX); // ◄ This is the line that causes the crash on SAMD51.
-                                // #endif
-                                // #else
                                 memcpy(&rcChannelsFrame, &rxFrame, CRSF_FRAME_SIZE_MAX);
-                                // #endif
                                 rcFrameReceived = true;
                             }
                             break;
@@ -149,11 +131,8 @@ namespace serialReceiverLayer
 #endif
                     }
                 }
-                // #ifdef USE_DMA
-                //                 memset_dma(&rxFrame, 0, CRSF_FRAME_SIZE_MAX); // ◄ This line works fine on both SAMD21 and SAMD51.
-                // #else
+
                 memset(rxFrame.raw, 0, CRSF_FRAME_SIZE_MAX);
-                // #endif
                 framePosition = 0;
 
                 return true;

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -191,6 +191,7 @@ namespace serialReceiverLayer
 #if CRSF_LINK_STATISTICS_ENABLED > 0
         memcpy(linkStats, &linkStatistics, sizeof(link_statistics_t));
 #else
+        (void)linkStats;
 #endif
     }
 

--- a/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/SerialReceiver/CRSF/CRSF.hpp
@@ -71,7 +71,7 @@ namespace serialReceiverLayer
         crsfProtocol::frame_t rxFrame;
         crsfProtocol::frame_t rcChannelsFrame;
         link_statistics_t linkStatistics;
-        genericCrc::GenericCRC *crc8;
+        genericCrc::GenericCRC *crc8 = nullptr;
         uint8_t calculateFrameCRC();
     };
 } // namespace serialReceiverLayer

--- a/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/SerialReceiver/CRSF/CRSF.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This decodes CRSF frames from a serial port.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/SerialReceiver/CRSF/CRSF.hpp
@@ -31,7 +31,6 @@
 
 namespace serialReceiverLayer
 {
-    // #if CRSF_LINK_STATISTICS_ENABLED > 0
     typedef struct link_statistics_s
     {
         int16_t rssi = 0;
@@ -51,7 +50,6 @@ namespace serialReceiverLayer
         250,  // 250 mW
         50    // 50 mW
     };
-    // #endif
 
     class CRSF
     {

--- a/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -54,7 +54,6 @@ namespace genericStreamBuffer
         memset(buffer, 0, bufferSizeMax);
     }
 
-    // Write signed integers in little endian
     size_t SerialBuffer::write8(int8_t value)
     {
         if (bufferIndex + 1 > bufferSizeMax)
@@ -98,7 +97,6 @@ namespace genericStreamBuffer
         return 4;
     }
 
-    // Write unsigned integers in little endian
     size_t SerialBuffer::writeU8(uint8_t value)
     {
         if (bufferIndex + 1 > bufferSizeMax)
@@ -142,7 +140,6 @@ namespace genericStreamBuffer
         return 4;
     }
 
-    // Write signed integers in big endian
     size_t SerialBuffer::write8BE(int8_t value)
     {
         if (bufferIndex + 1 > bufferSizeMax)
@@ -186,7 +183,6 @@ namespace genericStreamBuffer
         return 4;
     }
 
-    // Write unsigned integers in big endian
     size_t SerialBuffer::writeU8BE(uint8_t value)
     {
         if (bufferIndex + 1 > bufferSizeMax)
@@ -245,7 +241,6 @@ namespace genericStreamBuffer
         return 4;
     }
 
-    // Write a string
     size_t SerialBuffer::writeString(const char *string)
     {
         size_t length = strlen(string);
@@ -262,25 +257,21 @@ namespace genericStreamBuffer
         return length;
     }
 
-    // Get the current buffer length
     size_t SerialBuffer::getLength()
     {
         return bufferLength;
     }
 
-    // Get the maximum buffer size
     size_t SerialBuffer::getMaxSize()
     {
         return bufferSizeMax;
     }
 
-    // Get the current buffer index
     size_t SerialBuffer::getIndex()
     {
         return bufferIndex;
     }
 
-    // Get the byte at the specified index
     uint8_t SerialBuffer::getByte(size_t index)
     {
         if (index >= bufferSizeMax)
@@ -291,7 +282,6 @@ namespace genericStreamBuffer
         return buffer[index];
     }
 
-    // Get the buffer
     uint8_t *SerialBuffer::getBuffer()
     {
         return buffer;

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic serial buffer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -51,11 +51,7 @@ namespace genericStreamBuffer
     {
         bufferIndex = 0;
         bufferLength = 0;
-        // #ifdef USE_DMA
-        //         memset_dma(buffer, 0, bufferSizeMax);
-        // #else
         memset(buffer, 0, bufferSizeMax);
-        // #endif
     }
 
     // Write signed integers in little endian

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic serial buffer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -39,43 +39,33 @@ namespace genericStreamBuffer
 
         void reset();
 
-        // Write signed integers in little endian
         size_t write8(int8_t value);
         size_t write16(int16_t value);
         size_t write32(int32_t value);
 
-        // Write unsigned integers in little endian
         size_t writeU8(uint8_t value);
         size_t writeU16(uint16_t value);
         size_t writeU32(uint32_t value);
 
-        // Write signed integers in big endian
         size_t write8BE(int8_t value);
         size_t write16BE(int16_t value);
         size_t write32BE(int32_t value);
 
-        // Write unsigned integers in big endian
         size_t writeU8BE(uint8_t value);
         size_t writeU16BE(uint16_t value);
         size_t writeU24BE(uint32_t value);
         size_t writeU32BE(uint32_t value);
 
-        // Write a string
         size_t writeString(const char *string);
 
-        // Get the current buffer length
         size_t getLength();
 
-        // Get the maximum buffer size
         size_t getMaxSize();
 
-        // Get the current buffer index
         size_t getIndex();
 
-        // Get the byte at the specified index
         uint8_t getByte(size_t index);
 
-        // Get the buffer
         uint8_t *getBuffer();
 
       private:

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -336,7 +336,7 @@ namespace serialReceiverLayer
         {
             for (size_t i = 0; i < (size_t)FLIGHT_MODE_COUNT; i++)
             {
-                if (_rcChannels[_flightModes[i].channel] >= _flightModes[i].min && _rcChannels[_flightModes[i].channel] <= _flightModes[i].max)
+                if (_rcChannels->value[_flightModes[i].channel] >= _flightModes[i].min && _rcChannels->value[_flightModes[i].channel] <= _flightModes[i].max)
                 {
                     _flightModeCallback((flightModeId_t)i);
                     break;

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -82,6 +82,7 @@ namespace serialReceiverLayer
         _rcChannels = nullptr;
 #if CRSF_FLIGHTMODES_ENABLED > 0
         delete[] _flightModes;
+        _flightModes = nullptr;
 #endif
 #endif
     }
@@ -152,17 +153,6 @@ namespace serialReceiverLayer
 
         // Initialize the CRSF Protocol.
         crsf = new CRSF();
-
-        // Check that the CRSF Protocol was initialized successfully.
-        if (crsf == nullptr)
-        {
-#if CRSF_DEBUG_ENABLED > 0
-            // Debug.
-            CRSF_DEBUG_SERIAL_PORT.println("\n[Serial Receiver | FATAL ERROR]: CRSF Protocol could not be initialized.");
-#endif
-            return false;
-        }
-
         crsf->begin();
         crsf->setFrameTime(BAUD_RATE, 10);
         _uart->begin(BAUD_RATE);
@@ -170,17 +160,6 @@ namespace serialReceiverLayer
 #if CRSF_TELEMETRY_ENABLED > 0
         // Initialise telemetry.
         telemetry = new Telemetry();
-
-        // Check that the telemetry was initialised successfully.
-        if (telemetry == nullptr)
-        {
-#if CRSF_DEBUG_ENABLED > 0
-            // Debug.
-            CRSF_DEBUG_SERIAL_PORT.println("\n[Serial Receiver | FATAL ERROR]: Telemetry could not be initialized.");
-#endif
-            return false;
-        }
-
         telemetry->begin();
 #endif
 
@@ -213,6 +192,7 @@ namespace serialReceiverLayer
         {
             crsf->end();
             delete crsf;
+            crsf = nullptr;
         }
 
 #if CRSF_TELEMETRY_ENABLED > 0
@@ -221,6 +201,7 @@ namespace serialReceiverLayer
         {
             telemetry->end();
             delete telemetry;
+            telemetry = nullptr;
         }
 #endif
     }

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -397,49 +397,49 @@ namespace serialReceiverLayer
         {
             switch (flightMode)
             {
-            case FLIGHT_MODE_FAILSAFE:
-                flightModeStr = "!FS!";
-                break;
-            case FLIGHT_MODE_GPS_RESCUE:
-                flightModeStr = "RTH";
-                break;
-            case FLIGHT_MODE_PASSTHROUGH:
-                flightModeStr = "MANU";
-                break;
-            case FLIGHT_MODE_ANGLE:
-                flightModeStr = "STAB";
-                break;
-            case FLIGHT_MODE_HORIZON:
-                flightModeStr = "HOR";
-                break;
-            case FLIGHT_MODE_AIRMODE:
-                flightModeStr = "AIR";
-                break;
+                case FLIGHT_MODE_FAILSAFE:
+                    flightModeStr = "!FS!";
+                    break;
+                case FLIGHT_MODE_GPS_RESCUE:
+                    flightModeStr = "RTH";
+                    break;
+                case FLIGHT_MODE_PASSTHROUGH:
+                    flightModeStr = "MANU";
+                    break;
+                case FLIGHT_MODE_ANGLE:
+                    flightModeStr = "STAB";
+                    break;
+                case FLIGHT_MODE_HORIZON:
+                    flightModeStr = "HOR";
+                    break;
+                case FLIGHT_MODE_AIRMODE:
+                    flightModeStr = "AIR";
+                    break;
 
 #if CRSF_CUSTOM_FLIGHT_MODES_ENABLED > 0
-            /* All 8 custom flight modes are handled here. */
-            case CUSTOM_FLIGHT_MODE1:
-                [[fallthrough]];
-            case CUSTOM_FLIGHT_MODE2:
-                [[fallthrough]];
-            case CUSTOM_FLIGHT_MODE3:
-                [[fallthrough]];
-            case CUSTOM_FLIGHT_MODE4:
-                [[fallthrough]];
-            case CUSTOM_FLIGHT_MODE5:
-                [[fallthrough]];
-            case CUSTOM_FLIGHT_MODE6:
-                [[fallthrough]];
-            case CUSTOM_FLIGHT_MODE7:
-                [[fallthrough]];
-            case CUSTOM_FLIGHT_MODE8:
-                flightModeStr = _flightModes[flightMode].name;
-                break;
+                /* All 8 custom flight modes are handled here. */
+                case CUSTOM_FLIGHT_MODE1:
+                    [[fallthrough]];
+                case CUSTOM_FLIGHT_MODE2:
+                    [[fallthrough]];
+                case CUSTOM_FLIGHT_MODE3:
+                    [[fallthrough]];
+                case CUSTOM_FLIGHT_MODE4:
+                    [[fallthrough]];
+                case CUSTOM_FLIGHT_MODE5:
+                    [[fallthrough]];
+                case CUSTOM_FLIGHT_MODE6:
+                    [[fallthrough]];
+                case CUSTOM_FLIGHT_MODE7:
+                    [[fallthrough]];
+                case CUSTOM_FLIGHT_MODE8:
+                    flightModeStr = _flightModes[flightMode].name;
+                    break;
 #endif
 
-            default:
-                flightModeStr = "ACRO";
-                break;
+                default:
+                    flightModeStr = "ACRO";
+                    break;
             }
         }
         else

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -310,6 +310,27 @@ namespace serialReceiverLayer
     }
 
 #if CRSF_FLIGHTMODES_ENABLED > 0
+    bool SerialReceiver::setFlightMode(flightModeId_t flightModeId, const char *flightModeName, uint8_t channel, uint16_t min, uint16_t max)
+    {
+        if (flightModeId < FLIGHT_MODE_COUNT && flightModeName != nullptr && channel <= 15)
+        {
+            if (strlen(flightModeName) > 16)
+            {
+                return false;
+            }
+
+            _flightModes[flightModeId].name = flightModeName;
+            _flightModes[flightModeId].channel = channel;
+            _flightModes[flightModeId].min = min;
+            _flightModes[flightModeId].max = max;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     [[deprecated]] bool SerialReceiver::setFlightMode(flightModeId_t flightMode, uint8_t channel, uint16_t min, uint16_t max)
     {
         if (flightMode < FLIGHT_MODE_COUNT && channel <= 15)
@@ -394,6 +415,28 @@ namespace serialReceiverLayer
             case FLIGHT_MODE_AIRMODE:
                 flightModeStr = "AIR";
                 break;
+
+#if CRSF_CUSTOM_FLIGHT_MODES_ENABLED > 0
+            /* All 8 custom flight modes are handled here. */
+            case CUSTOM_FLIGHT_MODE1:
+                [[fallthrough]];
+            case CUSTOM_FLIGHT_MODE2:
+                [[fallthrough]];
+            case CUSTOM_FLIGHT_MODE3:
+                [[fallthrough]];
+            case CUSTOM_FLIGHT_MODE4:
+                [[fallthrough]];
+            case CUSTOM_FLIGHT_MODE5:
+                [[fallthrough]];
+            case CUSTOM_FLIGHT_MODE6:
+                [[fallthrough]];
+            case CUSTOM_FLIGHT_MODE7:
+                [[fallthrough]];
+            case CUSTOM_FLIGHT_MODE8:
+                flightModeStr = _flightModes[flightMode].name;
+                break;
+#endif
+
             default:
                 flightModeStr = "ACRO";
                 break;

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -397,7 +397,6 @@ namespace serialReceiverLayer
                 break;
         }
 
-        // Serial.println(flightModeStr);
         telemetry->setFlightModeData(flightModeStr, (bool)(flightModeId == FLIGHT_MODE_DISARMED ? true : false));
     }
 #endif

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -310,7 +310,7 @@ namespace serialReceiverLayer
     }
 
 #if CRSF_FLIGHTMODES_ENABLED > 0
-    bool SerialReceiver::setFlightMode(flightModeId_t flightMode, uint8_t channel, uint16_t min, uint16_t max)
+    [[deprecated]] bool SerialReceiver::setFlightMode(flightModeId_t flightMode, uint8_t channel, uint16_t min, uint16_t max)
     {
         if (flightMode < FLIGHT_MODE_COUNT && channel <= 15)
         {

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -370,10 +370,12 @@ namespace serialReceiverLayer
 #endif
 
 #if CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
-    void SerialReceiver::telemetryWriteFlightMode(flightModeId_t flightModeId)
+    void SerialReceiver::telemetryWriteFlightMode(flightModeId_t flightMode, bool disarmed)
     {
-        switch (flightModeId)
+        if (flightMode != FLIGHT_MODE_DISARMED)
         {
+            switch (flightMode)
+            {
             case FLIGHT_MODE_FAILSAFE:
                 flightModeStr = "!FS!";
                 break;
@@ -395,14 +397,17 @@ namespace serialReceiverLayer
             default:
                 flightModeStr = "ACRO";
                 break;
+            }
+        }
+        else
+        {
+            disarmed = true;
         }
 
-        telemetry->setFlightModeData(flightModeStr, (bool)(flightModeId == FLIGHT_MODE_DISARMED ? true : false));
+        telemetry->setFlightModeData(flightModeStr, disarmed);
     }
-#endif
 
-#if CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
-    void SerialReceiver::telemetryWriteCustomFlightMode(const char *flightModeStr, bool armed = true)
+    void SerialReceiver::telemetryWriteCustomFlightMode(const char *flightModeStr, bool armed)
     {
         telemetry->setFlightModeData(flightModeStr, armed);
     }

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Serial Receiver layer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -230,17 +230,17 @@ namespace serialReceiverLayer
                     telemetry->sendTelemetryData(_uart);
                 }
 #endif
-            }
-        }
 
 #if CRSF_RC_ENABLED > 0
-        crsf->getFailSafe(&_rcChannels->failsafe);
-        crsf->getRcChannels(_rcChannels->value);
-        if (_rcChannelsCallback != nullptr)
-        {
-            _rcChannelsCallback(_rcChannels);
-        }
+                crsf->getFailSafe(&_rcChannels->failsafe);
+                crsf->getRcChannels(_rcChannels->value);
+                if (_rcChannelsCallback != nullptr)
+                {
+                    _rcChannelsCallback(_rcChannels);
+                }
 #endif
+            }
+        }
     }
 #endif
 

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -92,7 +92,6 @@ namespace serialReceiverLayer
         // Debug.
         CRSF_DEBUG_SERIAL_PORT.print("[Serial Receiver | INFO]: Initialising... ");
 #endif
-        // _uart->enterCriticalSection();
 
 #if CRSF_RC_ENABLED > 0 && CRSF_RC_INITIALISE_CHANNELS > 0
         // Initialize the RC Channels.
@@ -140,7 +139,6 @@ namespace serialReceiverLayer
         {
             delete ct;
             ct = nullptr;
-            // _uart->exitCriticalSection();
 
 #if CRSF_DEBUG_ENABLED > 0
             // Debug.
@@ -158,8 +156,6 @@ namespace serialReceiverLayer
         // Check that the CRSF Protocol was initialized successfully.
         if (crsf == nullptr)
         {
-            // _uart->exitCriticalSection();
-
 #if CRSF_DEBUG_ENABLED > 0
             // Debug.
             CRSF_DEBUG_SERIAL_PORT.println("\n[Serial Receiver | FATAL ERROR]: CRSF Protocol could not be initialized.");
@@ -178,8 +174,6 @@ namespace serialReceiverLayer
         // Check that the telemetry was initialised successfully.
         if (telemetry == nullptr)
         {
-            // _uart->exitCriticalSection();
-
 #if CRSF_DEBUG_ENABLED > 0
             // Debug.
             CRSF_DEBUG_SERIAL_PORT.println("\n[Serial Receiver | FATAL ERROR]: Telemetry could not be initialized.");
@@ -189,8 +183,6 @@ namespace serialReceiverLayer
 
         telemetry->begin();
 #endif
-
-        // _uart->exitCriticalSection();
 
         // Clear the UART buffer.
         _uart->flush();
@@ -214,9 +206,7 @@ namespace serialReceiverLayer
             _uart->read();
         }
 
-        // _uart->enterCriticalSection();
         _uart->end();
-        // _uart->clearUART();
 
         // Check if the CRSF Protocol was initialized.
         if (crsf != nullptr)
@@ -233,7 +223,6 @@ namespace serialReceiverLayer
             delete telemetry;
         }
 #endif
-        // _uart->exitCriticalSection();
     }
 
 #if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0 || CRSF_LINK_STATISTICS_ENABLED > 0

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -407,7 +407,7 @@ namespace serialReceiverLayer
         telemetry->setFlightModeData(flightModeStr, disarmed);
     }
 
-    void SerialReceiver::telemetryWriteCustomFlightMode(const char *flightModeStr, bool armed)
+    [[deprecated]] void SerialReceiver::telemetryWriteCustomFlightMode(const char *flightModeStr, bool armed)
     {
         telemetry->setFlightModeData(flightModeStr, armed);
     }

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -54,13 +54,9 @@ namespace serialReceiverLayer
         uint16_t value[crsfProtocol::RC_CHANNEL_COUNT];
     } rcChannels_t;
 
-    // Function pointer for RC Channels Callback
+    /* Function pointers for callbacks. */
     typedef void (*rcChannelsCallback_t)(rcChannels_t *);
-
-    // Function pointer for Flight Mode Callback
     typedef void (*flightModeCallback_t)(flightModeId_t);
-
-    // Function pointer for Link Statistics Callback
     typedef void (*linkStatisticsCallback_t)(link_statistics_t);
 
     class SerialReceiver

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -95,7 +95,7 @@ namespace serialReceiverLayer
         void telemetryWriteAttitude(int16_t roll, int16_t pitch, int16_t yaw);
         void telemetryWriteBaroAltitude(uint16_t altitude, int16_t vario);
         void telemetryWriteBattery(float voltage, float current, uint32_t fuel, uint8_t percent);
-        void telemetryWriteFlightMode(flightModeId_t flightMode);
+        void telemetryWriteFlightMode(flightModeId_t flightMode, bool disarmed = false);
         void telemetryWriteCustomFlightMode(const char *flightMode, bool armed = true);
         void telemetryWriteGPS(float latitude, float longitude, float altitude, float speed, float groundCourse, uint8_t satellites);
 #endif

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Serial Receiver layer for the CRSF for Arduino library.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -44,6 +44,17 @@ namespace serialReceiverLayer
         FLIGHT_MODE_ANGLE,
         FLIGHT_MODE_HORIZON,
         FLIGHT_MODE_AIRMODE,
+
+#if CRSF_CUSTOM_FLIGHT_MODES_ENABLED > 0
+        CUSTOM_FLIGHT_MODE1,
+        CUSTOM_FLIGHT_MODE2,
+        CUSTOM_FLIGHT_MODE3,
+        CUSTOM_FLIGHT_MODE4,
+        CUSTOM_FLIGHT_MODE5,
+        CUSTOM_FLIGHT_MODE6,
+        CUSTOM_FLIGHT_MODE7,
+        CUSTOM_FLIGHT_MODE8,
+#endif
         FLIGHT_MODE_COUNT
     } flightModeId_t;
 
@@ -85,6 +96,7 @@ namespace serialReceiverLayer
         uint16_t readRcChannel(uint8_t channel, bool raw = false);
 
 #if CRSF_FLIGHTMODES_ENABLED > 0
+        bool setFlightMode(flightModeId_t flightModeId, const char *flightModeName, uint8_t channel, uint16_t min, uint16_t max);
         bool setFlightMode(flightModeId_t flightMode, uint8_t channel, uint16_t min, uint16_t max);
         void setFlightModeCallback(flightModeCallback_t callback);
         void handleFlightMode();
@@ -125,6 +137,7 @@ namespace serialReceiverLayer
 #if CRSF_RC_ENABLED > 0 && CRSF_FLIGHTMODES_ENABLED > 0
         typedef struct flightMode_s
         {
+            const char *name = nullptr;
             uint8_t channel = 0;
             uint16_t min = 0;
             uint16_t max = 0;

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -234,7 +234,6 @@ namespace serialReceiverLayer
 
     int16_t Telemetry::_decidegreeToRadians(int16_t decidegrees)
     {
-        /* convert angle in decidegree to radians/10000 with reducing angle to +/-180 degree range */
         while (decidegrees > 18000)
         {
             decidegrees -= 36000;
@@ -284,7 +283,6 @@ namespace serialReceiverLayer
 
     void Telemetry::_appendFlightModeData()
     {
-        // Return if the length of the flight mode string is greater than the flight mode payload size.
         size_t length = strlen(_telemetryData.flightMode.flightMode) + 1;
         if (length > CRSF_FRAME_FLIGHT_MODE_PAYLOAD_SIZE)
         {

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This encodes data into CRSF telemetry frames for transmission to the RC handset.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -202,6 +202,7 @@ namespace serialReceiverLayer
         }
 #else
         (void)flightMode;
+        (void)armed;
 #endif
     }
 

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -39,7 +39,8 @@ namespace serialReceiverLayer
 #define RAD PI / 180.0F
 #endif
 
-    Telemetry::Telemetry() : SerialBuffer(CRSF_FRAME_SIZE_MAX)
+    Telemetry::Telemetry() :
+        SerialBuffer(CRSF_FRAME_SIZE_MAX)
     {
         _telemetryFrameScheduleCount = 0;
         memset(_telemetryFrameSchedule, 0, sizeof(_telemetryFrameSchedule));

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -39,8 +39,7 @@ namespace serialReceiverLayer
 #define RAD PI / 180.0F
 #endif
 
-    Telemetry::Telemetry() :
-        GenericCRC(), SerialBuffer(CRSF_FRAME_SIZE_MAX)
+    Telemetry::Telemetry() : SerialBuffer(CRSF_FRAME_SIZE_MAX)
     {
         _telemetryFrameScheduleCount = 0;
         memset(_telemetryFrameSchedule, 0, sizeof(_telemetryFrameSchedule));

--- a/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This encodes data into CRSF telemetry frames for transmission to the RC handset.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -50,7 +50,6 @@ namespace serialReceiverLayer
         void setBatteryData(float voltage, float current, uint32_t capacity, uint8_t percent);
         void setFlightModeData(const char *flightMode, bool armed = false);
         void setGPSData(float latitude, float longitude, float altitude, float speed, float course, uint8_t satellites);
-        // void setVarioData(float vario);
 
         void sendTelemetryData(HardwareSerial *db);
 
@@ -67,8 +66,6 @@ namespace serialReceiverLayer
         void _appendBatterySensorData();
         void _appendFlightModeData();
         void _appendGPSData();
-        // void _appendHeartbeatData();
-        // void _appendVarioData();
         void _finaliseFrame();
     };
 } // namespace serialReceiverLayer

--- a/src/hal/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.cpp
@@ -36,8 +36,6 @@ namespace hal
      */
     CompatibilityTable::CompatibilityTable()
     {
-// TEMPORARILY DISABLED: Arduino IDE must be 1.7.0 or greater
-// #if ARDUINO >= 10700
 
 // Arduino ESP32 Architecture
 #if defined(ARDUINO_ARCH_ESP32)
@@ -566,10 +564,6 @@ as two separate boards. To prevent a false negative, check for both boards. */
 #error "Unsupported architecture. CRSF for Arduino only supports the ESP32, SAMD, and Teensy architectures."
         device.type.devboard = DEVBOARD_IS_INCOMPATIBLE;
 #endif // ARDUINO_ARCH_SAMD
-
-        // #else
-        // #error "This library requires Arduino IDE 1.7.0 or greater. Please update your IDE."
-        // #endif // ARDUINO >= 10700
     }
 
     CompatibilityTable::~CompatibilityTable()

--- a/src/hal/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.cpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Compatibility Table determines if the target development board is compatible with CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/hal/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.hpp
@@ -3,7 +3,7 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Compatibility Table determines if the target development board is compatible with CRSF for Arduino.
  * @version 1.0.0
- * @date 2024-2-14
+ * @date 2024-2-18
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/targets/common.ini
+++ b/targets/common.ini
@@ -33,6 +33,7 @@ platform = teensy@4.18.0
 [env]
 framework = arduino
 build_src_filter = 
+    -<../examples/platformio/cfa_code_test.cpp>
     +<../examples/platformio/main.cpp>
     +<*/*/*.cpp>
     +<*.cpp>


### PR DESCRIPTION
## Overview

This Pull Request is the "final touches" I need to do with the code-base _before_ it's released.  
It brings in some much needed housekeeping, and quality-of-life fixes.

## Details

### Deleted...

- CoPilot Prompts.
- Deprecated code.
- Unnecessary code.
- Unnecessary comments.

### Disabled...

- Arduino CI compile-testing on "supported platforms", until Adafruit fixes a bug with CI on their end.

### Fixes...

- Class constructors being called twice. EG `serialReceiverLayer::SerialReceiver::SerialReceiver();`
- Compiler warnings.
- Memory leaks.

### Re-factors...

- Flight Modes API
- Custom Flight Modes integration

### API changes

#### Flight Modes API

Both standard and custom flight modes are registered with this function:

- `setFlightMode(serialReceiverLayer::flightModeId_t flightModeId, const char *flightModeName, uint8_t channel, uint16_t min, uint16_t max)`
  - `flightModeId` is the same Flight Mode constants you all have been using, thus far.
  - `flightModeName` allows you to give your flight mode a name to identify it.
    This is particularly useful for Custom Flight Modes.
  - `channel` is your chosen channel number from `1` to `16`.
  - `min` is the minimum channel value (in microseconds) that will trigger this mode.
  - `max` is the maximum  channel value (in microseconds) that will trigger this mode.

Both standard Flight Modes and custom Flight Modes are written out using this function:

- `telemetryWriteFlightMode(serialReceiverLayer::flightModeId_t flightMode, bool disarmed)`
  - `flightMode` is the Flight Mode ID to pass in.
  - `disarmed` is whether-or-not you have flicked your Disarmed channel (Usually `Aux1` for ExpressLRS) or not.
    - `true` means it is disarmed.
    - `false` means it is armed.

An example usage situation looks like this:

```cpp
#include "Arduino.h"
#include "CRSFforArduino.hpp"

/* Define our modes up here, including putting ARM on Channel 5 (Aux1). */
#define FLIGHT_MODE_ARM_CHANNEL 5
#define FLIGHT_MODE_ARM_MIN     1000
#define FLIGHT_MODE_ARM_MAX     1800

#define FLIGHT_MODE_NORMAL_CHANNEL 6
#define FLIGHT_MODE_NORMAL_MIN     750
#define FLIGHT_MODE_NORMAL_MAX     1250

#define FLIGHT_MODE_IDLEUP1_CHANNEL 6
#define FLIGHT_MODE_IDLEUP1_MIN     1250
#define FLIGHT_MODE_IDLEUP1_MAX     1750

#define FLIGHT_MODE_IDLEUP2_CHANNEL 6
#define FLIGHT_MODE_IDLEUP2_MIN     1750
#define FLIGHT_MODE_IDLEUP2_MAX     2250

/* Pointer to CRSF for Arduino. */
CRSFforArduino *crsf = nullptr;

/* Our Flight Modes handler may be declared here. */
void onFlightModeUpdate(serialReceiverLayer::flightModeId_t);

void setup()
{
    /* Initialise the native USB port and wait for it to be ready. */
    Serial.begin(115200);
    while (!Serial)
    {
        delay(10);
    }

    Serial.println("[Sketch | INFO]: CRSF for Arduino Example");

    /* Create a new CRSF for Arduino object and initialise it. */
    crsf = new CRSFforArduino();
    if (!crsf->begin())
    {
        /* CRSF for Arduino failed to initialise.
        Tear-down and clean up any resources what were allocated. */
        crsf->end();
        delete crsf;
        crsf = nullptr;

        Serial.println("[Sketch | ERROR]: CRSF failed to initialise.");
    }
    else
    {
        /* CRSF for Arduino successfully initialised.
        Now, register the custom flight modes, along with the Disarmed mode. */
        crsf->setFlightMode(serialReceiverLayer::FLIGHT_MODE_DISARMED, FLIGHT_MODE_ARM_CHANNEL, FLIGHT_MODE_ARM_MIN, FLIGHT_MODE_ARM_MAX);
        crsf->setFlightMode(serialReceiverLayer::CUSTOM_FLIGHT_MODE1, "Normal", FLIGHT_MODE_NORMAL_CHANNEL, FLIGHT_MODE_NORMAL_MIN, FLIGHT_MODE_NORMAL_MAX);
        crsf->setFlightMode(serialReceiverLayer::CUSTOM_FLIGHT_MODE2, "Idle-Up 1", FLIGHT_MODE_IDLEUP1_CHANNEL, FLIGHT_MODE_IDLEUP1_MIN, FLIGHT_MODE_IDLEUP1_MAX);
        crsf->setFlightMode(serialReceiverLayer::CUSTOM_FLIGHT_MODE3, "Idle-Up 2", FLIGHT_MODE_IDLEUP2_CHANNEL, FLIGHT_MODE_IDLEUP2_MIN, FLIGHT_MODE_IDLEUP2_MAX);

        /* Set the Flight Modes callback. */
        crsf->setFlightModeCallback(onFlightModeUpdate);

        Serial.println("[Sketch | INFO]: CRSF initialised.");
    }
}

void loop()
{
    /* Guard CRSF for Arduino. */
    if (crsf != nullptr)
    {
        /* Update CRSF for Arduino. */
        crsf->update();
    }
}

void onFlightModeUpdate(serialReceiverLayer::flightModeId_t flightMode)
{
    /* This is our Flight Modes callback that we declared earlier.
    Whenever a Flight Mode is changed, this is what gets called.
    You may write your own Flight Modes implementation using this callback function.
    For the purposes of this example, simply relaying the flight modes back to the handset is shown here,
    and the modes are printed to the Serial Monitor. */

    /* Are we disarmed? */
    bool isDisarmed = true;
    if (flightMode != serialReceiverLayer::FLIGHT_MODE_DISARMED)
    {
        isDisarmed = false;
    }
    else if (isFailsafeActive)
    {
        isDisarmed = true;
    }

    /* Update the flight mode telemetry with the new value. */
    crsf->telemetryWriteFlightMode(flightMode, isDisarmed);


    /* Print the flight mode to the Serial Monitor, but only if the flight mode has changed. */
    static serialReceiverLayer::flightModeId_t lastFlightMode = serialReceiverLayer::FLIGHT_MODE_DISARMED;
    if (flightMode != lastFlightMode)
    {
        lastFlightMode = flightMode;

        Serial.print("[Sketch | INFO]: Flight Mode: ");
        switch (flightMode)
        {
            case serialReceiverLayer::FLIGHT_MODE_DISARMED:
                Serial.println("Disarmed");
                break;
            case serialReceiverLayer::CUSTOM_FLIGHT_MODE1:
                Serial.println("Normal");
                break;
            case serialReceiverLayer::CUSTOM_FLIGHT_MODE2:
                Serial.println("Idle Up 1");
                break;
            case serialReceiverLayer::CUSTOM_FLIGHT_MODE3:
                Serial.println("Idle Up 2");
                break;
            default:
                Serial.println("Unknown");
                break;
        }
    }
}
```

In order to use the API above, you `MUST` have the following flags set in `CFA_Config.hpp`:

- `CRSF_FLIGHTMODES_ENABLED` set to `1`
- CRSF_CUSTOM_FLIGHT_MODES_ENABLED set to `1` if you want access to the Custom Flight Modes integration.

This is also assuming that you have `CRSF_RC_ENABLED` set to `1` (which is the default, by the way. Because the entire library relies on this for _everything_), and you  have `CRSF_TELEMETRY_ENABLED` set to `1` if you want your Flight Modes to be fed back to your controller.

## Additional

Now that this is complete. All that is left is the documentation.  
Then, CRSF for Arduino version 1.0.0 will be released to the public.

Thank you all from the bottom of my heart for being here, and using my library in your projects.  
A huge thanks to those daring enough to try out CRSF for Arduino in its various stages of jankiness-to-refinement and everything in between.