### PR TITLE
fix(platformio): PlatformIO `library.json` manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -18,7 +18,7 @@
         "maintainer": true
       }
     ],
-    "license": "GNU AGPLv3",
+    "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/ZZ-Cat/CRSFforArduino",
     "dependencies": {
     },

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
     "name": "CRSFforArduino",
-    "version": "2025.12.8",
+    "version": "2025.12.11",
     "description": "An Arduino Library for communicating with ExpressLRS and TBS Crossfire receivers.",
     "keywords": "arduino, remote-control, arduino-library, protocols, rc, radio-control, crsf, expresslrs",
     "repository":

--- a/library.json
+++ b/library.json
@@ -20,6 +20,7 @@
     ],
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/ZZ-Cat/CRSFforArduino",
+    "headers" : "CRSFforArduino.hpp",
     "dependencies": {
     },
     "frameworks": "Arduino",

--- a/library.json
+++ b/library.json
@@ -32,5 +32,25 @@
         "teensy"
     ],
     "examples": [
+      {
+        "name": "flight_modes",
+        "base": "examples/flight_modes",
+        "files": ["flight_modes.ino"]
+      },
+      {
+        "name": "link_stats",
+        "base": "examples/link_stats",
+        "files": ["link_stats.ino"]
+      },
+      {
+        "name": "rc_channels",
+        "base": "examples/rc_channels",
+        "files": ["rc_channels.ino"]
+      },
+      {
+        "name": "telemetry",
+        "base": "examples/telemetry",
+        "files": ["telemetry.ino"]
+      }
     ]
   }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRSFforArduino
-version=2025.12.8
+version=2025.12.11
 author=Cassandra Robinson <nicad.heli.flier@gmail.com>
 maintainer=Cassandra Robinson <nicad.heli.flier@gmail.com>
 sentence=CRSF for Arduino brings the Crossfire Protocol to the Arduino ecosystem.

--- a/src/CFA_Config.hpp
+++ b/src/CFA_Config.hpp
@@ -35,11 +35,11 @@ namespace crsfForArduinoConfig
 Versioning is based on a rolling release model
 and is backwards-compatible with Semantic Versioning 2.0.0.
 See https://semver.org/ for more information. */
-#define CRSFFORARDUINO_VERSION       "2025.12.8"
-#define CRSFFORARDUINO_VERSION_DATE  "2025-12-08"
+#define CRSFFORARDUINO_VERSION       "2025.12.11"
+#define CRSFFORARDUINO_VERSION_DATE  "2025-12-11"
 #define CRSFFORARDUINO_VERSION_MAJOR 2025
 #define CRSFFORARDUINO_VERSION_MINOR 12
-#define CRSFFORARDUINO_VERSION_PATCH 8
+#define CRSFFORARDUINO_VERSION_PATCH 11
 
 // This is set to 1 if the version is a pre-release version.
 #define CRSFFORARDUINO_VERSION_IS_PRERELEASE 0


### PR DESCRIPTION
This fixes up the following:

- Missing `CRSFforArduino.hpp` header.
- Incorrect SPDX identifier for AGPL v3.
- Populates examples field with all examples except the `platformio` one due to it being outdated.

This should also hopefully fix the typos in the installation instructions on CFA'S PlatformIO Registry page.

CFA's version is also bumped to `2025.12.11` and a follow-up release shall be made once this pull request is merged.