### PR TITLE
refactor(targets): :recycle: Use Arduino-Pico instead of the "official" PlatformIO package for RP2040

### DIFF
--- a/targets/common.ini
+++ b/targets/common.ini
@@ -16,7 +16,11 @@ build_flags =
 platform = espressif32@6.4.0
 
 [env_common_rp2040]
-platform = raspberrypi@1.11.0
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board_build.core = earlephilhower
+board_build.filesystem_size = 0.5m
+platform_packages = 
+	maxgerhardt/framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#master
 
 [env_common_samd21]
 platform = atmelsam@8.2.0

--- a/targets/unified_rp2040.ini
+++ b/targets/unified_rp2040.ini
@@ -1,7 +1,7 @@
 [env:arduino_nano_rp2040_connect]
 extends = env_common_rp2040
-board = nanorp2040connect
+board = arduino_nano_connect
 
 [env:raspberrypi_pico_rp2040]
 extends = env_common_rp2040
-board = pico
+board = rpipico


### PR DESCRIPTION
## Overview

This Pull Request replaces the existing "official" PlatformIO RP2040 support package with Earle Philhower's [Arduino-Pico](https://github.com/earlephilhower/arduino-pico) package.

> [!NOTE]
> This Pull Request is a re-factor and it does not add any new targets.
> New targets are in the pipeline, once this Pull Request is merged.

Up until _now,_ I believed that RP2040 support in PlatformIO had come to a grinding halt, and I had erroneously believed that it couldn't be done because of that... until I read the [documentation](https://arduino-pico.readthedocs.io/en/latest/) of Arduino-Pico telling me that [it can be done.](https://arduino-pico.readthedocs.io/en/latest/platformio.html)

So... here you are. =^/.^=