### PR TITLE
chore(library): House keeping

### DIFF
--- a/examples/flight_modes/flight_modes.ino
+++ b/examples/flight_modes/flight_modes.ino
@@ -2,8 +2,6 @@
  * @file flight_modes.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read flight modes from a receiver.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/link_stats/link_stats.ino
+++ b/examples/link_stats/link_stats.ino
@@ -2,8 +2,6 @@
  * @file link_stats.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read link statistics from a receiver.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/platformio/main.cpp
+++ b/examples/platformio/main.cpp
@@ -2,8 +2,6 @@
  * @file main.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the main development file for CRSF for Arduino.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/rc_channels/rc_channels.ino
+++ b/examples/rc_channels/rc_channels.ino
@@ -2,8 +2,6 @@
  * @file rc_channels.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to read rc channels from a receiver.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/examples/telemetry/telemetry.ino
+++ b/examples/telemetry/telemetry.ino
@@ -2,8 +2,6 @@
  * @file flight_modes.ino
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief Example of how to send telemetry back to your RC handset using CRSF for Arduino.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -2,8 +2,6 @@
  * @file CFA_Config.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the configuration file for CRSF for Arduino.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -106,10 +106,11 @@ and assign them to a switch on your controller. */
 /* Debug Options
 - DEBUG_ENABLED: Enables or disables debug output over the selected serial port.
 - CRSF_DEBUG_SERIAL_PORT: The serial port to use for debug output. Usually the native USB port.
-- CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT: Enables or disables debug output from the compatibility table. */
-#define CRSF_DEBUG_ENABLED                           0
+- CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT: Enables or disables debug output from the compatibility table.
+- CRSF_DEBUG_ENABLE_CONFIGURATION_DUMP: When enabled, this will print the configuration of CFA to the Serial Monitor.*/
 #define CRSF_DEBUG_SERIAL_PORT                       Serial
 #define CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT 0
+#define CRSF_DEBUG_ENABLE_CONFIGURATION_DUMP         0
 
 /* All warnings and asserts below this point are to ensure that the configuration is valid. */
 

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -35,7 +35,7 @@ namespace crsfForArduinoConfig
 Versioning is done using Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
 #define CRSFFORARDUINO_VERSION       "1.0.4"
-#define CRSFFORARDUINO_VERSION_DATE  "2024-8-14"
+#define CRSFFORARDUINO_VERSION_DATE  "2024-8-17"
 #define CRSFFORARDUINO_VERSION_MAJOR 1
 #define CRSFFORARDUINO_VERSION_MINOR 0
 #define CRSFFORARDUINO_VERSION_PATCH 4

--- a/src/CRSFforArduino.cpp
+++ b/src/CRSFforArduino.cpp
@@ -3,8 +3,6 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the Sketch Layer, which is a simplified API for CRSF for Arduino.
  * It is intended to be used by the user in their sketches.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/CRSFforArduino.hpp
+++ b/src/CRSFforArduino.hpp
@@ -3,8 +3,6 @@
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This is the Sketch Layer, which is a simplified API for CRSF for Arduino.
  * It is intended to be used by the user in their sketches.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRC/CRC.cpp
+++ b/src/SerialReceiver/CRC/CRC.cpp
@@ -2,8 +2,6 @@
  * @file CRC.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic CRC8 implementation for the CRSF for Arduino library.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRC/CRC.hpp
+++ b/src/SerialReceiver/CRC/CRC.hpp
@@ -2,8 +2,6 @@
  * @file GenericCRC.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic CRC8 implementation for the CRSF for Arduino library.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -2,8 +2,6 @@
  * @file CRSF.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This decodes CRSF frames from a serial port.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSF.cpp
+++ b/src/SerialReceiver/CRSF/CRSF.cpp
@@ -122,7 +122,7 @@ namespace serialReceiverLayer
             frameStartTime = currentTime;
         }
 
-        /* Assume the full frame lenthg is 5 bytes until the frame length byte is received. */
+        /* Assume the full frame length is 5 bytes until the frame length byte is received. */
         const int fullFrameLength = framePosition < 3 ? 5 : min(rxFrame.frame.frameLength + CRSF_FRAME_LENGTH_ADDRESS + CRSF_FRAME_LENGTH_FRAMELENGTH, (int)CRSF_FRAME_SIZE_MAX);
 
         if (framePosition < fullFrameLength)

