### PR TITLE
refactor(quality control): Use Clang-Tidy together with CppCheck

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "CRSFforArduino development container",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "postCreateCommand": "pip install platformio",
-  "postStartCommand": "sudo groupadd -g 986 uucp || true && sudo usermod -aG uucp vscode",
+  "postStartCommand": "sudo groupadd -g 985 uucp || true && sudo usermod -aG uucp vscode",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -23,7 +23,7 @@
   },
   "runArgs": [
     "--device=/dev/ttyACM0",
-    "--group-add=986"
+    "--group-add=985"
   ],
   "mounts": [
     "source=/dev/bus/usb,target=/dev/bus/usb,type=bind"

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "CRSFforArduino",
-    "version": "2025.9.2",
+    "version": "2025.10.24",
     "description": "An Arduino Library for communicating with ExpressLRS and TBS Crossfire receivers.",
     "keywords": "arduino, remote-control, arduino-library, protocols, rc, radio-control, crsf, expresslrs",
     "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRSFforArduino
-version=2025.9.2
+version=2025.10.24
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=CRSF for Arduino brings the Crossfire Protocol to the Arduino ecosystem.

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -35,11 +35,11 @@ namespace crsfForArduinoConfig
 Versioning is based on a rolling release model
 and is backwards-compatible with Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
-#define CRSFFORARDUINO_VERSION       "2025.9.2"
-#define CRSFFORARDUINO_VERSION_DATE  "2025-09-02"
+#define CRSFFORARDUINO_VERSION       "2025.10.24"
+#define CRSFFORARDUINO_VERSION_DATE  "2025-10-24"
 #define CRSFFORARDUINO_VERSION_MAJOR 2025
-#define CRSFFORARDUINO_VERSION_MINOR 9
-#define CRSFFORARDUINO_VERSION_PATCH 2
+#define CRSFFORARDUINO_VERSION_MINOR 10
+#define CRSFFORARDUINO_VERSION_PATCH 24
 
 // This is set to 1 if the version is a pre-release version.
 #define CRSFFORARDUINO_VERSION_IS_PRERELEASE 0

--- a/src/build/scripts/.clang-tidy
+++ b/src/build/scripts/.clang-tidy
@@ -1,0 +1,16 @@
+---
+Checks:
+  - 'bugprone-*'
+  - 'cert-*'
+  - 'clang-diagnostic-*'
+  - 'clang-analyzer-*'
+  - 'cppcoreguidelines-*'
+  - 'hicpp-*'
+  - 'misc-*'
+  - 'modernize-*'
+  - 'performance-*'
+  - 'portability-*'
+  - 'readability-*'
+HeaderFileExtensions: ['h', 'hpp']
+ImplementationFileExtensions: ['c', 'cpp']
+...

--- a/src/build/scripts/build.py
+++ b/src/build/scripts/build.py
@@ -3,7 +3,7 @@ import sys
 
 if __name__ == "__main__":
     # Run the defect detector to check for any issues in the code.
-    command = "pio check -e defect_detector --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high"
+    command = "pio check -e defect_detector_clangtidy --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high"
     try:
         subprocess.run(command, shell=True, check=True, text=True, capture_output=True)
     except subprocess.CalledProcessError as e:

--- a/src/build/scripts/build.py
+++ b/src/build/scripts/build.py
@@ -14,6 +14,15 @@ if __name__ == "__main__":
         print("There were issues detected in the code-base. Please resolve them before proceeding.")
         exit(1)
 
+    command = "pio check -e defect_detector_cppcheck --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high"
+    try:
+        subprocess.run(command, shell=True, check=True, text=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        print(f"{e.stdout.strip()}")
+        print(f"{e.stderr.strip()}")
+        print("There were issues detected in the code-base. Please resolve them before proceeding.")
+        exit(1)
+
     # Get the command line arguments.
     args = sys.argv[1:]
     # If --deploy was specified as a command line argument, deploy the code to the device.

--- a/src/build/scripts/build.py
+++ b/src/build/scripts/build.py
@@ -3,9 +3,7 @@ import sys
 
 if __name__ == "__main__":
     # Run the defect detector to check for any issues in the code.
-    # command = "pio check -e defect_detector_clangtidy --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high"
-    # Temporarily disable failure on medium defects.
-    command = "pio check -e defect_detector_clangtidy --fail-on-defect=low --fail-on-defect=high"
+    command = "pio check -e defect_detector_clangtidy --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high"
     try:
         subprocess.run(command, shell=True, check=True, text=True, capture_output=True)
     except subprocess.CalledProcessError as e:

--- a/src/build/scripts/build.py
+++ b/src/build/scripts/build.py
@@ -3,7 +3,9 @@ import sys
 
 if __name__ == "__main__":
     # Run the defect detector to check for any issues in the code.
-    command = "pio check -e defect_detector_clangtidy --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high"
+    # command = "pio check -e defect_detector_clangtidy --fail-on-defect=low --fail-on-defect=medium --fail-on-defect=high"
+    # Temporarily disable failure on medium defects.
+    command = "pio check -e defect_detector_clangtidy --fail-on-defect=low --fail-on-defect=high"
     try:
         subprocess.run(command, shell=True, check=True, text=True, capture_output=True)
     except subprocess.CalledProcessError as e:

--- a/src/build/scripts/platformio.ini
+++ b/src/build/scripts/platformio.ini
@@ -8,6 +8,26 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+core_dir =      ../../../.pio/core
+workspace_dir = ../../../.pio
+include_dir =   ../../../src
+lib_dir =       ../../../src
+src_dir =       ../../../src
+test_dir =      ../../../src
+default_envs = 
+    ${build.commonly_used}
+extra_configs =
+    ../../../src/build/targets/common.ini
+    ../../../src/build/targets/quality_control.ini
+    ../../../src/build/targets/unified_esp32.ini
+    ../../../src/build/targets/unified_rp2040.ini
+    ../../../src/build/targets/unified_samd21.ini
+    ../../../src/build/targets/unified_samd51.ini
+    ../../../src/build/targets/unified_stm32.ini
+    ../../../src/build/targets/unified_teensy3x.ini
+    ../../../src/build/targets/unified_teensy4x.ini
+
 ; [platformio]
 ; core_dir =      ../../../.pio/core
 ; workspace_dir = ../../../.pio

--- a/src/build/scripts/platformio.ini
+++ b/src/build/scripts/platformio.ini
@@ -8,38 +8,38 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[platformio]
-core_dir =      ../../../.pio/core
-workspace_dir = ../../../.pio
-default_envs =
-    ; defect_detector
-    ; development
-    ${build.commonly_used}
-extra_configs =
-    ../../../src/build/targets/common.ini
-    ../../../src/build/targets/quality_control.ini
-    ../../../src/build/targets/unified_esp32.ini
-    ../../../src/build/targets/unified_rp2040.ini
-    ../../../src/build/targets/unified_samd21.ini
-    ../../../src/build/targets/unified_samd51.ini
-    ../../../src/build/targets/unified_stm32.ini
-    ../../../src/build/targets/unified_teensy3x.ini
-    ../../../src/build/targets/unified_teensy4x.ini
-include_dir = ../../../src
-lib_dir = ../../../src
-src_dir = ../../../src
-test_dir = 
+; [platformio]
+; core_dir =      ../../../.pio/core
+; workspace_dir = ../../../.pio
+; default_envs =
+;     ; defect_detector
+;     ; development
+;     ${build.commonly_used}
+; extra_configs =
+;     ../../../src/build/targets/common.ini
+;     ../../../src/build/targets/quality_control.ini
+;     ../../../src/build/targets/unified_esp32.ini
+;     ../../../src/build/targets/unified_rp2040.ini
+;     ../../../src/build/targets/unified_samd21.ini
+;     ../../../src/build/targets/unified_samd51.ini
+;     ../../../src/build/targets/unified_stm32.ini
+;     ../../../src/build/targets/unified_teensy3x.ini
+;     ../../../src/build/targets/unified_teensy4x.ini
+; include_dir = ../../../src
+; lib_dir = ../../../src
+; src_dir = ../../../src
+; test_dir = 
 
-[env:development]
-board = adafruit_metro_m4
-build_src_filter =
-    +<../examples/platformio/main.cpp>
-    +<CRSFforArduino.cpp>
-    +<hal/CompatibilityTable/CompatibilityTable.cpp>
-    +<SerialReceiver/SerialReceiver.cpp>
-    +<SerialReceiver/CRC/CRC.cpp>
-    +<SerialReceiver/CRSF/CRSF.cpp>
-    +<SerialReceiver/SerialBuffer/SerialBuffer.cpp>
-    +<SerialReceiver/Telemetry/Telemetry.cpp>
-build_type = debug
-extends = env_common_samd51
+; [env:development]
+; board = adafruit_metro_m4
+; build_src_filter =
+;     +<../examples/platformio/main.cpp>
+;     +<CRSFforArduino.cpp>
+;     +<hal/CompatibilityTable/CompatibilityTable.cpp>
+;     +<SerialReceiver/SerialReceiver.cpp>
+;     +<SerialReceiver/CRC/CRC.cpp>
+;     +<SerialReceiver/CRSF/CRSF.cpp>
+;     +<SerialReceiver/SerialBuffer/SerialBuffer.cpp>
+;     +<SerialReceiver/Telemetry/Telemetry.cpp>
+; build_type = debug
+; extends = env_common_samd51

--- a/src/build/targets/common.ini
+++ b/src/build/targets/common.ini
@@ -1,3 +1,83 @@
+[optimisation_level]
+minimal = -Oz
+debug = -Og
+default = -Os
+fast = -O2
+faster = -O3
+fastest = -Ofast
+highway_to_hell = -Ofast -funroll-loops
+
+[c_cpp_standard]
+deprecated = 
+    -std=gnu11
+    -std=gnu++11
+stable =
+    -std=gnu17
+    -std=gnu++17
+latest =
+    -std=gnu23
+    -std=gnu++23
+
+[os_usb_port]
+linux = /dev/ttyACM0
+macos = ; Currently not yet supported.
+windows = COM3 ; Replace with the COM port your development board is connected to.
+
+[usb_port]
+selected = ${os_usb_port.linux}
+
+[common]
+build_flags =
+    -include "Arduino.h"
+    ; !python git_commit_sha1_macro.py ; TO-DO: Add git commit SHA1 to CFA's Serial Monitor output.
+    ${c_cpp_standard.stable}
+    ${optimisation_level.fastest}
+build_unflags =
+    ${c_cpp_standard.deprecated}
+    ${optimisation_level.default}
+
+[env_common_esp32]
+platform = espressif32@6.4.0
+upload_port = ${usb_port.selected}
+
+[env_common_rp2040]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board_build.core = earlephilhower
+board_build.filesystem_size = 0.5m
+platform_packages = 
+	maxgerhardt/framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#master
+upload_port = ${usb_port.selected}
+
+[env_common_samd21]
+platform = atmelsam@8.2.0
+upload_protocol = sam-ba
+upload_port = ${usb_port.selected}
+
+[env_common_samd51]
+platform = atmelsam@8.2.0
+upload_protocol = sam-ba
+upload_port = ${usb_port.selected}
+
+[env_common_stm32]
+platform = ststm32@17.2.0
+upload_port = ${usb_port.selected}
+
+[env_common_teensy]
+platform = teensy@4.18.0
+upload_port = ${usb_port.selected}
+
+[env]
+build_src_filter =
+    +<../examples/platformio/main.cpp>
+    +<CRSFforArduino.cpp>
+    +<hal/CompatibilityTable/CompatibilityTable.cpp>
+    +<SerialReceiver/SerialReceiver.cpp>
+    +<SerialReceiver/CRC/CRC.cpp>
+    +<SerialReceiver/CRSF/CRSF.cpp>
+    +<SerialReceiver/SerialBuffer/SerialBuffer.cpp>
+    +<SerialReceiver/Telemetry/Telemetry.cpp>
+framework = arduino
+
 ; [optimise_level]
 ; tiny = -Oz
 ; default = -Os

--- a/src/build/targets/common.ini
+++ b/src/build/targets/common.ini
@@ -1,55 +1,55 @@
-[optimise_level]
-tiny = -Oz
-default = -Os
-debug = -Og
-fast = -O2
-faster = -O3
-fastest = -Ofast
-here_be_dragons = -Ofast -funroll-loops
+; [optimise_level]
+; tiny = -Oz
+; default = -Os
+; debug = -Og
+; fast = -O2
+; faster = -O3
+; fastest = -Ofast
+; here_be_dragons = -Ofast -funroll-loops
 
-[common]
-build_flags = 
-    -DCRC_OPTIMISATION_LEVEL=0
-    ${optimise_level.fastest}
+; [common]
+; build_flags = 
+;     -DCRC_OPTIMISATION_LEVEL=0
+;     ${optimise_level.fastest}
 
-[env_common_esp32]
-platform = espressif32@6.4.0
+; [env_common_esp32]
+; platform = espressif32@6.4.0
 
-[env_common_rp2040]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git
-board_build.core = earlephilhower
-board_build.filesystem_size = 0.5m
-platform_packages = 
-	maxgerhardt/framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#master
+; [env_common_rp2040]
+; platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+; board_build.core = earlephilhower
+; board_build.filesystem_size = 0.5m
+; platform_packages = 
+; 	maxgerhardt/framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#master
 
-[env_common_samd21]
-platform = atmelsam@8.2.0
+; [env_common_samd21]
+; platform = atmelsam@8.2.0
 
-[env_common_samd51]
-platform = atmelsam@8.2.0
+; [env_common_samd51]
+; platform = atmelsam@8.2.0
 
-[env_common_stm32]
-platform = ststm32@17.2.0
+; [env_common_stm32]
+; platform = ststm32@17.2.0
 
-[env_common_teensy]
-platform = teensy@4.18.0
+; [env_common_teensy]
+; platform = teensy@4.18.0
 
-[env]
-framework = arduino
-build_src_filter =
-    +<../examples/platformio/main.cpp>
-    +<CRSFforArduino.cpp>
-    +<hal/CompatibilityTable/CompatibilityTable.cpp>
-    +<SerialReceiver/SerialReceiver.cpp>
-    +<SerialReceiver/CRC/CRC.cpp>
-    +<SerialReceiver/CRSF/CRSF.cpp>
-    +<SerialReceiver/SerialBuffer/SerialBuffer.cpp>
-    +<SerialReceiver/Telemetry/Telemetry.cpp>
-    ; -<../examples/platformio/cfa_code_test.cpp>
-    ; +<../examples/platformio/main.cpp>
-    ; +<*/*/*.cpp>
-    ; +<*.cpp>
-build_unflags = 
-    -Os
-build_flags =
-    ${common.build_flags}
+; [env]
+; framework = arduino
+; build_src_filter =
+;     +<../examples/platformio/main.cpp>
+;     +<CRSFforArduino.cpp>
+;     +<hal/CompatibilityTable/CompatibilityTable.cpp>
+;     +<SerialReceiver/SerialReceiver.cpp>
+;     +<SerialReceiver/CRC/CRC.cpp>
+;     +<SerialReceiver/CRSF/CRSF.cpp>
+;     +<SerialReceiver/SerialBuffer/SerialBuffer.cpp>
+;     +<SerialReceiver/Telemetry/Telemetry.cpp>
+;     ; -<../examples/platformio/cfa_code_test.cpp>
+;     ; +<../examples/platformio/main.cpp>
+;     ; +<*/*/*.cpp>
+;     ; +<*.cpp>
+; build_unflags = 
+;     -Os
+; build_flags =
+;     ${common.build_flags}

--- a/src/build/targets/common.ini
+++ b/src/build/targets/common.ini
@@ -60,6 +60,12 @@ upload_port = ${usb_port.selected}
 
 [env_common_samd51]
 platform = atmelsam@8.2.0
+platform_packages =
+    platformio/framework-arduino-samd-adafruit@1.10716.0
+    platformio/framework-cmsis@2.50400.181126
+    platformio/toolchain-gccarmnoneeabi@1.90301.200702
+    platformio/tool-clangtidy@1.190100.0
+    platformio/tool-cppcheck@1.21100.230717
 upload_protocol = sam-ba
 upload_port = ${usb_port.selected}
 

--- a/src/build/targets/common.ini
+++ b/src/build/targets/common.ini
@@ -32,6 +32,11 @@ build_flags =
     ; !python git_commit_sha1_macro.py ; TO-DO: Add git commit SHA1 to CFA's Serial Monitor output.
     ${c_cpp_standard.stable}
     ${optimisation_level.fastest}
+build_flags_development =
+    -include "Arduino.h"
+    ; !python git_commit_sha1_macro.py ; TO-DO: Add git commit SHA1 to CFA's Serial Monitor output.
+    ${c_cpp_standard.stable}
+    ${optimisation_level.debug}
 build_unflags =
     ${c_cpp_standard.deprecated}
     ${optimisation_level.default}

--- a/src/build/targets/common.ini
+++ b/src/build/targets/common.ini
@@ -28,7 +28,7 @@ selected = ${os_usb_port.linux}
 
 [common]
 build_flags =
-    -include "Arduino.h"
+    ; -include "Arduino.h" ; BUG: This causes builds for RP2040, and Teensy 3.x and 4.x targets to fail.
     ; !python git_commit_sha1_macro.py ; TO-DO: Add git commit SHA1 to CFA's Serial Monitor output.
     ${c_cpp_standard.stable}
     ${optimisation_level.fastest}

--- a/src/build/targets/quality_control.ini
+++ b/src/build/targets/quality_control.ini
@@ -46,18 +46,18 @@ check_flags =
         -I ../../../.pio/core/packages/framework-arduino-samd-adafruit/cores/arduino
         --platform=native
         --suppress=*:../../../.pio/core/packages/framework-arduino-samd-adafruit/cores/*
-        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
-        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/CRC/CRC.hpp
-        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
-        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
-        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
-        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/hal/CompatibilityTable/CompatibilityTable.cpp
-        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
-        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
-        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
-        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
-        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
-        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/CRSFforArduino.cpp
+        --suppress=missingInclude:../../src/SerialReceiver/CRC/CRC.cpp
+        --suppress=missingInclude:../../src/SerialReceiver/CRC/CRC.hpp
+        --suppress=missingInclude:../../src/SerialReceiver/CRSF/CRSFProtocol.hpp
+        --suppress=missingInclude:../../src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+        --suppress=missingInclude:../../src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+        --suppress=unusedFunction:../../src/hal/CompatibilityTable/CompatibilityTable.cpp
+        --suppress=unusedFunction:../../src/SerialReceiver/SerialReceiver.cpp
+        --suppress=unusedFunction:../../src/SerialReceiver/CRC/CRC.cpp
+        --suppress=unusedFunction:../../src/SerialReceiver/CRSF/CRSF.cpp
+        --suppress=unusedFunction:../../src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+        --suppress=unusedFunction:../../src/SerialReceiver/Telemetry/Telemetry.cpp
+        --suppress=unusedFunction:../../src/CRSFforArduino.cpp
 check_severity =
     ; low
     ; medium

--- a/src/build/targets/quality_control.ini
+++ b/src/build/targets/quality_control.ini
@@ -28,6 +28,53 @@ check_src_filters =
     +<../../SerialReceiver/SerialReceiver.cpp>
 check_tool = clangtidy
 
+[env:defect_detector_cppcheck]
+extends = env_common_samd51
+board = adafruit_metro_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    -include "Arduino.h"
+    ${c_cpp_standard.stable}
+    ${optimisation_level.debug}
+build_type = debug
+check_flags =
+    cppcheck:
+        --enable=all
+        --language=c++
+        --std=c++17
+        -I ../../../.pio/core/packages/framework-arduino-samd-adafruit/cores/arduino
+        --platform=native
+        --suppress=*:../../../.pio/core/packages/framework-arduino-samd-adafruit/cores/*
+        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
+        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/CRC/CRC.hpp
+        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/CRSF/CRSFProtocol.hpp
+        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+        --suppress=missingInclude:/workspaces/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.hpp
+        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/hal/CompatibilityTable/CompatibilityTable.cpp
+        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/SerialReceiver.cpp
+        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/CRC/CRC.cpp
+        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/CRSF/CRSF.cpp
+        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/SerialBuffer/SerialBuffer.cpp
+        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
+        --suppress=unusedFunction:/workspaces/CRSFforArduino/src/CRSFforArduino.cpp
+check_severity =
+    low
+    medium
+    high
+check_skip_packages = yes
+check_src_filters =
+    ; +<../../../examples/platformio/qc.cpp>
+    +<../../../examples/platformio/main.cpp>
+    +<../../CRSFforArduino.cpp>
+    +<../../hal/CompatibilityTable/CompatibilityTable.cpp>
+    +<../../SerialReceiver/CRC/CRC.cpp>
+    +<../../SerialReceiver/CRSF/CRSF.cpp>
+    +<../../SerialReceiver/SerialBuffer/SerialBuffer.cpp>
+    +<../../SerialReceiver/Telemetry/Telemetry.cpp>
+    +<../../SerialReceiver/SerialReceiver.cpp>
+check_tool = cppcheck
+
 [env:defect_detector]
 board = adafruit_metro_m4
 build_flags =

--- a/src/build/targets/quality_control.ini
+++ b/src/build/targets/quality_control.ini
@@ -19,6 +19,13 @@ check_skip_packages = yes
 check_src_filters =
     ; +<../../../examples/platformio/qc.cpp>
     +<../../../examples/platformio/main.cpp>
+    +<../../CRSFforArduino.cpp>
+    +<../../hal/CompatibilityTable/CompatibilityTable.cpp>
+    +<../../SerialReceiver/CRC/CRC.cpp>
+    +<../../SerialReceiver/CRSF/CRSF.cpp>
+    +<../../SerialReceiver/SerialBuffer/SerialBuffer.cpp>
+    +<../../SerialReceiver/Telemetry/Telemetry.cpp>
+    +<../../SerialReceiver/SerialReceiver.cpp>
 check_tool = clangtidy
 
 [env:defect_detector]

--- a/src/build/targets/quality_control.ini
+++ b/src/build/targets/quality_control.ini
@@ -1,3 +1,26 @@
+[env:defect_detector_clangtidy]
+extends = env_common_samd51
+board = adafruit_metro_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    -include "Arduino.h"
+    ${c_cpp_standard.stable}
+    ${optimisation_level.debug}
+build_type = debug
+check_flags =
+    clangtidy:
+        --config-file=.clang-tidy
+check_severity =
+    low
+    medium
+    high
+check_skip_packages = yes
+check_src_filters =
+    ; +<../../../examples/platformio/qc.cpp>
+    +<../../../examples/platformio/main.cpp>
+check_tool = clangtidy
+
 [env:defect_detector]
 board = adafruit_metro_m4
 build_flags =

--- a/src/build/targets/quality_control.ini
+++ b/src/build/targets/quality_control.ini
@@ -12,8 +12,8 @@ check_flags =
     clangtidy:
         --config-file=.clang-tidy
 check_severity =
-    low
-    medium
+    ; low
+    ; medium
     high
 check_skip_packages = yes
 check_src_filters =
@@ -59,8 +59,8 @@ check_flags =
         --suppress=unusedFunction:/workspaces/CRSFforArduino/src/SerialReceiver/Telemetry/Telemetry.cpp
         --suppress=unusedFunction:/workspaces/CRSFforArduino/src/CRSFforArduino.cpp
 check_severity =
-    low
-    medium
+    ; low
+    ; medium
     high
 check_skip_packages = yes
 check_src_filters =

--- a/src/build/targets/quality_control.ini
+++ b/src/build/targets/quality_control.ini
@@ -75,58 +75,6 @@ check_src_filters =
     +<../../SerialReceiver/SerialReceiver.cpp>
 check_tool = cppcheck
 
-[env:defect_detector]
-board = adafruit_metro_m4
-build_flags =
-    ; An isolated configuration from CFA_Config.hpp is used here to test EVERY possible
-    ; configuration, and ensure that defects (if any) are picked up.
-    ; The `ENV_DEFECT_DETECTOR` define configures CRSF for Arduino for use with the Defect Detector.
-    -DENV_DEFECT_DETECTOR
-
-    -DCRSF_FAILSAFE_LQI_THRESHOLD=80
-    -DCRSF_FAILSAFE_RSSI_THRESHOLD=105
-
-    -DCRSF_RC_ENABLED=1
-    -DCRSF_RC_MAX_CHANNELS=16
-    -DCRSF_RC_CHANNEL_MIN=172
-    -DCRSF_RC_CHANNEL_MAX=1811
-    -DCRSF_RC_CHANNEL_CENTER=992
-    -DCRSF_RC_INITIALISE_CHANNELS=1
-    -DCRSF_RC_INITIALISE_ARMCHANNEL=1
-    -DCRSF_RC_INITIALISE_THROTTLECHANNEL=1
-
-    -DCRSF_FLIGHTMODES_ENABLED=1
-    -DCRSF_CUSTOM_FLIGHT_MODES_ENABLED=1
-
-    -DCRSF_TELEMETRY_ENABLED=1
-    -DCRSF_TELEMETRY_ATTITUDE_ENABLED=1
-    -DCRSF_TELEMETRY_BAROALTITUDE_ENABLED=1
-    -DCRSF_TELEMETRY_BATTERY_ENABLED=1
-    -DCRSF_TELEMETRY_FLIGHTMODE_ENABLED=1
-    -DCRSF_TELEMETRY_GPS_ENABLED=1
-
-    -DCRSF_LINK_STATISTICS_ENABLED=1
-
-build_src_filter =
-    +<../examples/platformio/main.cpp>
-    +<CRSFforArduino.cpp>
-    +<hal/CompatibilityTable/CompatibilityTable.cpp>
-    +<SerialReceiver/SerialReceiver.cpp>
-    +<SerialReceiver/CRC/CRC.cpp>
-    +<SerialReceiver/CRSF/CRSF.cpp>
-    +<SerialReceiver/SerialBuffer/SerialBuffer.cpp>
-    +<SerialReceiver/Telemetry/Telemetry.cpp>
-    ; +<../examples/platformio/main.cpp>
-    ; +<*/*/*.cpp>
-    ; +<*.cpp>
-build_type = debug
-check_flags =
-    --disable=unusedFunction
-check_severity = low, medium, high
-check_skip_packages = yes
-check_tool = cppcheck
-extends = env_common_samd51
-
 [build]
 ; Intentionally left blank to allow PlatformIO to process _all_ targets CRSF for Arduino is compatible with.
 all =

--- a/src/build/targets/unified_esp32.ini
+++ b/src/build/targets/unified_esp32.ini
@@ -1,79 +1,179 @@
 [env:adafruit_qtpy_esp32]
 extends = env_common_esp32
 board = adafruit_qtpy_esp32
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_qtpy_esp32c3]
 extends = env_common_esp32
 board = adafruit_qtpy_esp32c3
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_qtpy_esp32s2]
 extends = env_common_esp32
 board = adafruit_qtpy_esp32s2
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_qtpy_esp32s3_nopsram]
 extends = env_common_esp32
 board = adafruit_qtpy_esp32s3_nopsram
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_feather_esp32s3]
 extends = env_common_esp32
 board = adafruit_feather_esp32s3
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_feather_esp32s3_nopsram]
 extends = env_common_esp32
 board = adafruit_feather_esp32s3_nopsram
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_itsybitsy_esp32]
 extends = env_common_esp32
 board = adafruit_itsybitsy_esp32
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_metro_esp32s2]
 extends = env_common_esp32
 board = adafruit_metro_esp32s2
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_feather_esp32]
 extends = env_common_esp32
 board = featheresp32
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_feather_esp32-s2]
 extends = env_common_esp32
 board = featheresp32-s2
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_nano_esp32]
 extends = env_common_esp32
 board = arduino_nano_esp32
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:esp32-c3-devkit-02]
 extends = env_common_esp32
 board = esp32-c3-devkitc-02
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:esp32-c3-devkitm-1]
 extends = env_common_esp32
 board = esp32-c3-devkitm-1
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:esp32-s3-devkitc-1]
 extends = env_common_esp32
 board = esp32-s3-devkitc-1
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:seeed_xiao_esp32c3]
 extends = env_common_esp32
 board = seeed_xiao_esp32c3
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:seeed_xiao_esp32s3]
 extends = env_common_esp32
 board = seeed_xiao_esp32s3
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:sparkfun_esp32_thing]
 extends = env_common_esp32
 board = esp32thing
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:sparkfun_esp32_thing_plus]
 extends = env_common_esp32
 board = esp32thing_plus
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:sparkfun_esp32_iot_redboard]
 extends = env_common_esp32
 board = sparkfun_esp32_iot_redboard
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:sparkfun_esp32s2_thing_plus]
 extends = env_common_esp32
 board = sparkfun_esp32s2_thing_plus
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release

--- a/src/build/targets/unified_rp2040.ini
+++ b/src/build/targets/unified_rp2040.ini
@@ -1,7 +1,17 @@
 [env:arduino_nano_rp2040_connect]
 extends = env_common_rp2040
 board = arduino_nano_connect
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:raspberrypi_pico_rp2040]
 extends = env_common_rp2040
 board = rpipico
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release

--- a/src/build/targets/unified_samd21.ini
+++ b/src/build/targets/unified_samd21.ini
@@ -1,43 +1,98 @@
 [env:adafruit_feather_m0]
 extends = env_common_samd21
 board = adafruit_feather_m0
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_feather_m0_express]
 extends = env_common_samd21
 board = adafruit_feather_m0_express
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_itsybitsy_m0]
 extends = env_common_samd21
 board = adafruit_itsybitsy_m0
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_metro_m0]
 extends = env_common_samd21
 board = adafruit_metro_m0
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_mkrwan1310]
 extends = env_common_samd21
 board = mkrwan1310
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_mkrwifi1010]
 extends = env_common_samd21
 board = mkrwifi1010
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_mkrzero]
 extends = env_common_samd21
 board = mkrzero
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_nano_33_iot]
 extends = env_common_samd21
 board = nano_33_iot
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_zero]
 extends = env_common_samd21
 board = zero
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_zeroUSB]
 extends = env_common_samd21
 board = zeroUSB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:seeed_xiao_samd21]
 extends = env_common_samd21
 board = seeed_xiao
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release

--- a/src/build/targets/unified_samd51.ini
+++ b/src/build/targets/unified_samd51.ini
@@ -1,3 +1,12 @@
+[env:development]
+extends = env_common_samd51
+board = adafruit_metro_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags_development}
+build_type = debug
+
 [env:adafruit_feather_m4]
 extends = env_common_samd51
 board = adafruit_feather_m4

--- a/src/build/targets/unified_samd51.ini
+++ b/src/build/targets/unified_samd51.ini
@@ -1,23 +1,53 @@
 [env:adafruit_feather_m4]
 extends = env_common_samd51
 board = adafruit_feather_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_feather_m4_can]
 extends = env_common_samd51
 board = adafruit_feather_m4_can
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_grandcentral_m4]
 extends = env_common_samd51
 board = adafruit_grandcentral_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_itsybitsy_m4]
 extends = env_common_samd51
 board = adafruit_itsybitsy_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_metro_m4]
 extends = env_common_samd51
 board = adafruit_metro_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:adafruit_metro_m4_airliftlite]
 extends = env_common_samd51
 board = adafruit_metro_m4_airliftlite
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release

--- a/src/build/targets/unified_stm32.ini
+++ b/src/build/targets/unified_stm32.ini
@@ -1,371 +1,836 @@
 [env:adafruit_feather_f405]
 extends = env_common_stm32
 board = adafruit_feather_f405
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_nicla_vision]
 extends = env_common_stm32
 board = nicla_vision
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_nicla_vision_m4_core]
 extends = env_common_stm32
 board = nicla_vision_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_opta]
 extends = env_common_stm32
 board = opta
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_nicla_opta_m4_core]
 extends = env_common_stm32
 board = opta_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_portenta_m4_core]
 extends = env_common_stm32
 board = portenta_h7_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:arduino_portenta_m7_core]
 extends = env_common_stm32
 board = portenta_h7_m7
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:blackpill_stm32f103c8]
 extends = env_common_stm32
 board = blackpill_f103c8
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:blackpill_stm32f103c8_128]
 extends = env_common_stm32
 board = blackpill_f103c8_128
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:blackpill_stm32f401cc]
 extends = env_common_stm32
 board = blackpill_f401cc
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:blackpill_stm32f401ce]
 extends = env_common_stm32
 board = blackpill_f401ce
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:blackpill_stm32f411ce]
 extends = env_common_stm32
 board = blackpill_f411ce
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:bluepill_stm32f103c6]
 extends = env_common_stm32
 board = bluepill_f103c6
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:bluepill_stm32f103c8]
 extends = env_common_stm32
 board = bluepill_f103c8
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:bluepill_stm32f103c8_128]
 extends = env_common_stm32
 board = bluepill_f103c8_128k
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_black_stm32f407ve]
 extends = env_common_stm32
 board = black_f407ve
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_black_stm32f407vg]
 extends = env_common_stm32
 board = black_f407vg
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_black_stm32f407ze]
 extends = env_common_stm32
 board = black_f407ze
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_black_stm32f407zg]
 extends = env_common_stm32
 board = black_f407zg
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_blue_stm32f407ve_mini]
 extends = env_common_stm32
 board = blue_f407ve_mini
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_discovery_f413]
 extends = env_common_stm32
 board = disco_f413zh
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_discovery_f746]
 extends = env_common_stm32
 board = disco_f746ng
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_f401re]
 extends = env_common_stm32
 board = nucleo_f401re
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_f411re]
 extends = env_common_stm32
 board = nucleo_f411re
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_f429zi]
 extends = env_common_stm32
 board = nucleo_f429zi
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_f446re]
 extends = env_common_stm32
 board = nucleo_f446re
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_f722ze]
 extends = env_common_stm32
 board = nucleo_f722ze
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_f746zg]
 extends = env_common_stm32
 board = nucleo_f746zg
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_f756zg]
 extends = env_common_stm32
 board = nucleo_f756zg
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_f767zi]
 extends = env_common_stm32
 board = nucleo_f767zi
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_h723zg]
 extends = env_common_stm32
 board = nucleo_h723zg
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:st_nucleo_h743zi]
 extends = env_common_stm32
 board = nucleo_h743zi
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103c6]
 extends = env_common_stm32
 board = genericSTM32F103C6
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103c8]
 extends = env_common_stm32
 board = genericSTM32F103C8
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103cb]
 extends = env_common_stm32
 board = genericSTM32F103CB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103r6]
 extends = env_common_stm32
 board = genericSTM32F103R6
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103r8]
 extends = env_common_stm32
 board = genericSTM32F103R8
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103rb]
 extends = env_common_stm32
 board = genericSTM32F103RB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103rc]
 extends = env_common_stm32
 board = genericSTM32F103RC
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103rd]
 extends = env_common_stm32
 board = genericSTM32F103RD
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103re]
 extends = env_common_stm32
 board = genericSTM32F103RE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103rf]
 extends = env_common_stm32
 board = genericSTM32F103RF
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103rg]
 extends = env_common_stm32
 board = genericSTM32F103RG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103t6]
 extends = env_common_stm32
 board = genericSTM32F103T6
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103t8]
 extends = env_common_stm32
 board = genericSTM32F103T8
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103tb]
 extends = env_common_stm32
 board = genericSTM32F103TB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103v8]
 extends = env_common_stm32
 board = genericSTM32F103V8
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103vb]
 extends = env_common_stm32
 board = genericSTM32F103VB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103vc]
 extends = env_common_stm32
 board = genericSTM32F103VC
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103vd]
 extends = env_common_stm32
 board = genericSTM32F103VD
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103ve]
 extends = env_common_stm32
 board = genericSTM32F103VE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103vf]
 extends = env_common_stm32
 board = genericSTM32F103VF
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103vg]
 extends = env_common_stm32
 board = genericSTM32F103VG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103zc]
 extends = env_common_stm32
 board = genericSTM32F103ZC
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103zd]
 extends = env_common_stm32
 board = genericSTM32F103ZD
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103ze]
 extends = env_common_stm32
 board = genericSTM32F103ZE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103zf]
 extends = env_common_stm32
 board = genericSTM32F103ZF
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f103zg]
 extends = env_common_stm32
 board = genericSTM32F103ZG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f401cb]
 extends = env_common_stm32
 board = genericSTM32F401CB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f401cc]
 extends = env_common_stm32
 board = genericSTM32F401CC
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f401cd]
 extends = env_common_stm32
 board = genericSTM32F401CD
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f401ce]
 extends = env_common_stm32
 board = genericSTM32F401CE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f401rb]
 extends = env_common_stm32
 board = genericSTM32F401RB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f401rc]
 extends = env_common_stm32
 board = genericSTM32F401RC
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f401rd]
 extends = env_common_stm32
 board = genericSTM32F401RD
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f401re]
 extends = env_common_stm32
 board = genericSTM32F401RE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f405rg]
 extends = env_common_stm32
 board = genericSTM32F405RG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f407ve]
 extends = env_common_stm32
 board = genericSTM32F407VET6
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f407vg]
 extends = env_common_stm32
 board = genericSTM32F407VGT6
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f410c8]
 extends = env_common_stm32
 board = genericSTM32F410C8
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f410cb]
 extends = env_common_stm32
 board = genericSTM32F410CB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f410r8]
 extends = env_common_stm32
 board = genericSTM32F410R8
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f410rb]
 extends = env_common_stm32
 board = genericSTM32F410RB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f411ce]
 extends = env_common_stm32
 board = genericSTM32F411CE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f411rc]
 extends = env_common_stm32
 board = genericSTM32F411RC
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f411re]
 extends = env_common_stm32
 board = genericSTM32F411RE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f412ce]
 extends = env_common_stm32
 board = genericSTM32F412CE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f412cg]
 extends = env_common_stm32
 board = genericSTM32F412CG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f412re]
 extends = env_common_stm32
 board = genericSTM32F412RE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f412rg]
 extends = env_common_stm32
 board = genericSTM32F412RG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f413cg]
 extends = env_common_stm32
 board = genericSTM32F413CG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f413ch]
 extends = env_common_stm32
 board = genericSTM32F413CH
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f413rg]
 extends = env_common_stm32
 board = genericSTM32F413RG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f413rh]
 extends = env_common_stm32
 board = genericSTM32F413RH
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f415rg]
 extends = env_common_stm32
 board = genericSTM32F415RG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f417ve]
 extends = env_common_stm32
 board = genericSTM32F417VE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f417vg]
 extends = env_common_stm32
 board = genericSTM32F417VG
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f423ch]
 extends = env_common_stm32
 board = genericSTM32F423CH
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f423rh]
 extends = env_common_stm32
 board = genericSTM32F423RH
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f446rc]
 extends = env_common_stm32
 board = genericSTM32F446RC
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32f446re]
 extends = env_common_stm32
 board = genericSTM32F446RE
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:stm32h750vb]
 extends = env_common_stm32
 board = genericSTM32H750VB
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:sparkfun_micromod_f405]
 extends = env_common_stm32
 board = sparkfun_micromod_f405
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release

--- a/src/build/targets/unified_teensy3x.ini
+++ b/src/build/targets/unified_teensy3x.ini
@@ -1,19 +1,44 @@
 [env:teensy_30]
 extends = env_common_teensy
 board = teensy30
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:teensy_31]
 extends = env_common_teensy
 board = teensy31
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:teensy_32]
 extends = env_common_teensy
 board = teensy31
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:teensy_35]
 extends = env_common_teensy
 board = teensy35
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:teensy_36]
 extends = env_common_teensy
 board = teensy36
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release

--- a/src/build/targets/unified_teensy4x.ini
+++ b/src/build/targets/unified_teensy4x.ini
@@ -1,7 +1,17 @@
 [env:teensy_40]
 extends = env_common_teensy
 board = teensy40
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release
 
 [env:teensy_41]
 extends = env_common_teensy
 board = teensy41
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+build_type = release


### PR DESCRIPTION
> [!note]
> This Pull Request contains 19 `Unverified` commits from 3144f3ed9feb2051c087925a498a5bcb63b940f7 to de24843368d5b2e5bf5e56608660a4f9aaab946a.
> This is because the GPG signature I was using when I was working on CFA from 2025-09-03 to 2025-09-07 has expired and I have since revoked it.
> All commits from d3ae855adec32d1673e1830932e1bb7a799ea22d on 2025-10-24 onward are verified, because I am now using a new GPG signature.
> 
> This is also the first Pull Request where I am using GitHub CoPilot as my code reviewer in addition to me reviewing my own code off-site.

## Key changes

- **Defect Detector only scans what matters to CFA**
  All out-of-scope defects (EG defects in upstream board support packages) are ignored.
- **`Arduino.h` header is commented out for Teensy and RP2040 targets**
  This prevents the Defect Detector from picking up out-of-scope defects on Teensy 4 and RP2040 based development boards and (by extension) failing builds on these targets for out-of-scope defects.
- **Defect Detector now uses `clang-tidy` as a part of its scanning process**
  `clang-tidy` scans the entirety of CFA for defects.
- **Defect Detector now uses `cppcheck` in tandem with `clang-tidy`**
  One catches what the other one may miss — IE `clang-tidy` will scan CFA for medium and high severity defects, and `cppcheck` will only scan for high severity defects. Everything else is ignored.

## What this does

To help with cutting through the noise when building CFA for various targets, I have refactored my Defect Detector script to only pick up on code and build errors that are relevant to CFA.  
All out-of-scope defects (usually more relevant to the various upstream repositories CFA relies on for compatibility with your development boards) are ignored.

This means I can focus more on CFA itself and bringing you high quality code instead of bogging myself down with fixing an upstream's coding mistakes.