### PR TITLE
feat(targets): Add DOIT ESP32 DevKit V1 to Compatibility Table

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "CRSFforArduino",
-    "version": "2025.10.26",
+    "version": "2025.11.2",
     "description": "An Arduino Library for communicating with ExpressLRS and TBS Crossfire receivers.",
     "keywords": "arduino, remote-control, arduino-library, protocols, rc, radio-control, crsf, expresslrs",
     "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRSFforArduino
-version=2025.10.26
+version=2025.11.2
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=CRSF for Arduino brings the Crossfire Protocol to the Arduino ecosystem.

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -35,11 +35,11 @@ namespace crsfForArduinoConfig
 Versioning is based on a rolling release model
 and is backwards-compatible with Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
-#define CRSFFORARDUINO_VERSION       "2025.10.26"
-#define CRSFFORARDUINO_VERSION_DATE  "2025-10-26"
+#define CRSFFORARDUINO_VERSION       "2025.11.2"
+#define CRSFFORARDUINO_VERSION_DATE  "2025-11-02"
 #define CRSFFORARDUINO_VERSION_MAJOR 2025
-#define CRSFFORARDUINO_VERSION_MINOR 10
-#define CRSFFORARDUINO_VERSION_PATCH 26
+#define CRSFFORARDUINO_VERSION_MINOR 11
+#define CRSFFORARDUINO_VERSION_PATCH 2
 
 // This is set to 1 if the version is a pre-release version.
 #define CRSFFORARDUINO_VERSION_IS_PRERELEASE 0

--- a/src/SerialReceiver/SerialReceiver.cpp
+++ b/src/SerialReceiver/SerialReceiver.cpp
@@ -44,20 +44,23 @@ namespace serialReceiverLayer
 #elif defined(ARDUINO_ARCH_ESP32)
         _uart = &Serial1;
 
-#if defined(D0)
-        _rxPin = D0;
-#else
-        _rxPin = 0;
-#endif
+// #if defined(D0)
+//         _rxPin = D0;
+// #else
+//         _rxPin = 0;
+// #endif
 
-#if defined(D1)
-        _txPin = D1;
-#else
-        _txPin = 1;
-#endif
+// #if defined(D1)
+//         _txPin = D1;
+// #else
+//         _txPin = 1;
+// #endif
 #else
         _uart = &Serial1;
 #endif
+
+    _rxPin = PIN_SERIAL1_RX;
+    _txPin = PIN_SERIAL1_TX;
 
 #if CRSF_RC_ENABLED > 0
         _rcChannels = new rcChannels_t;
@@ -74,19 +77,22 @@ namespace serialReceiverLayer
     {
         _uart = hwUartPort;
 
-#if defined(ARDUINO_ARCH_ESP32)
-        #if defined(D0)
-        _rxPin = D0;
-#else
-        _rxPin = 0;
-#endif
+// #if defined(ARDUINO_ARCH_ESP32)
+// #if defined(RX)
+//         _rxPin = RX;
+// #else
+//         _rxPin = 0;
+// #endif
 
-#if defined(D1)
-        _txPin = D1;
-#else
-        _txPin = 1;
-#endif
-#endif
+// #if defined(TX)
+//         _txPin = TX;
+// #else
+//         _txPin = 1;
+// #endif
+// #endif
+
+        _rxPin = PIN_SERIAL1_RX;
+        _txPin = PIN_SERIAL1_TX;
 
 #if CRSF_RC_ENABLED > 0
         _rcChannels = new rcChannels_t;

--- a/src/build/scripts/platformio.ini
+++ b/src/build/scripts/platformio.ini
@@ -19,6 +19,7 @@ default_envs =
     ${build.commonly_used}
 extra_configs =
     ../../../src/build/targets/common.ini
+    ../../../src/build/targets/development.ini
     ../../../src/build/targets/quality_control.ini
     ../../../src/build/targets/unified_esp32.ini
     ../../../src/build/targets/unified_rp2040.ini

--- a/src/build/targets/development.ini
+++ b/src/build/targets/development.ini
@@ -1,6 +1,8 @@
 [env:development]
-extends = env_common_samd51
-board = adafruit_metro_m4
+; extends = env_common_samd51
+; board = adafruit_metro_m4
+extends = env_common_esp32
+board = esp32doit-devkit-v1
 build_unflags =
     ${common.build_unflags}
 build_flags =

--- a/src/build/targets/development.ini
+++ b/src/build/targets/development.ini
@@ -1,0 +1,8 @@
+[env:development]
+extends = env_common_samd51
+board = adafruit_metro_m4
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags_development}
+build_type = debug

