### PR TITLE
refactor(serial receiver interface): :recycle: Facilitate custom baud rates

### DIFF
--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -70,10 +70,10 @@ namespace sketchLayer
      * 
      * @return true if CRSF for Arduino was initialised successfully.
      */
-    bool CRSFforArduino::begin()
+    bool CRSFforArduino::begin(const uint32_t baud_rate)
     {
 #if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0
-        return this->SerialReceiver::begin();
+        return this->SerialReceiver::begin(baud_rate);
 #else
         // Return false if RC is disabled
         return false;

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -39,7 +39,7 @@ namespace sketchLayer
         explicit CRSFforArduino(HardwareSerial *serialPort);
         CRSFforArduino(HardwareSerial *serialPort, int rxPin, int txPin);
         ~CRSFforArduino();
-        bool begin();
+        bool begin(const uint32_t baud_rate = crsfProtocol::BAUD_RATE);
         void end();
         void update();
 

--- a/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -263,6 +263,7 @@ namespace crsfProtocol
 
     enum baudRate_e
     {
-        BAUD_RATE = 420000
+        BAUD_RATE_LEGACY = 420000,
+        BAUD_RATE = 416666
     };
 } // namespace crsfProtocol

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -212,7 +212,7 @@ namespace serialReceiverLayer
 #endif
     }
 
-    bool SerialReceiver::begin()
+    bool SerialReceiver::begin(const uint32_t baudRate)
     {
 #if CRSF_DEBUG_ENABLED > 0
         CRSF_DEBUG_SERIAL_PORT.print("[Serial Receiver | INFO]: Initialising... ");
@@ -279,11 +279,11 @@ namespace serialReceiverLayer
         /* Initialise the CRSF Protocol and Telemetry. */
         crsf = new CRSF();
         crsf->begin();
-        crsf->setFrameTime(BAUD_RATE, 10);
+        crsf->setFrameTime(baudRate, 10);
 #if defined(ARDUINO_ARCH_ESP32)
-        _uart->begin(BAUD_RATE, SERIAL_8N1, _rxPin, _txPin);
+        _uart->begin(baudRate, SERIAL_8N1, _rxPin, _txPin);
 #else
-        _uart->begin(BAUD_RATE);
+        _uart->begin(baudRate);
 #endif
 
 #if CRSF_TELEMETRY_ENABLED > 0

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -82,7 +82,7 @@ namespace serialReceiverLayer
         SerialReceiver &operator=(const SerialReceiver &serialReceiver);
         virtual ~SerialReceiver();
 
-        bool begin();
+        bool begin(const uint32_t baudRate);
         void end();
 
 #if CRSF_RC_ENABLED > 0 || CRSF_TELEMETRY_ENABLED > 0 || CRSF_LINK_STATISTICS_ENABLED > 0


### PR DESCRIPTION
## Overview

Resolves #131.

This Pull Request enables the ability to set custom baud rates as a parameter to `sketchLayer::CRSFforArduino::begin()`.  
In turn, this passes the baud rate to the Serial Receiver Interface, where the physical UART is initialised with your custom baud rate and the expected time to receive a full length frame is automatically adjusted at initialisation to compensate.

For backwards-compatibility, if no parameter is provided in the `begin()` function, CRSF for Arduino defaults to the legacy 420 KB/s baud rate.

## Code examples

### Using the default baud rate

```cpp
#include "Arduino.h"
#include "CRSFforArduino.hpp"

CRSFforArduino *cfa = nullptr;

void a_generic_function()
{
    /* ...previous set-up code...*/

    /* Initialise CRSF for Arduino. */
    cfa = new CRSFforArduino();
    if (cfa != nullptr)
    {
        /* By default, CRSF for Arduino initialises its hardware UART with the legacy 420 KB/s if no parameter is provided. */
        cfa->begin();
    }

    /* ...more set-up code... */

}
```

### Providing your own baud rate

> "Fine, I'll do it myself!" --Thanos

You MAY pass in your own baud rate as a parameter to `sketchLayer::CRSFforArduino::begin()`

```cpp
#include "Arduino.h"
#include "CRSFforArduino.hpp"

CRSFforArduino *cfa = nullptr;

void a_generic_function()
{
    /* ...previous set-up code...*/

    /* Initialise CRSF for Arduino. */
    cfa = new CRSFforArduino();
    if (cfa != nullptr)
    {
        /* You MAY provide your own baud rate as a parameter. */
        const unsigned long yourCustomBaudRate = 416666;

        /* Pass your custom baud rate to `begin()` to tell CRSF for Arduino to initialise its UART with your custom baud rate.
        In this example, the "official" 416.67 KB/s baud rate is chosen. */
        cfa->begin(yourCustomBaudRate);
    }

    /* ...more set-up code... */

}
```