--- a/src/SerialReceiver/CRSF/CRSF.hpp
+++ b/src/SerialReceiver/CRSF/CRSF.hpp
@@ -2,8 +2,6 @@
  * @file CRSF.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This decodes CRSF frames from a serial port.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+++ b/src/SerialReceiver/CRSF/CRSFProtocol.hpp
@@ -2,8 +2,6 @@
  * @file CRSFProtocol.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This file contains enums and structs for the CRSF protocol.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
@@ -2,8 +2,6 @@
  * @file SerialBuffer.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic serial buffer for the CRSF for Arduino library.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+++ b/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
@@ -2,8 +2,6 @@
  * @file SerialBuffer.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief A generic serial buffer for the CRSF for Arduino library.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -213,6 +213,33 @@ namespace serialReceiverLayer
     bool SerialReceiver::begin(const uint32_t baudRate)
     {
 #if CRSF_DEBUG_ENABLED > 0
+        for (int i = 0; i < 93; i++)
+        {
+            CRSF_DEBUG_SERIAL_PORT.print("=");
+        }
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
+        CRSF_DEBUG_SERIAL_PORT.println("Cassie Robinson's");
+        CRSF_DEBUG_SERIAL_PORT.println("CRSF for Arduino");
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
+        CRSF_DEBUG_SERIAL_PORT.print("Version: ");
+        CRSF_DEBUG_SERIAL_PORT.println(CRSFFORARDUINO_VERSION);
+        CRSF_DEBUG_SERIAL_PORT.print("Build date: ");
+        CRSF_DEBUG_SERIAL_PORT.println(CRSFFORARDUINO_VERSION_DATE);
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
+        for (int i = 0; i < 93; i++)
+        {
+            CRSF_DEBUG_SERIAL_PORT.print("-");
+        }
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
         CRSF_DEBUG_SERIAL_PORT.print("[Serial Receiver | INFO]: Initialising... ");
 #endif
 

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -2,8 +2,6 @@
  * @file SerialReceiver.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Serial Receiver layer for the CRSF for Arduino library.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -287,13 +287,23 @@ namespace serialReceiverLayer
         /* Check if the target development board is
         compatible with the CRSF Protocol, and return false if it isn't. */
         CompatibilityTable *ct = new CompatibilityTable();
-        if (!ct->isDevboardCompatible(ct->getDevboardName()))
+        const char *devboardName = ct->getDevboardName();
+        if (!ct->isDevboardCompatible(devboardName))
         {
             delete ct;
             ct = nullptr;
 
 #if CRSF_DEBUG_ENABLED > 0
-            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Serial Receiver | FATAL ERROR]: Devboard is not compatible with CRSF Protocol.");
+#if CRSF_DEBUG_ENABLE_COMPATIBILITY_TABLE_OUTPUT == 0
+            CRSF_DEBUG_SERIAL_PORT.println("\r\n[Serial Receiver | FATAL ERROR]: Your device is not compatible with CRSF for Arduino.");
+#endif
+
+            for (int i = 0; i < 93; i++)
+            {
+                CRSF_DEBUG_SERIAL_PORT.print("=");
+            }
+            CRSF_DEBUG_SERIAL_PORT.println();
+            CRSF_DEBUG_SERIAL_PORT.flush();
 #endif
             return false;
         }
@@ -325,6 +335,152 @@ namespace serialReceiverLayer
 
 #if CRSF_DEBUG_ENABLED > 0
         CRSF_DEBUG_SERIAL_PORT.println("Done.");
