### PR TITLE
fix(targets): Refine ESP32 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # PlatformIO specific files
 test/README
 examples/platformio/cfa_code_test.cpp
+examples/platformio/hac_driver_test.cpp
+examples/platformio/hw_multi_mutex_test.cpp
+examples/platformio/hw_mutex_test.cpp
 
 # Template files for CRSF for Arduino
 templates/

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -39,8 +39,8 @@ See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION       "1.1.0"
 #define CRSFFORARDUINO_VERSION_DATE  "2024-3-8"
 #define CRSFFORARDUINO_VERSION_MAJOR 1
-#define CRSFFORARDUINO_VERSION_MINOR 0
-#define CRSFFORARDUINO_VERSION_PATCH 1
+#define CRSFFORARDUINO_VERSION_MINOR 1
+#define CRSFFORARDUINO_VERSION_PATCH 0
 
 /* Failsafe Options
 - CRSF_FAILSAFE_LQI_THRESHOLD: The minimum LQI value for the receiver to be considered connected.

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -44,7 +44,7 @@ namespace sketchLayer
      * @param rxPin 
      * @param txPin 
      */
-    CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort)
+    CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort, int rxPin, int txPin) : SerialReceiver(serialPort, rxPin, txPin)
     {
     }
 

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -39,6 +39,15 @@ namespace sketchLayer
     }
 
     /**
+     * @brief Construct a new CRSFforArduino object with the specified serial port.
+     * 
+     * @param serialPort 
+     */
+    CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort) : SerialReceiver(serialPort)
+    {
+    }
+
+    /**
      * @brief Construct a new CRSFforArduino object with the specified RX and TX pins.
      * 
      * @param rxPin 

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -44,7 +44,7 @@ namespace sketchLayer
      * @param rxPin 
      * @param txPin 
      */
-    CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort, int rxPin, int txPin) : SerialReceiver(serialPort, rxPin, txPin)
+    CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort, int rxPin, int txPin) /* : SerialReceiver(serialPort, rxPin, txPin) */
     {
     }
 

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -34,7 +34,7 @@ namespace sketchLayer
      * @brief Construct a new CRSFforArduino object.
      * 
      */
-    CRSFforArduino::CRSFforArduino()
+    CRSFforArduino::CRSFforArduino() : SerialReceiver()
     {
     }
 
@@ -44,7 +44,7 @@ namespace sketchLayer
      * @param rxPin 
      * @param txPin 
      */
