### PR TITLE
refactor(quality control): Use an isolated version of `CFA_Config.hpp` for Defect Detector environment.

### DIFF
--- a/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -28,7 +28,9 @@
 
 #pragma once
 
+#ifndef ENV_DEFECT_DETECTOR
 #include "../../CFA_Config.hpp"
+#endif
 
 namespace crsfProtocol
 {

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -182,6 +182,7 @@ namespace serialReceiverLayer
                 _flightModes[i].min = serialReceiver._flightModes[i].min;
                 _flightModes[i].max = serialReceiver._flightModes[i].max;
             }
+            _flightModeCallback = serialReceiver._flightModeCallback;
 #endif
 
 #if CRSF_LINK_STATISTICS_ENABLED > 0

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#ifndef ENV_DEFECT_DETECTOR
 #include "../CFA_Config.hpp"
+#endif
 #include "Arduino.h"
 #include "CRSF/CRSF.hpp"
 #include "Telemetry/Telemetry.hpp"

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -25,7 +25,9 @@
  */
 
 #include "Telemetry.hpp"
+#ifndef ENV_DEFECT_DETECTOR
 #include "CFA_Config.hpp"
+#endif
 
 using namespace crsfProtocol;
 

--- a/src/hal/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.cpp
@@ -25,7 +25,9 @@
  */
 
 #include "CompatibilityTable.hpp"
+#ifndef ENV_DEFECT_DETECTOR
 #include "../../CFA_Config.hpp"
+#endif
 #include "Arduino.h"
 
 namespace hal

--- a/targets/quality_control.ini
+++ b/targets/quality_control.ini
@@ -1,5 +1,35 @@
 [env:defect_detector]
 board = adafruit_metro_m4
+build_flags =
+    ; An isolated configuration from CFA_Config.hpp is used here to test EVERY possible
+    ; configuration, and ensure that defects (if any) are picked up.
+    ; The `ENV_DEFECT_DETECTOR` define configures CRSF for Arduino for use with the Defect Detector.
+    -DENV_DEFECT_DETECTOR
+
+    -DCRSF_FAILSAFE_LQI_THRESHOLD=80
+    -DCRSF_FAILSAFE_RSSI_THRESHOLD=105
+
+    -DCRSF_RC_ENABLED=1
+    -DCRSF_RC_MAX_CHANNELS=16
+    -DCRSF_RC_CHANNEL_MIN=172
+    -DCRSF_RC_CHANNEL_MAX=1811
+    -DCRSF_RC_CHANNEL_CENTER=992
+    -DCRSF_RC_INITIALISE_CHANNELS=1
+    -DCRSF_RC_INITIALISE_ARMCHANNEL=1
+    -DCRSF_RC_INITIALISE_THROTTLECHANNEL=1
+
+    -DCRSF_FLIGHTMODES_ENABLED=1
+    -DCRSF_CUSTOM_FLIGHT_MODES_ENABLED=1
+
+    -DCRSF_TELEMETRY_ENABLED=1
+    -DCRSF_TELEMETRY_ATTITUDE_ENABLED=1
+    -DCRSF_TELEMETRY_BAROALTITUDE_ENABLED=1
+    -DCRSF_TELEMETRY_BATTERY_ENABLED=1
+    -DCRSF_TELEMETRY_FLIGHTMODE_ENABLED=1
+    -DCRSF_TELEMETRY_GPS_ENABLED=1
+
+    -DCRSF_LINK_STATISTICS_ENABLED=1
+
 build_src_filter = 
     +<../examples/platformio/main.cpp>
     +<*/*/*.cpp>


### PR DESCRIPTION
## Overview

This is a quick follow-up to 5b5a8984bdca4f476e8904912e75b0883e4150a4.  
Instead of the Defect Detector using [`CFA_Config.hpp`](../blob/Main-Trunk/src/CFA_Config.hpp), the defines in the configuration are declared in the `build_flags` section of the Defect Detector's environment.

## Benefits

Any configurations made to `CFA_Config.hpp` no longer affects the outcome of my overall Quality Control.  
This frees `CFA_Config.hpp` to be set to whichever way I want/need it to be to provide the best quality default configuration that most people will use.  

It also means that I can run various combinations of configurations through my Defect Detector _without_ affecting `CFA_Config.hpp`. Say, if I wanted to disable `CRSF_RC_ENABLED` but I wanted to leave `CRSF_TELEMETRY_ENABLED` turned on, I can do that _without_ touching `CFA_Config.hpp`.

## In other words...

This is mostly a quality-of-life thing from a developer's point-of-view.  
The more modular CRSF for Arduino is, the easier it is to test key aspects in isolation, and (by extension) that means improving the overall quality of the code-base.