--- a/src/build/targets/unified_esp32.ini
+++ b/src/build/targets/unified_esp32.ini
@@ -124,6 +124,15 @@ build_flags =
     ${common.build_flags}
 build_type = release
 
+[env:esp32doit-devkit-v1]
+extends = env_common_esp32
+board = esp32doit-devkit-v1
+build_unflags =
+    ${common.build_unflags}
+build_flags =
+    ${common.build_flags_development}
+build_type = debug
+
 [env:seeed_xiao_esp32c3]
 extends = env_common_esp32
 board = seeed_xiao_esp32c3

--- a/src/build/targets/unified_samd51.ini
+++ b/src/build/targets/unified_samd51.ini
@@ -1,11 +1,11 @@
-[env:development]
-extends = env_common_samd51
-board = adafruit_metro_m4
-build_unflags =
-    ${common.build_unflags}
-build_flags =
-    ${common.build_flags_development}
-build_type = debug
+; [env:development]
+; extends = env_common_samd51
+; board = adafruit_metro_m4
+; build_unflags =
+;     ${common.build_unflags}
+; build_flags =
+;     ${common.build_flags_development}
+; build_type = debug
 
 [env:adafruit_feather_m4]
 extends = env_common_samd51

--- a/src/hal/CompatibilityTable/CompatibilityTable.cpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.cpp
@@ -67,6 +67,8 @@ namespace hal
         device.type.devboard = DEVBOARD_ESPRESSIF_ESP32C3_DEVKIT;
 #elif defined(ARDUINO_ESP32S3_DEV)
         device.type.devboard = DEVBOARD_ESPRESSIF_ESP32S3_DEVKIT;
+#elif defined(ARDUINO_ESP32_DEV)
+        device.type.devboard = DEVBOARD_ESPRESSIF_ESP32DOIT_DEVKIT_V1;
 
 // Seeed Studio ESP32 devboards.
 #elif defined(ARDUINO_XIAO_ESP32C3)

--- a/src/hal/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.hpp
@@ -105,6 +105,7 @@ namespace hal
             // Espressif ESP32 boards.
             DEVBOARD_ESPRESSIF_ESP32C3_DEVKIT,
             DEVBOARD_ESPRESSIF_ESP32S3_DEVKIT,
+            DEVBOARD_ESPRESSIF_ESP32DOIT_DEVKIT_V1,
 
             // Raspberry Pi RP2040 boards.
             DEVBOARD_RASPBERRYPI_PICO,
@@ -297,6 +298,7 @@ namespace hal
             "Arduino Portenta H7 (M4 Core)",
             "Espressif ESP32-C3 DevKit",
             "Espressif ESP32-S3 DevKit",
+            "Espressif ESP32 DOIT DevKit V1",
             "Raspberry Pi Pico",
             "Seeed Studio Xiao ESP32-C3",
             "Seeed Studio Xiao ESP32-S3",

--- a/src/hal/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.hpp
@@ -35,6 +35,14 @@
 #define PIN_SERIAL1_TX TX
 #endif
 
+/* Serial1 workarounds for everything else. */
+#else
+
+#if (defined(PIN_SERIAL_RX) && defined(PIN_SERIAL_TX))
+#define PIN_SERIAL1_RX PIN_SERIAL_RX
+#define PIN_SERIAL1_TX PIN_SERIAL_TX
+#endif
+
 #endif
 
 namespace hal

--- a/src/hal/CompatibilityTable/CompatibilityTable.hpp
+++ b/src/hal/CompatibilityTable/CompatibilityTable.hpp
@@ -24,6 +24,19 @@
 
 #pragma once
 
+/* ESP32 workarounds for non-compliant generic UART definitions. */
+#if defined(ARDUINO_ARCH_ESP32)
+
+#ifndef PIN_SERIAL1_RX
+#define PIN_SERIAL1_RX RX
+#endif
+
+#ifndef PIN_SERIAL1_TX
+#define PIN_SERIAL1_TX TX
+#endif
+
+#endif
+
 namespace hal
 {
     class CompatibilityTable


### PR DESCRIPTION
Right-oh. Been a hot minute since I last made any Pull Requests for new targets.  
As per #159, this adds support for the DOIT ESP32 DevKit V1.

I have been made aware that there may also be a conflict between CFA and how this target handles UART, as it uses The Old Skool Method™️ of sharing the default UART with an external Serial-to-USB converter chip.

So I have marked this Pull Request as a draft until this gets sorted.