-    CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort, int rxPin, int txPin) /* : SerialReceiver(serialPort, rxPin, txPin) */
+    CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort, int rxPin, int txPin) : SerialReceiver(serialPort, rxPin, txPin)
     {
     }
 

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -36,7 +36,8 @@ namespace sketchLayer
     {
       public:
         CRSFforArduino();
-        CRSFforArduino(HardwareSerial *serialPort, int rxPin = -1, int txPin = -1);
+        CRSFforArduino(HardwareSerial *serialPort);
+        CRSFforArduino(HardwareSerial *serialPort, int rxPin, int txPin);
         ~CRSFforArduino();
         bool begin();
         void end();

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -36,7 +36,7 @@ namespace sketchLayer
     {
       public:
         CRSFforArduino();
-        CRSFforArduino(HardwareSerial *serialPort);
+        CRSFforArduino(HardwareSerial *serialPort, int rxPin = -1, int txPin = -1);
         ~CRSFforArduino();
         bool begin();
         void end();

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -58,9 +58,17 @@ namespace serialReceiverLayer
 #endif
     }
 
-    SerialReceiver::SerialReceiver(HardwareSerial *hwUartPort)
+    SerialReceiver::SerialReceiver(HardwareSerial *hwUartPort, int8_t rxPin, int8_t txPin)
     {
         _uart = hwUartPort;
+
+#if defined(ARDUINO_ARCH_ESP32)
+        _rxPin = rxPin;
+        _txPin = txPin;
+#else
+        (void)rxPin;
+        (void)txPin;
+#endif
 
 #if CRSF_RC_ENABLED > 0
         _rcChannels = new rcChannels_t;
@@ -76,6 +84,9 @@ namespace serialReceiverLayer
     SerialReceiver::~SerialReceiver()
     {
         _uart = nullptr;
+
+        _rxPin = -1;
+        _txPin = -1;
 
 #if CRSF_RC_ENABLED > 0
         delete _rcChannels;
@@ -155,7 +166,11 @@ namespace serialReceiverLayer
         crsf = new CRSF();
         crsf->begin();
         crsf->setFrameTime(BAUD_RATE, 10);
+#if defined(ARDUINO_ARCH_ESP32)
+        _uart->begin(BAUD_RATE, SERIAL_8N1, _rxPin, _txPin);
+#else
         _uart->begin(BAUD_RATE);
+#endif
 
 #if CRSF_TELEMETRY_ENABLED > 0
         telemetry = new Telemetry();

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -43,6 +43,11 @@ namespace serialReceiverLayer
 #elif defined(HAVE_HWSERIAL3)
         _uart = &Serial3;
 #endif
+#elif defined(ARDUINO_ARCH_ESP32)
+        _uart = &Serial1;
+
+        _rxPin = 0;
+        _txPin = 1;
 #else
         _uart = &Serial1;
 #endif

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -46,8 +46,17 @@ namespace serialReceiverLayer
 #elif defined(ARDUINO_ARCH_ESP32)
         _uart = &Serial1;
 
+#if defined(D0)
+        _rxPin = D0;
+#else
         _rxPin = 0;
+#endif
+
+#if defined(D1)
+        _txPin = D1;
+#else
         _txPin = 1;
+#endif
 #else
         _uart = &Serial1;
 #endif
@@ -66,6 +75,20 @@ namespace serialReceiverLayer
     SerialReceiver::SerialReceiver(HardwareSerial *hwUartPort)
     {
         _uart = hwUartPort;
+
+#if defined(ARDUINO_ARCH_ESP32)
+        #if defined(D0)
+        _rxPin = D0;
+#else
+        _rxPin = 0;
+#endif
+
+#if defined(D1)
+        _txPin = D1;
+#else
+        _txPin = 1;
+#endif
+#endif
 
 #if CRSF_RC_ENABLED > 0
         _rcChannels = new rcChannels_t;

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -63,6 +63,21 @@ namespace serialReceiverLayer
 #endif
     }
 
+    SerialReceiver::SerialReceiver(HardwareSerial *hwUartPort)
+    {
+        _uart = hwUartPort;
+
+#if CRSF_RC_ENABLED > 0
+        _rcChannels = new rcChannels_t;
+        _rcChannels->valid = false;
+        _rcChannels->failsafe = false;
+        memset(_rcChannels->value, 0, sizeof(_rcChannels->value));
+#if CRSF_FLIGHTMODES_ENABLED > 0
+        _flightModes = new flightMode_t[FLIGHT_MODE_COUNT];
+#endif
+#endif
+    }
+
     SerialReceiver::SerialReceiver(HardwareSerial *hwUartPort, int8_t rxPin, int8_t txPin)
     {
         _uart = hwUartPort;

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -74,7 +74,8 @@ namespace serialReceiverLayer
     {
       public:
         SerialReceiver();
-        SerialReceiver(HardwareSerial *hwUartPort, int8_t rxPin = -1, int8_t txPin = -1);
+        SerialReceiver(HardwareSerial *hwUartPort);
+        SerialReceiver(HardwareSerial *hwUartPort, int8_t rxPin, int8_t txPin);
         virtual ~SerialReceiver();
 
         bool begin();

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -74,7 +74,7 @@ namespace serialReceiverLayer
     {
       public:
         SerialReceiver();
-        SerialReceiver(HardwareSerial *hwUartPort);
+        SerialReceiver(HardwareSerial *hwUartPort, int8_t rxPin = -1, int8_t txPin = -1);
         virtual ~SerialReceiver();
 
         bool begin();
@@ -115,6 +115,9 @@ namespace serialReceiverLayer
       private:
         CRSF *crsf;
         HardwareSerial *_uart;
+
+        int8_t _rxPin = -1;
+        int8_t _txPin = -1;
 
 #if CRSF_TELEMETRY_ENABLED > 0
         Telemetry *telemetry;


### PR DESCRIPTION
## Overview

This Pull Request fixes #97.

## Details

I had erroneously assumed that _all_ targets define their UART pin assignments via their respective constructors (which _is_ the case for  SAMD21, SAMD51/SAME51 targets), but it has been brought to my attention that _this_ is _not_ the case for ESP32 targets.

ESP32 assigns UART Rx and Tx pins in the `begin()` function as opposed to using a constructor.  
This has resulted in a lot of confusion around why things like RC Channels don't work on ESP32 targets and the inability to assign custom pins.  
This Pull Request aims to fix both of these issues.

### API changes

There is now a custom UART parameter that accepts custom pin assignments:

> [!NOTE]
> This constructor is currently _only_ available to ESP32 targets.
> Custom pin assignments for SSAMD21 and SAMD51 targets `SHOULD` still be done externally.

- `CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort, int rxPin, int txPin)`
  - **Parameters:**
    - `serialPort`  
      This is a pointer to your UART port. EG `Serial1`.
    - `rxPin`
        This is the pin number for your UART Rx pin.
    - `txPin`
        This is the pin number for your UART Tx pin.

### UART initialisation for ESP32 targets

When you pass in your pin numbers in the constructor, this tells CRSF for Arduino _what_ pins you are using.  
When you call `CRSFforArduino::begin()`, this internally calls the appropriate `HardwareSerial::begin()` function that's specific to ESP32 targets, where the pins that you provided in the constructor above get passed into this function.  
By rights, this `SHOULD` work.

If you use the default `CRSFforArduino::CRSFforArduino()` constructor, the pins for `Serial1` are internally set to `0` and `1` for Rx and Tx, respectively.

To initialise CRSF for Arduino with your ES32 target... especially if you want to use custom pins, this is what you do:

```cpp
#include "Arduino.h"
#include "CRSFforArduino.hpp"

#define CRSF_SERIAL_PORT Serial1
#define CRSF_RX_PIN 0
#define CRSF_TX_PIN 1

CRSFforArduino *crsf = nullptr;

void setup()
{
    /* Create an instance of CRSF for Arduino with your custom port and pins. */
    crsf = new CRSFforArduino(&CRSF_SERIAL_PORT, CRSF_RX_PIN, CRSF_TX_PIN);

    /* Initialise CRSF for Arduino how you would normally. */
    if (crsf->begin() == true)
    {
        /* You may initialise the rest of CRSF for Arduino here. */

        /* ... */

    }
    else
    {
        /* CRSF for Arduino failed to initialise.
        Its resources MUST be released. */
        crsf->end();
        delete crsf;
        crsf = nullptr;
    }
}

void loop()
{
    /* As always, it's good practice to guard CRSF for Arduino. */
    if (crsf != nullptr)
    {
        crsf->update();
    }
}
```

## Additional

I have been made aware that, for some reason, installing the .ZIP file in the Arduino IDE is failing.  
From what I have tested on my end, apparently the error flag that comes up is something along the lines of CRSF for Arduino already existing, but at a different version.  
EG If you have already installed Version 1.0.0, Arduino IDE will tell you `Installation failed: CRSFforArduino already exists, but with a different version. CRSFforArduino @ 1.0.0`

### Workaround 1

Extract the zip file and manually install CRSF for Arduino.

### Workaround 2

Remove the existing CRSF for Arduino folder (thus, deleting the contents in the process) and install the .ZIP file.

### Treading on uncharted territory

It has been a _very_ long time since I last used the Arduino IDE myself. The last version I had was 1.8.10, which has since been discontinued for quite some time.  
Therefore, I am _not yet_ up to speed with the latest version of the Arduino IDE.

Instead, I have been using Visual Studio Code and PlatformIO as my primary code editing and development environment since 2021.

There have been significant changes to the Arduino IDE that I am not yet familiar with - To the extent where it appears as though it's a completely different development environment. So, please bear with me, as I familiarise myself with this environment.

I am _not_ entirely certain on why the .ZIP installation is failing if you already have an "older" version of CRSF for Arduino present.  
By rights, this `SHOULD` automatically be replaced with the new version.  
However, I will look into this myself, and figure out what's going on and why this is happening.