### PR TITLE
Fix: Initialize SerialReceiver base in CRSFforArduino constructor

### DIFF
--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -45,6 +45,7 @@ namespace sketchLayer
      * @param txPin 
      */
     CRSFforArduino::CRSFforArduino(HardwareSerial *serialPort)
+        : serialReceiverLayer::SerialReceiver(serialPort)
     {
     }
 


### PR DESCRIPTION
Hi ZZ-Cat,

I discovered an issue where the `CRSFforArduino` constructor wasn't properly initializing its `SerialReceiver` base class with the provided `HardwareSerial` object. As a result, attempts to specify a different hardware serial port (e.g., `new CRSFforArduino(&Serial5);`) would default to `Serial1`, ignoring the user-specified port. This pull request corrects that by ensuring the base class is properly initialized with the user-provided `HardwareSerial` object.

I've tested the changes using a Teensy 4.0 and an ELRS receiver, confirming the hardware serial port can now be successfully customized. However, as this is my first contribution to any open-source project, I apologize for any possible oversights or missed protocols specific to your project. I'm eager to receive feedback and am fully prepared to make any needed adjustments to meet the project's standards and expectations.

Thank you for considering my contribution. I look forward to any feedback and the opportunity to learn from this experience.

Best regards,
TZShin