### PR TITLE
Containerise CFA

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "CRSFforArduino development container",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "postCreateCommand": "pip install platformio",
+  "postStartCommand": "sudo groupadd -g 986 uucp || true && sudo usermod -aG uucp vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "donjayamanne.githistory",
+        "eamodio.gitlens",
+        "github.vscode-github-actions",
+        "GitHub.vscode-pull-request-github",
+        "ms-vscode.cpptools",
+        "ms-vscode.cpptools-extension-pack",
+        "ms-vscode.cpptools-themes",
+        "platformio.platformio-ide",
+        "streetsidesoftware.code-spell-checker",
+        "vivaxy.vscode-conventional-commits",
+        "xaver.clang-format"
+      ]
+    }
+  },
+  "runArgs": [
+    "--device=/dev/ttyACM0",
+    "--group-add=986"
+  ],
+  "mounts": [
+    "source=/dev/bus/usb,target=/dev/bus/usb,type=bind"
+  ]
+}


### PR DESCRIPTION
## Overview

I have revisited an earlier attempt at putting CRSF for Arduino in a development container, and this is the _one_ attempt that is successful, and it is the way CRSF for Arduino is being developed, moving forward.

## What this means

- Isolation from your system—Your OS cannot interfere with CFA's pipeline, and CFA itself cannot interdere with your OS.
- Deterministic build-flash-and-debug pipeline—literally nothing happens with CFA unless you say so.
- Port assignments (including USB) are deterministic, and the container requires an _explicit_ USB passthrough (which has already been pre-configured... by yours truly).
- Future contributors to CFA are REQUIRED to have Docker installed on their operating systems as well as the Dev Containers extenstion in VSCode.