+
+
+#if CRSF_DEBUG_ENABLE_CONFIGURATION_DUMP > 0
+        for (int i = 0; i < 93; i++)
+        {
+            CRSF_DEBUG_SERIAL_PORT.print("-");
+        }
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
+        CRSF_DEBUG_SERIAL_PORT.println("CRSF for Arduino initialised with the following configuration:");
+
+        CRSF_DEBUG_SERIAL_PORT.println(" - Device:");
+        CRSF_DEBUG_SERIAL_PORT.print("   - Name: ");
+        CRSF_DEBUG_SERIAL_PORT.println(devboardName);
+        CRSF_DEBUG_SERIAL_PORT.println("   - UART:");
+        CRSF_DEBUG_SERIAL_PORT.print("     - Baud rate: ");
+        CRSF_DEBUG_SERIAL_PORT.println(baudRate);
+        CRSF_DEBUG_SERIAL_PORT.print("     - Rx pin: ");
+        CRSF_DEBUG_SERIAL_PORT.println(_rxPin == -1 ? PIN_SERIAL1_RX : _rxPin);
+        CRSF_DEBUG_SERIAL_PORT.print("     - Tx pin: ");
+        CRSF_DEBUG_SERIAL_PORT.println(_txPin == -1 ? PIN_SERIAL1_TX : _txPin);
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
+        CRSF_DEBUG_SERIAL_PORT.println(" - Failsafe thresholds:");
+        CRSF_DEBUG_SERIAL_PORT.print("   - LQI threshold: ");
+        CRSF_DEBUG_SERIAL_PORT.println(CRSF_FAILSAFE_LQI_THRESHOLD);
+        CRSF_DEBUG_SERIAL_PORT.print("   - RSSI threshold: ");
+        CRSF_DEBUG_SERIAL_PORT.println(CRSF_FAILSAFE_RSSI_THRESHOLD);
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
+        CRSF_DEBUG_SERIAL_PORT.println(" - RC Channels API:");
+        CRSF_DEBUG_SERIAL_PORT.print("   - Enabled: ");
+#if CRSF_RC_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+
+        CRSF_DEBUG_SERIAL_PORT.print("     - RC channels: ");
+        CRSF_DEBUG_SERIAL_PORT.println(CRSF_RC_MAX_CHANNELS);
+        CRSF_DEBUG_SERIAL_PORT.print("     - Minimum RC Channel value: ");
+        CRSF_DEBUG_SERIAL_PORT.println((uint16_t)((CRSF_RC_CHANNEL_MIN * 0.62477120195241F) + 881));
+        CRSF_DEBUG_SERIAL_PORT.print("     - Maximum RC Channel value: ");
+        CRSF_DEBUG_SERIAL_PORT.println((uint16_t)((CRSF_RC_CHANNEL_MAX * 0.62477120195241F) + 881));
+        CRSF_DEBUG_SERIAL_PORT.print("     - Center RC Channel value: ");
+        CRSF_DEBUG_SERIAL_PORT.println((uint16_t)((CRSF_RC_CHANNEL_CENTER * 0.62477120195241F) + 881));
+
+        CRSF_DEBUG_SERIAL_PORT.print("     - Initialise RC channels: ");
+#if CRSF_RC_INITIALISE_CHANNELS > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+
+        CRSF_DEBUG_SERIAL_PORT.print("     - Initialise Arm channel: ");
+#if CRSF_RC_INITIALISE_ARMCHANNEL > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+            
+        CRSF_DEBUG_SERIAL_PORT.print("     - Initialise Throttle channel: ");
+#if CRSF_RC_INITIALISE_THROTTLECHANNEL > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+#endif
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
+        CRSF_DEBUG_SERIAL_PORT.println(" - Flight Modes API:");
+        CRSF_DEBUG_SERIAL_PORT.print("   - Enabled: ");
+#if CRSF_FLIGHTMODES_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+
+        CRSF_DEBUG_SERIAL_PORT.print("     - Custom Flight Modes enabled: ");
+#if CRSF_CUSTOM_FLIGHT_MODES_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
+
+
+        CRSF_DEBUG_SERIAL_PORT.println(" - Telemetry API:");
+        CRSF_DEBUG_SERIAL_PORT.print("   - Enabled: ");
+#if CRSF_TELEMETRY_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+
+        CRSF_DEBUG_SERIAL_PORT.print("     - Attitude telemetry enabled: ");
+#if CRSF_TELEMETRY_ATTITUDE_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+            
+        CRSF_DEBUG_SERIAL_PORT.print("     - Barometric altitude telemetry enabled: ");
+#if CRSF_TELEMETRY_BAROALTITUDE_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+                
+        CRSF_DEBUG_SERIAL_PORT.print("     - Battery telemetry enabled: ");
+#if CRSF_TELEMETRY_BATTERY_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+                    
+        CRSF_DEBUG_SERIAL_PORT.print("     - Flight Mode telemetry enabled: ");
+#if CRSF_TELEMETRY_FLIGHTMODE_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+
+        CRSF_DEBUG_SERIAL_PORT.print("     - GPS telemetry enabled: ");
+#if CRSF_TELEMETRY_GPS_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+
+        CRSF_DEBUG_SERIAL_PORT.print("     - Link Statistics telemetry enabled: ");
+#if CRSF_LINK_STATISTICS_ENABLED > 0
+        CRSF_DEBUG_SERIAL_PORT.println("Yes");
+#else
+        CRSF_DEBUG_SERIAL_PORT.println("No");
+#endif
+#endif
+        CRSF_DEBUG_SERIAL_PORT.println();
+#endif
+
+        for (int i = 0; i < 93; i++)
+        {
+            CRSF_DEBUG_SERIAL_PORT.print("=");
+        }
+        CRSF_DEBUG_SERIAL_PORT.println();
+        CRSF_DEBUG_SERIAL_PORT.flush();
 #endif
         return true;
     }

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -406,7 +406,7 @@ namespace serialReceiverLayer
             else
             {
                 /* Convert RC value from raw to microseconds.
-                - Mininum: 172 (988us)
+                - Minimum: 172 (988us)
                 - Middle: 992 (1500us)
                 - Maximum: 1811 (2012us)
                 - Scale factor = (2012 - 988) / (1811 - 172) = 0.62477120195241

--- a/src/SerialReceiver/SerialReceiver.hpp
+++ b/src/SerialReceiver/SerialReceiver.hpp
@@ -2,8 +2,6 @@
  * @file SerialReceiver.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Serial Receiver layer for the CRSF for Arduino library.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/Telemetry/Telemetry.cpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.cpp
@@ -2,8 +2,6 @@
  * @file Telemetry.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This encodes data into CRSF telemetry frames for transmission to the RC handset.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/SerialReceiver/Telemetry/Telemetry.hpp
+++ b/src/SerialReceiver/Telemetry/Telemetry.hpp
@@ -2,8 +2,6 @@
  * @file Telemetry.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief This encodes data into CRSF telemetry frames for transmission to the RC handset.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/hal/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.cpp
@@ -2,8 +2,6 @@
  * @file CompatibilityTable.cpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Compatibility Table determines if the target development board is compatible with CRSF for Arduino.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *

--- a/src/hal/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.hpp
@@ -102,7 +102,7 @@ namespace hal
             DEVBOARD_ARDUINO_PORTENTA_H7,
             DEVBOARD_ARDUINO_PORTENTA_H7_M4,
 
-            // Espresif ESP32 boards.
+            // Espressif ESP32 boards.
             DEVBOARD_ESPRESSIF_ESP32C3_DEVKIT,
             DEVBOARD_ESPRESSIF_ESP32S3_DEVKIT,
 

--- a/src/hal/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.hpp
@@ -2,8 +2,6 @@
  * @file CompatibilityTable.hpp
  * @author Cassandra "ZZ Cat" Robinson (nicad.heli.flier@gmail.com)
  * @brief The Compatibility Table determines if the target development board is compatible with CRSF for Arduino.
- * @version 1.0.4
- * @date 2024-8-14
  *
  * @copyright Copyright (c) 2024, Cassandra "ZZ Cat" Robinson. All rights reserved.
  *


### PR DESCRIPTION
## Overview

> [!NOTE]
> 
> This Pull Request targets the `v1.0.x-Maintenance-Branch`

This PR brings various clean-ups, and streamlines the Semantic Versioning for each source and header file.

## Details

### Streamlined Semantic Versioning

As CRSF for Arduino grows, it has become increasingly tedious to go through every individual file to update the Semantic Version header. Not only that, this is the primary source of clashes when it comes to re-basing CRSF for Arduino onto different branches... namely when a branch's head has been updated.

### New debug configuration flags

This Pull Request also brings in a small-ish feature where CRSF for Arduino's boiler plate (IE Name, Version, and Build Date etc) are printed to the Serial Monitor if you have the `CRSF_DEBUG_ENABLED` flag set to `1`.

Another helpful debug feature intorduced by this Pull Request is the `CRSF_DEBUG_ENABLE_CONFIGURATION_DUMP` flag. Setting this to `1` will show your current configuration of CRSF for Arduino in the Serial Monitor.

The configuration dump identifies your development board and what pins you are currently using with CRSF for Arduino as well as LQI and RSSI thresholds, maximum number of RC channels, minimum and maximum RC channel values (in microseconds) and the centre channel value (also in microseconds).