### PR TITLE
chore: Bump version to `2025.12.8`

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "CRSFforArduino",
-    "version": "2025.12.07",
+    "version": "2025.12.8",
     "description": "An Arduino Library for communicating with ExpressLRS and TBS Crossfire receivers.",
     "keywords": "arduino, remote-control, arduino-library, protocols, rc, radio-control, crsf, expresslrs",
     "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRSFforArduino
-version=2025.12.07
+version=2025.12.8
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=CRSF for Arduino brings the Crossfire Protocol to the Arduino ecosystem.

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -35,11 +35,11 @@ namespace crsfForArduinoConfig
 Versioning is based on a rolling release model
 and is backwards-compatible with Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
-#define CRSFFORARDUINO_VERSION       "2025.12.07"
-#define CRSFFORARDUINO_VERSION_DATE  "2025-12-07"
+#define CRSFFORARDUINO_VERSION       "2025.12.8"
+#define CRSFFORARDUINO_VERSION_DATE  "2025-12-08"
 #define CRSFFORARDUINO_VERSION_MAJOR 2025
 #define CRSFFORARDUINO_VERSION_MINOR 12
-#define CRSFFORARDUINO_VERSION_PATCH 7
+#define CRSFFORARDUINO_VERSION_PATCH 8
 
 // This is set to 1 if the version is a pre-release version.
 #define CRSFFORARDUINO_VERSION_IS_PRERELEASE 0


### PR DESCRIPTION
Just a quick PR this time around.

This (hopefully) resolves the linter error about the versioning being incompatible, because last night I put a leading zero in the `PATCH` field, which broke backward-compatibility. =</.>=

**Note to self:** Don't code while tired!