### PR TITLE
Adding paragraph

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.1.0
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=CRSF for Arduino brings the Crossfire Protocol to the Arduino ecosystem.
+paragraph=CRSF for Arduino brings the Crossfire Protocol to the Arduino ecosystem.
 category=Communication
 url=https://github.com/ZZ-Cat/CRSFforArduino
 dot_a_linkage=false


### PR DESCRIPTION
Arduino IDE was screaming at me with the following error message:

`Invalid library found in ~/Arduino/libraries/CRSFforArduino-1.0.2: Missing 'paragraph' from library`

I grepped "paragraph" into another random repo and found an entry like this in library.properties .

Adding it stopped the spam in Arduino IDE.

Disclamer:
I've got next to no experience with Arduino and Arduino IDE, the warning might very well be user error!